### PR TITLE
fix: never run nested queries while a rows cursor is open

### DIFF
--- a/backend/controllers/concurrency_test.go
+++ b/backend/controllers/concurrency_test.go
@@ -1,0 +1,124 @@
+package controllers
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Cawlumm/lyftr-backend/db"
+)
+
+// Regression test for #30: list handlers used to run nested queries while a
+// parent rows cursor was still open, so each request needed multiple pool
+// connections at once. With the pool capped at N, N concurrent requests
+// deadlocked the pool permanently. The fix scans parents fully and closes the
+// cursor before loading children, so one connection per request suffices.
+func TestListWorkoutsConcurrentDoesNotExhaustPool(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+	exID := createTestExercise(t)
+
+	// Two workouts with exercises and sets so the nested loaders actually run.
+	for w := 0; w < 2; w++ {
+		res, err := db.DB.Exec(
+			`INSERT INTO workouts (user_id, name) VALUES (?, ?)`, uid, fmt.Sprintf("Workout %d", w),
+		)
+		if err != nil {
+			t.Fatalf("insert workout: %v", err)
+		}
+		wid, _ := res.LastInsertId()
+		weRes, err := db.DB.Exec(
+			`INSERT INTO workout_exercises (workout_id, exercise_id, order_index) VALUES (?, ?, 0)`, wid, exID,
+		)
+		if err != nil {
+			t.Fatalf("insert workout_exercise: %v", err)
+		}
+		weid, _ := weRes.LastInsertId()
+		if _, err := db.DB.Exec(
+			`INSERT INTO sets (workout_exercise_id, set_number, reps, weight) VALUES (?, 1, 5, 135)`, weid,
+		); err != nil {
+			t.Fatalf("insert set: %v", err)
+		}
+	}
+
+	// Small pool + more concurrent requests than connections: the old nested
+	// cursor pattern deadlocks here; the fixed code must finish promptly.
+	db.DB.SetMaxOpenConns(2)
+	const concurrency = 6
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c, w := newContext(uid, "GET", "/workouts", nil)
+				ListWorkouts(c)
+				if w.Code != 200 {
+					t.Errorf("ListWorkouts returned %d", w.Code)
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent ListWorkouts deadlocked the connection pool (#30 regression)")
+	}
+}
+
+func TestListProgramsConcurrentDoesNotExhaustPool(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+	exID := createTestExercise(t)
+
+	res, err := db.DB.Exec(`INSERT INTO programs (user_id, name) VALUES (?, 'PPL')`, uid)
+	if err != nil {
+		t.Fatalf("insert program: %v", err)
+	}
+	pid, _ := res.LastInsertId()
+	peRes, err := db.DB.Exec(
+		`INSERT INTO program_exercises (program_id, exercise_id, order_index) VALUES (?, ?, 0)`, pid, exID,
+	)
+	if err != nil {
+		t.Fatalf("insert program_exercise: %v", err)
+	}
+	peid, _ := peRes.LastInsertId()
+	if _, err := db.DB.Exec(
+		`INSERT INTO program_sets (program_exercise_id, set_number, target_reps, target_weight) VALUES (?, 1, 5, 135)`, peid,
+	); err != nil {
+		t.Fatalf("insert program_set: %v", err)
+	}
+
+	db.DB.SetMaxOpenConns(2)
+	const concurrency = 6
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c, w := newContext(uid, "GET", "/programs", nil)
+				ListPrograms(c)
+				if w.Code != 200 {
+					t.Errorf("ListPrograms returned %d", w.Code)
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent ListPrograms deadlocked the connection pool (#30 regression)")
+	}
+}

--- a/backend/controllers/programs.go
+++ b/backend/controllers/programs.go
@@ -44,12 +44,26 @@ func ListPrograms(c *gin.Context) {
 	}
 	defer rows.Close()
 
+	// Scan all parents and close the cursor before loading children: querying
+	// while a cursor is open needs a second pool connection per request, which
+	// deadlocks the pool under concurrent load (#30).
 	programs := []models.Program{}
 	for rows.Next() {
 		var p models.Program
-		rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt)
-		p.Exercises = loadProgramExercises(p.ID)
+		if err := rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt); err != nil {
+			utils.InternalError(c)
+			return
+		}
 		programs = append(programs, p)
+	}
+	if err := rows.Err(); err != nil {
+		utils.InternalError(c)
+		return
+	}
+	rows.Close()
+
+	for i := range programs {
+		programs[i].Exercises = loadProgramExercises(programs[i].ID)
 	}
 	utils.OK(c, programs)
 }
@@ -286,14 +300,22 @@ func loadProgramExercises(programID int64) []models.ProgramExercise {
 	var exercises []models.ProgramExercise
 	for rows.Next() {
 		var pe models.ProgramExercise
-		rows.Scan(
+		if err := rows.Scan(
 			&pe.ID, &pe.ProgramID, &pe.ExerciseID, &pe.OrderIndex, &pe.Notes,
 			&pe.Exercise.Name, &pe.Exercise.MuscleGroup, &pe.Exercise.Category,
 			&pe.Exercise.Equipment, &pe.Exercise.ImageURL,
-		)
+		); err != nil {
+			return nil
+		}
 		pe.Exercise.ID = pe.ExerciseID
-		pe.Sets = loadProgramSets(pe.ID)
 		exercises = append(exercises, pe)
+	}
+	// Close before loading sets — a nested query while this cursor is open
+	// holds two pool connections and deadlocks under concurrent load (#30).
+	rows.Close()
+
+	for i := range exercises {
+		exercises[i].Sets = loadProgramSets(exercises[i].ID)
 	}
 	return exercises
 }
@@ -312,7 +334,9 @@ func loadProgramSets(programExerciseID int64) []models.ProgramSet {
 	var sets []models.ProgramSet
 	for rows.Next() {
 		var s models.ProgramSet
-		rows.Scan(&s.ID, &s.ProgramExerciseID, &s.SetNumber, &s.TargetReps, &s.TargetWeight)
+		if err := rows.Scan(&s.ID, &s.ProgramExerciseID, &s.SetNumber, &s.TargetReps, &s.TargetWeight); err != nil {
+			return nil
+		}
 		sets = append(sets, s)
 	}
 	return sets

--- a/backend/controllers/workouts.go
+++ b/backend/controllers/workouts.go
@@ -46,12 +46,26 @@ func ListWorkouts(c *gin.Context) {
 	}
 	defer rows.Close()
 
+	// Scan all parents and close the cursor before loading children: querying
+	// while a cursor is open needs a second pool connection per request, which
+	// deadlocks the pool under concurrent load (#30).
 	workouts := []models.Workout{}
 	for rows.Next() {
 		var w models.Workout
-		rows.Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt)
-		w.Exercises = loadWorkoutExercises(w.ID)
+		if err := rows.Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt); err != nil {
+			utils.InternalError(c)
+			return
+		}
 		workouts = append(workouts, w)
+	}
+	if err := rows.Err(); err != nil {
+		utils.InternalError(c)
+		return
+	}
+	rows.Close()
+
+	for i := range workouts {
+		workouts[i].Exercises = loadWorkoutExercises(workouts[i].ID)
 	}
 	utils.OK(c, workouts)
 }
@@ -290,14 +304,22 @@ func loadWorkoutExercises(workoutID int64) []models.WorkoutExercise {
 	var exercises []models.WorkoutExercise
 	for rows.Next() {
 		var we models.WorkoutExercise
-		rows.Scan(
+		if err := rows.Scan(
 			&we.ID, &we.WorkoutID, &we.ExerciseID, &we.OrderIndex, &we.Notes,
 			&we.Exercise.Name, &we.Exercise.MuscleGroup, &we.Exercise.Category,
 			&we.Exercise.Equipment, &we.Exercise.ImageURL,
-		)
+		); err != nil {
+			return nil
+		}
 		we.Exercise.ID = we.ExerciseID
-		we.Sets = loadSets(we.ID)
 		exercises = append(exercises, we)
+	}
+	// Close before loading sets — a nested query while this cursor is open
+	// holds two pool connections and deadlocks under concurrent load (#30).
+	rows.Close()
+
+	for i := range exercises {
+		exercises[i].Sets = loadSets(exercises[i].ID)
 	}
 	return exercises
 }
@@ -316,7 +338,9 @@ func loadSets(workoutExerciseID int64) []models.Set {
 	var sets []models.Set
 	for rows.Next() {
 		var s models.Set
-		rows.Scan(&s.ID, &s.WorkoutExerciseID, &s.SetNumber, &s.Reps, &s.Weight, &s.Duration, &s.Distance, &s.RPE, &s.IsWarmup)
+		if err := rows.Scan(&s.ID, &s.WorkoutExerciseID, &s.SetNumber, &s.Reps, &s.Weight, &s.Duration, &s.Distance, &s.RPE, &s.IsWarmup); err != nil {
+			return nil
+		}
 		sets = append(sets, s)
 	}
 	return sets


### PR DESCRIPTION
## Summary
Fixes the nested-cursor connection-pool deadlock from #30. `ListWorkouts`/`GetWorkout`/create-update reloads and the `programs.go` equivalents issued child queries (`loadWorkoutExercises` → `loadSets`) while the parent `rows` cursor was still open, so a single request needed up to three pool connections at once. With `MaxOpenConns(10)`, ten concurrent list requests deadlocked the pool permanently — every subsequent request on any endpoint failed until restart.

## Fix
Scan all parent rows into a slice and close the cursor **before** loading children, in both the handlers and the `load*` helpers — one connection per request now suffices. Also added `Scan`/`rows.Err` checks that were previously ignored (failed scans silently appended zero-valued rows).

## Verification
- New regression tests (`concurrency_test.go`) cap the pool at 2 and fire 6 concurrent list requests: **deadlock + 10s timeout on `main`, pass on this branch** (verified both ways).
- Live check: 20 concurrent `GET /api/v1/workouts` against a running backend → 20/20 × 200 OK (the #30 table shows total deadlock at 10 on `main`).
- `go build ./...`, `go vet ./...`, `go test ./controllers/` green; full Playwright e2e suite: 161 passed, 2 skipped.

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)