### PR TITLE
docs: clarify BACKEND_ORIGIN is a Docker service name, not a host IP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ JWT_SECRET=change-me-to-a-random-32-plus-character-string
 CORS_ORIGIN=http://localhost
 PORT=80
 
-# Where the frontend proxies /api to. Change the port if you set a custom backend
-# PORT (the value must match), e.g. BACKEND_ORIGIN=backend:3008.
+# Address the frontend's nginx proxies /api to, over the internal Docker network.
+# This MUST be the backend's Docker service name (backend) — NOT your host/LAN IP.
+# Only change the port, and only if you set a custom backend PORT, e.g. backend:3008.
+# A host IP like 192.168.1.10:3000 gives a 502 Bad Gateway: in the default compose
+# the backend's port is only exposed on the Docker network, not published to the host.
 BACKEND_ORIGIN=backend:3000

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ All variables live in `.env` at the project root.
 | `JWT_SECRET` | *required* | Min 32-char secret for signing tokens |
 | `CORS_ORIGIN` | `http://localhost` | Comma-separated allow-list of client origins. Use `*` to allow any (the API is Bearer-token based, no cookies) |
 | `PORT` | `80` | Host port for the web interface |
-| `BACKEND_ORIGIN` | `backend:3000` | `host:port` the frontend proxies `/api` to. Must match the backend's `PORT` if you change it |
+| `BACKEND_ORIGIN` | `backend:3000` | Docker **service name**:port the frontend proxies `/api` to — not a host IP. Only change the port, to match a custom backend `PORT` |
+
+> **Self-hosting note:** `BACKEND_ORIGIN` is resolved over the internal Docker network, so it must use the backend's **service name** (`backend`), not your server's host or LAN IP. The default compose only *exposes* the backend on the Docker network — it isn't published to the host — so pointing `BACKEND_ORIGIN` at something like `192.168.1.10:3000` produces a `502 Bad Gateway` (`connect() failed (111: Connection refused)`). If you set a custom backend `PORT`, change only the port (e.g. `backend:3008`).
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarify in `.env.example` and the README config table that `BACKEND_ORIGIN` must be the backend's Docker **service name** (`backend:3000`), not a host/LAN IP.
- Document the failure mode: pointing it at a host IP yields a `502 Bad Gateway` (`connect() failed (111: Connection refused)`) because the default compose only *exposes* the backend on the internal Docker network, not on the host.

## Context
Resolves the confusion behind #31. The reporter confirmed `BACKEND_ORIGIN=backend:3000` fixed registration and closed the issue — it was a documentation gap, not a code bug. Verified locally against the reporter's exact compose: `backend:3000` → HTTP 201, a host IP whose port isn't published → the same 502 they saw.

Docs-only change — no code or behavior change.

Closes #31

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6ZPmdSFTWAduVCZXiRvRZ)_