### PR TITLE
fix: claim seeding flag atomically before wiping exercises

### DIFF
--- a/backend/seed/exercises.go
+++ b/backend/seed/exercises.go
@@ -72,21 +72,36 @@ func SyncExercises(db *sql.DB) error {
 
 // WipeAndReseed deletes all exercises then re-fetches from source.
 func WipeAndReseed(db *sql.DB) error {
-	if seeding.Load() {
+	// Claim the flag atomically BEFORE wiping: a Load-then-act check races —
+	// two concurrent calls could both pass it, double-wipe, and seed twice.
+	if !seeding.CompareAndSwap(false, true) {
 		return fmt.Errorf("seed already in progress")
 	}
 	if _, err := db.Exec(`DELETE FROM exercises`); err != nil {
+		seeding.Store(false)
 		return fmt.Errorf("wipe failed: %w", err)
 	}
 	log.Println("seed: exercises wiped, starting re-seed...")
-	go fetchAndStoreAsync(db)
+	go func() {
+		defer seeding.Store(false)
+		if err := fetchAndStoreLocked(db); err != nil {
+			log.Printf("seed: exercise sync failed: %v", err)
+		}
+	}()
 	return nil
 }
 
+// fetchAndStore claims the seeding flag for the duration of the sync.
 func fetchAndStore(db *sql.DB) error {
-	seeding.Store(true)
+	if !seeding.CompareAndSwap(false, true) {
+		return fmt.Errorf("seed already in progress")
+	}
 	defer seeding.Store(false)
+	return fetchAndStoreLocked(db)
+}
 
+// fetchAndStoreLocked does the sync; the caller must hold the seeding flag.
+func fetchAndStoreLocked(db *sql.DB) error {
 	items, err := fetchAll()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
`WipeAndReseed` checked `seeding.Load()` but the flag was only set inside the async goroutine (`fetchAndStore`), leaving a window — from the check until the goroutine got scheduled — where the flag was still `false`. Two rapid `POST /admin/reset-exercises` calls could both pass the check, wipe twice (the second wipe deleting mid-seed rows), and run two seeds concurrently. `SyncExercises` had no concurrency guard at all.

## Fix
- `WipeAndReseed` claims the flag with `CompareAndSwap` **before** the wipe and holds it until the background sync finishes (released on wipe failure).
- `fetchAndStore` is now CAS-guarded too, so the admin sync endpoint and startup seed can't overlap a running seed; the actual sync lives in `fetchAndStoreLocked`.

## Verification
`go build ./...`, `go vet ./...`, `go test ./controllers/` green; Playwright e2e: 161 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)