### PR TITLE
docs: add Discord community badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/status-beta-orange" alt="Beta" />
   <a href="https://selfh.st/weekly/2026-04-24/"><img src="https://img.shields.io/badge/Featured%20in-selfh.st%20%C2%B7%20Apr%202026-6366f1" alt="Featured in selfh.st" /></a>
   <img src="https://img.shields.io/badge/iOS-planned-black?logo=apple&logoColor=white" alt="iOS Planned" />
-  <a href="https://discord.gg/uBr2tUH6j"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Join Discord" /></a>
+  <a href="https://discord.gg/hfFWsrebQA"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Join Discord" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <img src="https://img.shields.io/badge/status-beta-orange" alt="Beta" />
   <a href="https://selfh.st/weekly/2026-04-24/"><img src="https://img.shields.io/badge/Featured%20in-selfh.st%20%C2%B7%20Apr%202026-6366f1" alt="Featured in selfh.st" /></a>
   <img src="https://img.shields.io/badge/iOS-planned-black?logo=apple&logoColor=white" alt="iOS Planned" />
+  <a href="https://discord.gg/uBr2tUH6j"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Join Discord" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Add Discord join badge to README header alongside existing release/license/beta/iOS badges
- Links to permanent invite `https://discord.gg/hfFWsrebQA`

Closes #15

## Test plan
- [ ] Confirm badge renders on rendered README
- [ ] Confirm invite link opens Discord server

🤖 Generated with [Claude Code](https://claude.com/claude-code)