### PR TITLE
docs: announce v0.1.0-beta.1 release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center">
+  <a href="https://github.com/Cawlumm/lyftr/releases/latest"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?include_prereleases&label=release&color=6366f1" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
-  <img src="https://img.shields.io/badge/status-early%20beta-orange" alt="Early Beta" />
+  <img src="https://img.shields.io/badge/status-beta-orange" alt="Beta" />
   <a href="https://selfh.st/weekly/2026-04-24/"><img src="https://img.shields.io/badge/Featured%20in-selfh.st%20%C2%B7%20Apr%202026-6366f1" alt="Featured in selfh.st" /></a>
   <img src="https://img.shields.io/badge/iOS-planned-black?logo=apple&logoColor=white" alt="iOS Planned" />
 </p>
@@ -9,7 +10,9 @@
   <img src="docs/banner.png" alt="Lyftr — Self-hosted workout tracking" width="100%" />
 </p>
 
-> **Early beta** — actively being built. Expect rough edges and frequent updates. Issues and feedback are welcome. The software equivalent of going to the gym for the first time.
+> 🎉 **First beta release is live — [`v0.1.0-beta.1`](https://github.com/Cawlumm/lyftr/releases/tag/v0.1.0-beta.1).** Workouts, programs, gym mode, dashboard, weight, and the new nutrition tracker are all in. Pin this tag for a stable self-host target instead of tracking `main`.
+
+> **Beta** — actively being built. Expect rough edges and frequent updates. Issues and feedback are welcome. The software equivalent of going to the gym for the first time.
 
 > 🌐 **[Live demo → lyftr-demo.fly.dev](https://lyftr-demo.fly.dev)** — log in with `demo@lyftr.local` / `password123`. Shared instance, resets every hour.
 
@@ -50,7 +53,7 @@ Lyftr is for people who want a modern, mobile-first workout tracker that they fu
 | Weight tracking with trend graph | ✓ |
 | lbs / kg unit support across all data | ✓ |
 | Self-hosted — all data stays on your server | ✓ |
-| Nutrition tracking — calories and macros | In progress |
+| Nutrition tracking — calories, macros, barcode scan, food search | ✓ |
 | PWA — installable on any device | Planned |
 | Strong / Hevy CSV import | Planned |
 | iOS app (Swift) | Planned |
@@ -175,7 +178,7 @@ For HTTPS, put Lyftr behind Caddy or nginx with a Let's Encrypt certificate.
 - [x] Dashboard with charts and trends
 - [x] Weight tracking with trend graph + lbs/kg support
 - [x] Docker deployment with E2E test pipeline
-- [ ] Nutrition tracking — in progress
+- [x] Nutrition tracking — calories, macros, Open Food Facts search, barcode scan, history
 - [ ] PWA — installable on any device without an app store
 - [ ] Strong / Hevy CSV import — so you don't lose years of data switching
 - [ ] Apple Health / Google Fit export


### PR DESCRIPTION
## Summary

- Add live release badge at the top of the README (auto-pulls the latest GitHub release tag).
- Add a callout pointing to `v0.1.0-beta.1` with a self-host pinning tip.
- Mark nutrition tracking as shipped in both the features table and the roadmap.

## Test plan

- [ ] Render the README on GitHub and confirm the release badge resolves to `v0.1.0-beta.1`.
- [ ] Confirm the linked release URL opens correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)