### PR TITLE
feat: derive app version from git tag and surface it in the UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,22 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # The build below only proves backend/Dockerfile injects the version. fly/Dockerfile
-      # (used by deploy-demo) builds the same binary but isn't smoke-tested here — a full
-      # nginx+frontend build just to read a version string isn't worth it. Instead, assert
-      # the two Dockerfiles inject identically, so a rename/typo in one can't silently ship
-      # "dev" from the other.
-      - name: Guard fly/Dockerfile injects the version like backend/Dockerfile
-        run: |
-          set -euo pipefail
-          b=$(sed -n 's/.*-ldflags="\([^"]*\)".*/\1/p' backend/Dockerfile)
-          f=$(sed -n 's/.*-ldflags="\([^"]*\)".*/\1/p' fly/Dockerfile)
-          echo "backend ldflags: $b"
-          echo "fly ldflags:     $f"
-          if [ -z "$b" ] || [ "$b" != "$f" ]; then
-            echo "::error::ldflags drift — backend/ and fly/ Dockerfiles must inject the version identically" >&2
-            exit 1
-          fi
       - name: Build backend image with a known version
         run: docker build --build-arg VERSION=smoke-9.9.9 -t lyftr-backend:smoke ./backend
       - name: Assert the binary reports the injected version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The build below only proves backend/Dockerfile injects the version. fly/Dockerfile
+      # (used by deploy-demo) builds the same binary but isn't smoke-tested here — a full
+      # nginx+frontend build just to read a version string isn't worth it. Instead, assert
+      # the two Dockerfiles inject identically, so a rename/typo in one can't silently ship
+      # "dev" from the other.
+      - name: Guard fly/Dockerfile injects the version like backend/Dockerfile
+        run: |
+          set -euo pipefail
+          b=$(sed -n 's/.*-ldflags="\([^"]*\)".*/\1/p' backend/Dockerfile)
+          f=$(sed -n 's/.*-ldflags="\([^"]*\)".*/\1/p' fly/Dockerfile)
+          echo "backend ldflags: $b"
+          echo "fly ldflags:     $f"
+          if [ -z "$b" ] || [ "$b" != "$f" ]; then
+            echo "::error::ldflags drift — backend/ and fly/ Dockerfiles must inject the version identically" >&2
+            exit 1
+          fi
       - name: Build backend image with a known version
         run: docker build --build-arg VERSION=smoke-9.9.9 -t lyftr-backend:smoke ./backend
       - name: Assert the binary reports the injected version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           for i in $(seq 1 30); do curl -sf http://localhost:3000/health >/dev/null && break; sleep 1; done
           info=$(curl -s http://localhost:3000/api/v1/info)
           echo "info: $info"
-          echo "$info" | grep -q '"version":"smoke-9.9.9"'
+          echo "$info" | grep -qE '"version":[[:space:]]*"smoke-9.9.9"'
       - name: Cleanup
         if: always()
         run: docker rm -f lyftr-smoke || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,16 +91,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build backend image with a known version
         run: docker build --build-arg VERSION=smoke-9.9.9 -t lyftr-backend:smoke ./backend
-      - name: Assert /info reports the injected version
+      - name: Assert the binary reports the injected version
         run: |
-          docker run -d --name lyftr-smoke -p 3000:3000 lyftr-backend:smoke
-          for i in $(seq 1 30); do curl -sf http://localhost:3000/health >/dev/null && break; sleep 1; done
-          info=$(curl -s http://localhost:3000/api/v1/info)
-          echo "info: $info"
-          echo "$info" | grep -qE '"version":[[:space:]]*"smoke-9.9.9"'
-      - name: Cleanup
-        if: always()
-        run: docker rm -f lyftr-smoke || true
+          set -euo pipefail
+          out=$(docker run --rm lyftr-backend:smoke --version)
+          echo "version output: $out"
+          echo "$out" | grep -q 'smoke-9.9.9'
 
   build-backend:
     name: Build & push backend image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,35 @@ jobs:
           path: web/playwright-report/
           retention-days: 7
 
-  build-backend:
-    name: Build & push backend image
-    needs: [test, e2e]
+  version-smoke:
+    name: Version injection smoke test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Build backend image with a known version
+        run: docker build --build-arg VERSION=smoke-9.9.9 -t lyftr-backend:smoke ./backend
+      - name: Assert /info reports the injected version
+        run: |
+          docker run -d --name lyftr-smoke -p 3000:3000 lyftr-backend:smoke
+          for i in $(seq 1 30); do curl -sf http://localhost:3000/health >/dev/null && break; sleep 1; done
+          info=$(curl -s http://localhost:3000/api/v1/info)
+          echo "info: $info"
+          echo "$info" | grep -q '"version":"smoke-9.9.9"'
+      - name: Cleanup
+        if: always()
+        run: docker rm -f lyftr-smoke || true
+
+  build-backend:
+    name: Build & push backend image
+    needs: [test, e2e, version-smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so `git describe --tags` resolves
+      - name: Resolve version
+        id: ver
+        run: echo "version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -110,6 +133,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha,scope=lyftr-backend
           cache-to: type=gha,scope=lyftr-backend,mode=max
 
@@ -144,13 +169,15 @@ jobs:
 
   deploy-demo:
     name: Deploy to Fly.io
-    needs: [test, e2e]
+    needs: [test, e2e, version-smoke]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so `git describe --tags` resolves
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --build-arg VERSION="$(git describe --tags --always)"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,10 +12,10 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy source and build a statically linked binary
+# Copy source and build the static binary via the shared build script
+# (single source of the version ldflags — see backend/build.sh)
 COPY . .
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -ldflags="-s -w -X github.com/Cawlumm/lyftr-backend/config.buildVersion=${VERSION}" -o lyftr-api .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH VERSION=$VERSION sh build.sh
 
 # Stage 2: Runtime
 FROM alpine:3.19

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,8 @@ FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+# Version baked into the binary. CI passes the git tag; defaults to "dev" locally.
+ARG VERSION=dev
 
 WORKDIR /build
 
@@ -12,7 +14,8 @@ RUN go mod download
 
 # Copy source and build a statically linked binary
 COPY . .
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o lyftr-api .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w -X github.com/Cawlumm/lyftr-backend/config.buildVersion=${VERSION}" -o lyftr-api .
 
 # Stage 2: Runtime
 FROM alpine:3.19

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Single source of truth for the backend Go build, shared by backend/Dockerfile and
+# fly/Dockerfile so the version-injection ldflags can't drift between the two images.
+# The cross-compile vars (CGO_ENABLED/GOOS/GOARCH) and VERSION are supplied by the
+# calling RUN's environment; VERSION falls back to "dev" for local/untagged builds.
+set -eu
+
+go build \
+  -ldflags="-s -w -X github.com/Cawlumm/lyftr-backend/config.buildVersion=${VERSION:-dev}" \
+  -o lyftr-api .

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -29,10 +29,10 @@ var C *Config
 //
 //	-ldflags "-X github.com/Cawlumm/lyftr-backend/config.buildVersion=$VERSION"
 //
-// where the Dockerfile passes the git tag as the VERSION build-arg. It falls back
+// where the Dockerfiles pass the git tag as the VERSION build-arg. It falls back
 // to "dev" for local/untagged builds. If you rename this var or the package, also
-// update the Dockerfile ldflags path and the version-smoke CI job, or the injection
-// will silently no-op and ship "dev".
+// update backend/build.sh (the shared ldflags) and the version-smoke CI job, or the
+// injection will silently no-op and ship "dev".
 var buildVersion = "dev"
 
 // Version returns the build-time version. Unlike C.Version it needs no Load(),

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -35,6 +35,10 @@ var C *Config
 // will silently no-op and ship "dev".
 var buildVersion = "dev"
 
+// Version returns the build-time version. Unlike C.Version it needs no Load(),
+// so the --version flag can report it without touching env or the database.
+func Version() string { return buildVersion }
+
 func Load() {
 	_ = godotenv.Load()
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -25,6 +25,14 @@ type Config struct {
 
 var C *Config
 
+// buildVersion is set at build time via:
+//   -ldflags "-X github.com/Cawlumm/lyftr-backend/config.buildVersion=$VERSION"
+// where the Dockerfile passes the git tag as the VERSION build-arg. It falls back
+// to "dev" for local/untagged builds. If you rename this var or the package, also
+// update the Dockerfile ldflags path and the version-smoke CI job, or the injection
+// will silently no-op and ship "dev".
+var buildVersion = "dev"
+
 func Load() {
 	_ = godotenv.Load()
 
@@ -41,7 +49,7 @@ func Load() {
 		JWTExpiry:  getEnv("JWT_EXPIRY", "3600"),
 		CORSOrigin: getEnv("CORS_ORIGIN", "http://localhost:5173"),
 		Env:        getEnv("ENV", "development"),
-		Version:    getEnv("APP_VERSION", "0.1.0"),
+		Version:    getEnv("APP_VERSION", buildVersion),
 	}
 
 	if C.Env == "production" && C.JWTSecret == "change-me-in-production-min-32-chars!!" {

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -8,25 +8,27 @@ import (
 )
 
 type Config struct {
-	Port          string
-	DBType        string // "sqlite" or "postgres"
-	DBPath        string // sqlite only
-	DBHost        string // postgres only
-	DBPort        string
-	DBName        string
-	DBUser        string
-	DBPassword    string
-	JWTSecret     string
-	JWTExpiry     string
-	CORSOrigin    string
-	Env           string
-	Version       string
+	Port       string
+	DBType     string // "sqlite" or "postgres"
+	DBPath     string // sqlite only
+	DBHost     string // postgres only
+	DBPort     string
+	DBName     string
+	DBUser     string
+	DBPassword string
+	JWTSecret  string
+	JWTExpiry  string
+	CORSOrigin string
+	Env        string
+	Version    string
 }
 
 var C *Config
 
 // buildVersion is set at build time via:
-//   -ldflags "-X github.com/Cawlumm/lyftr-backend/config.buildVersion=$VERSION"
+//
+//	-ldflags "-X github.com/Cawlumm/lyftr-backend/config.buildVersion=$VERSION"
+//
 // where the Dockerfile passes the git tag as the VERSION build-arg. It falls back
 // to "dev" for local/untagged builds. If you rename this var or the package, also
 // update the Dockerfile ldflags path and the version-smoke CI job, or the injection
@@ -49,7 +51,7 @@ func Load() {
 		JWTExpiry:  getEnv("JWT_EXPIRY", "3600"),
 		CORSOrigin: getEnv("CORS_ORIGIN", "http://localhost:5173"),
 		Env:        getEnv("ENV", "development"),
-		Version:    getEnv("APP_VERSION", buildVersion),
+		Version:    buildVersion,
 	}
 
 	if C.Env == "production" && C.JWTSecret == "change-me-in-production-min-32-chars!!" {

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/Cawlumm/lyftr-backend/config"
 	"github.com/Cawlumm/lyftr-backend/db"
@@ -11,6 +14,13 @@ import (
 )
 
 func main() {
+	showVersion := flag.Bool("version", false, "print the build version and exit")
+	flag.Parse()
+	if *showVersion {
+		fmt.Printf("lyftr %s\n", config.Version())
+		os.Exit(0)
+	}
+
 	config.Load()
 	db.Connect()
 	seed.DemoUser(db.DB)

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -20,12 +20,14 @@ RUN npm run build
 # CGO_ENABLED=0 produces a fully static binary — no libc dependency in runtime.
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS backend
 ARG TARGETOS TARGETARCH
+# Version baked into the binary. The deploy workflow passes the git tag/describe.
+ARG VERSION=dev
 WORKDIR /build
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -ldflags="-s -w" -o lyftr-api .
+    go build -ldflags="-s -w -X github.com/Cawlumm/lyftr-backend/config.buildVersion=${VERSION}" -o lyftr-api .
 
 # ── Stage 3: Runtime ─────────────────────────────────────────────────────────
 FROM nginx:alpine

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -26,8 +26,9 @@ WORKDIR /build
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ .
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -ldflags="-s -w -X github.com/Cawlumm/lyftr-backend/config.buildVersion=${VERSION}" -o lyftr-api .
+# Build via backend/build.sh (copied above) — shared with backend/Dockerfile so the
+# version ldflags live in one place and can't drift between the two images.
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH VERSION=$VERSION sh build.sh
 
 # ── Stage 3: Runtime ─────────────────────────────────────────────────────────
 FROM nginx:alpine

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lyfter-web",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/hooks/useServerInfo.ts
+++ b/web/src/hooks/useServerInfo.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { testServerConnection, type ServerInfo } from '../services/api'
+import { useServerStore } from '../stores/server'
+
+// Fetches the connected backend's /info once per server URL and caches it, so the
+// footer and Settings can show a live version. Returns null while loading or when
+// the server is unreachable — callers render a graceful fallback rather than a
+// stuck "Loading" (the failure mode some apps hit by hard-depending on the fetch).
+const cache = new Map<string, ServerInfo>()
+
+export function useServerInfo(): ServerInfo | null {
+  const base = useServerStore(s => s.serverUrl)
+  const [info, setInfo] = useState<ServerInfo | null>(() => cache.get(base) ?? null)
+
+  useEffect(() => {
+    const cached = cache.get(base)
+    if (cached) {
+      setInfo(cached)
+      return
+    }
+    let active = true
+    testServerConnection(base).then(result => {
+      if (active && result.ok) {
+        cache.set(base, result.info)
+        setInfo(result.info)
+      }
+    })
+    return () => { active = false }
+  }, [base])
+
+  return info
+}

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -96,7 +96,7 @@ export default function Login() {
 
         {/* Footer */}
         <div className="relative text-tx-muted text-xs">
-          © lyftr{serverInfo ? ` · ${formatVersion(serverInfo.version)}` : ''}
+          © lyftr{serverInfo?.version ? ` · ${formatVersion(serverInfo.version)}` : ''}
         </div>
       </div>
 

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -3,12 +3,15 @@ import { useNavigate, Link } from 'react-router-dom'
 import { AlertCircle, Zap, Dumbbell, Apple, TrendingUp, LogIn } from 'lucide-react'
 import { useAuthStore } from '../stores/auth'
 import { apiErrorMessage } from '../services/api'
+import { useServerInfo } from '../hooks/useServerInfo'
+import { formatVersion } from '../utils/version'
 import Logo from '../components/Logo'
 import ServerSettings from '../components/ServerSettings'
 
 export default function Login() {
   const navigate = useNavigate()
   const { login } = useAuthStore()
+  const serverInfo = useServerInfo()
 
   const [email, setEmail]           = useState('')
   const [password, setPassword]     = useState('')
@@ -93,7 +96,7 @@ export default function Login() {
 
         {/* Footer */}
         <div className="relative text-tx-muted text-xs">
-          © lyftr · v0.1.0
+          © lyftr{serverInfo ? ` · ${formatVersion(serverInfo.version)}` : ''}
         </div>
       </div>
 

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -87,7 +87,7 @@ export default function Register() {
 
         {/* Footer */}
         <div className="relative text-tx-muted text-xs">
-          © lyftr{serverInfo ? ` · ${formatVersion(serverInfo.version)}` : ''}
+          © lyftr{serverInfo?.version ? ` · ${formatVersion(serverInfo.version)}` : ''}
         </div>
       </div>
 

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -3,12 +3,15 @@ import { useNavigate, Link } from 'react-router-dom'
 import { AlertCircle, Dumbbell, Apple, TrendingUp, UserPlus } from 'lucide-react'
 import { useAuthStore } from '../stores/auth'
 import { apiErrorMessage } from '../services/api'
+import { useServerInfo } from '../hooks/useServerInfo'
+import { formatVersion } from '../utils/version'
 import Logo from '../components/Logo'
 import ServerSettings from '../components/ServerSettings'
 
 export default function Register() {
   const navigate = useNavigate()
   const { register } = useAuthStore()
+  const serverInfo = useServerInfo()
 
   const [email, setEmail]                     = useState('')
   const [password, setPassword]               = useState('')
@@ -84,7 +87,7 @@ export default function Register() {
 
         {/* Footer */}
         <div className="relative text-tx-muted text-xs">
-          © lyftr · v0.1.0
+          © lyftr{serverInfo ? ` · ${formatVersion(serverInfo.version)}` : ''}
         </div>
       </div>
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useAuthStore } from '../stores/auth'
 import { useServerStore } from '../stores/server'
+import { useServerInfo } from '../hooks/useServerInfo'
 import { useSettingsStore } from '../stores/settings'
 import { useTheme } from '../hooks/useTheme'
 import { exerciseAPI } from '../services/api'
@@ -40,6 +41,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 export default function Settings() {
   const { user, logout } = useAuthStore()
   const serverUrl = useServerStore(s => s.serverUrl)
+  const serverInfo = useServerInfo()
   const { theme, toggleTheme } = useTheme()
   const { settings: storedSettings, update: updateSettings, fetch: fetchSettings, setWorkoutLayout } = useSettingsStore()
   const [loading, setLoading] = useState(!useSettingsStore.getState().loaded)
@@ -301,7 +303,7 @@ export default function Settings() {
           <span className="badge-dim">SQLite</span>
         </SettingRow>
         <SettingRow label="Version" description="lyftr backend version">
-          <span className="text-xs text-tx-muted font-mono">v0.1.0</span>
+          <span className="text-xs text-tx-muted font-mono">{serverInfo ? serverInfo.version : '—'}</span>
         </SettingRow>
       </Section>
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -303,7 +303,7 @@ export default function Settings() {
           <span className="badge-dim">SQLite</span>
         </SettingRow>
         <SettingRow label="Version" description="lyftr backend version">
-          <span className="text-xs text-tx-muted font-mono">{serverInfo ? serverInfo.version : '—'}</span>
+          <span className="text-xs text-tx-muted font-mono">{serverInfo?.version || '—'}</span>
         </SettingRow>
       </Section>
 

--- a/web/src/utils/version.ts
+++ b/web/src/utils/version.ts
@@ -1,0 +1,10 @@
+/**
+ * `git describe` emits "<tag>-<commits>-g<sha>" for commits past the latest tag
+ * (e.g. on :latest/main builds). Collapse that tooling output to a human-friendly
+ * "<tag> (<sha>)" for display. Exact tags ("v0.1.0-beta.1") and bare commit SHAs
+ * pass through unchanged.
+ */
+export const formatVersion = (raw: string): string => {
+  const m = raw.match(/^(.+)-\d+-g([0-9a-f]+)$/)
+  return m ? `${m[1]} (${m[2]})` : raw
+}


### PR DESCRIPTION
## Summary

Derives the backend version from the git tag (no hardcoding) and surfaces it across the UI. Builds on the merged registration fix (#24).

- **Version is the git tag, end to end.** `config.buildVersion` is injected at build time via `-ldflags` from `git describe --tags --always` (both Dockerfiles pass it as the `VERSION` build-arg), falling back to `dev` for local/untagged builds. Exposed through `GET /api/v1/info`.
- **`--version` flag.** The backend prints the version (e.g. `lyftr v1.2.3`) and exits *before* any config/DB work, so `docker run --rm lyftr-backend --version` is a clean ops command — it even works in a locked-down prod env without `JWT_SECRET`.
- **UI.** The Login/Register footer and Settings show the live version via a `useServerInfo` hook (graceful fallback when the server is unreachable). `formatVersion()` collapses git-describe's `-N-gSHA` tail for the footer (e.g. `v1.2.3-4-gabcdef` → `v1.2.3 (abcdef)`); Settings shows the raw, precise string for support.
- **DRY build.** A single `backend/build.sh` holds the `go build` + version ldflags and is run by **both** `backend/Dockerfile` and `fly/Dockerfile`, so the injection lives in one place and can't drift between the two images.
- **CI.** Passes the version as a build-arg (`fetch-depth: 0` so the tag resolves). The `version-smoke` job builds the backend image and asserts `--version` reports the injected value.
- `package.json` version neutralized to `0.0.0` (the real version is git-driven).

## Validation

Verified end-to-end by running the app (not just CI):

- **CLI:** `--version` → `lyftr v0.1.0-3-gabc1234` (injected) / `lyftr dev` (default); single-dash works; unknown flag exits 2 with usage. `ENV=production --version` prints and exits 0 (short-circuits before the JWT guard), while booting *without* the flag correctly fatals — confirming the ordering.
- **API:** `GET /api/v1/info` → `{"name":"lyftr","version":"v0.1.0-3-gabc1234"}`.
- **UI:** footer renders `© lyftr · v0.1.0 (abc1234)` (the `formatVersion` collapse); Settings shows the raw `v0.1.0-3-gabc1234`; with an empty version the footer falls back to `© lyftr` (no dangling separator) and Settings to `—`.
- **Build script:** `VERSION=smoke-9.9.9 sh backend/build.sh` produces a binary whose `--version` reports `lyftr smoke-9.9.9`; unset → `lyftr dev`.

## Test plan
- [x] `go build` + `go test ./controllers ./routes`
- [x] `npm run type-check`
- [x] `--version`, `/info`, and footer/Settings verified in a browser
- [x] `version-smoke` green in CI; shared `backend/build.sh` validated
- [x] Rebased cleanly onto `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeGweBeouxSsT6nSaXy8Pk)_