### PR TITLE
fix: resolve API base URL per-request so Server Settings takes effect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ CLAUDE.md
 # Playwright artifacts
 web/e2e/.auth/
 web/test-results/
+.playwright-mcp/

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,4 @@
-# API Configuration
-VITE_API_URL=http://localhost:3000/api
+# API Configuration — optional.
+# Leave unset for the standard deploy (nginx proxies /api to the backend).
+# If set, it must be the full API base including the version segment.
+# VITE_API_URL=http://localhost:3000/api/v1

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,19 +1,21 @@
 import axios, { AxiosInstance } from 'axios'
 import * as types from '../types'
 
-const getAPIBase = () => {
+// Resolved per-request so the "Server settings" panel takes effect immediately,
+// without needing a full page reload.
+const resolveAPIBase = () => {
+  const envUrl = import.meta.env.VITE_API_URL as string | undefined
+  if (envUrl) return envUrl
   const serverUrl = localStorage.getItem('server_url')
   return serverUrl ? `${serverUrl}/api/v1` : '/api/v1'
 }
 
-const API_BASE = (import.meta.env.VITE_API_URL as string) || getAPIBase()
-
 const api: AxiosInstance = axios.create({
-  baseURL: API_BASE,
   headers: { 'Content-Type': 'application/json' },
 })
 
 api.interceptors.request.use((config) => {
+  config.baseURL = resolveAPIBase()
   const token = localStorage.getItem('access_token')
   if (token) config.headers.Authorization = `Bearer ${token}`
   return config
@@ -27,7 +29,7 @@ api.interceptors.response.use(
       original._retry = true
       try {
         const refreshToken = localStorage.getItem('refresh_token')
-        const res = await axios.post(`${API_BASE}/auth/refresh`, { refresh_token: refreshToken })
+        const res = await axios.post(`${resolveAPIBase()}/auth/refresh`, { refresh_token: refreshToken })
         const newToken = res.data.data.token
         localStorage.setItem('access_token', newToken)
         original.headers.Authorization = `Bearer ${newToken}`


### PR DESCRIPTION
﻿## Summary

Resolves the API base URL **per-request** in the axios interceptor instead of freezing it at module-load time. The "Server Settings" panel change now takes effect immediately, with no page reload.

Relates to #14 — _not closing automatically, since the reporter never provided repro details and an alternate root cause is still plausible (see "Caveats" below)._

## Root cause

`web/src/services/api.ts` previously did:

```ts
const API_BASE = (import.meta.env.VITE_API_URL as string) || getAPIBase()
const api = axios.create({ baseURL: API_BASE })
```

`getAPIBase()` reads `localStorage.getItem('server_url')` — but only once, when the JS module first loads. The resolved value is baked into the axios instance. Writing a new server URL via the Server Settings panel updates localStorage but the axios instance keeps the stale `baseURL`, so the change is silently ignored until a full page reload. When the stale base is unreachable, every request fails and surfaces as a generic "Registration failed." / "Invalid email or password." with no diagnostic.

## Fix

Resolve the base in the axios request interceptor (and in the 401-refresh path) so every request re-reads localStorage:

```ts
const resolveAPIBase = () => {
  const envUrl = import.meta.env.VITE_API_URL as string | undefined
  if (envUrl) return envUrl
  const serverUrl = localStorage.getItem('server_url')
  return serverUrl ? `${serverUrl}/api/v1` : '/api/v1'
}

api.interceptors.request.use((config) => {
  config.baseURL = resolveAPIBase()
  ...
})
```

Also fixes `web/.env.example`: `/api` → `/api/v1` (path was missing the version segment, which would silently break any setup copying the example).

## Verification

End-to-end via Playwright MCP:

| Branch | server_url set to `:9999` | Behaviour |
|---|---|---|
| `main` | Request hits frozen `/api/v1` proxy → **201** | Setting was completely ignored |
| this branch | Request hits `:9999` → fail; change to `:3000` no reload → **201** | Setting takes effect on next request |

QA matrix (all PASS on this branch):
- Fresh state, no `server_url` (Vite proxy path) — register + dashboard 200
- Explicit good URL via panel — register 201, all dashboard calls cross-origin 200
- Bad → good URL with no reload — picks up new URL on next request
- Trailing-slash normalization — `:3000/` stored as `:3000`
- Login flow — same per-request resolve
- Logged-in + bad URL — all subsequent calls re-resolve, fail gracefully, empty state, no crash

`backend go test ./controllers/` → ok. Full Playwright suite: **147 passed / 4 failed / 2 skipped** — 4 failures (`food.spec.ts:289`, `food.spec.ts:444`, `programs.spec.ts:79`) are pre-existing on `main`, unrelated to this fix (the fix is functionally identical to `main` in the e2e default state where neither `server_url` nor `VITE_API_URL` are set).

## Caveats — please do not auto-close #14

I could not reproduce the original reporter's exact setup. One alternate root cause this fix does **not** change: `resolveAPIBase()` still gives `VITE_API_URL` precedence over `server_url`, so a `.env` with a wrong/stale `VITE_API_URL` will continue to ignore the Server Settings panel. The diff corrects `.env.example` so new setups don't hit that, but anyone with an existing bad `.env` will still be stuck.

Suggest leaving #14 open until the reporter confirms.

## Follow-up issues found during QA

Filed separately, **not** included in this PR:

- #16 — Network failures shown as misleading auth / empty-state messages (this is what made #14 hard to diagnose in the first place)
- #17 — Cannot change API server URL from in-app Settings (read-only)
- #18 — Server Settings "Save" stays disabled when typed value equals current

## Commits

- `c3ef125` — fix: resolve API base URL per-request so Server Settings takes effect
- `4d744c8` — chore: gitignore `.playwright-mcp/` artifact dir

_(rebased onto current `main`)_

