### PR TITLE
test(e2e): regression guard for server-settings Save enablement (closes #18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ CLAUDE.md
 # Playwright artifacts
 web/e2e/.auth/
 web/test-results/
+web/playwright-report/
 .playwright-mcp/

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -41,6 +41,28 @@ test('server settings tests and connects to the default (reverse proxy)', async 
   await expect(page.getByText(/connected · lyftr/i)).toBeVisible()
 })
 
+test('server settings Save stays enabled when the field equals the current server (regression #18)', async ({ page }) => {
+  // Regression for #18: before the #24 refactor the Save button was gated on a
+  // separate `serverInput` state that only became non-empty once the *displayed*
+  // value changed. So when the field already showed the current server URL and the
+  // user re-typed that same value, `serverInput` stayed empty and Save was stuck
+  // disabled. Seed a stored URL so the panel initializes with a non-empty value
+  // matching what the user re-types, and assert Save never gets stuck.
+  await page.addInitScript(() => localStorage.setItem('server_url', 'http://localhost:3000'))
+  await page.goto('/login')
+  await page.getByRole('button', { name: /server settings/i }).click()
+
+  const field = page.getByPlaceholder('Leave blank to use this site')
+  await expect(field).toHaveValue('http://localhost:3000')
+
+  const save = page.getByRole('button', { name: /test & save/i })
+  await expect(save).toBeEnabled()
+
+  // Re-typing the identical value must not disable Save (the original #18 repro).
+  await field.fill('http://localhost:3000')
+  await expect(save).toBeEnabled()
+})
+
 test('server settings rejects a scheme-less host instead of guessing the scheme', async ({ page }) => {
   // A bare host like "127.0.0.1:9" must be rejected with an error — we no longer
   // silently prepend a scheme. The user has to type http:// or https:// explicitly.


### PR DESCRIPTION
## What

#18 reported that the Server Settings **Save** button could stay stuck disabled when the typed value equaled the current server URL — caused by `value={serverInput || serverUrl}` + `disabled={!serverInput.trim()}` in the old inline `Login.tsx`/`Register.tsx` markup.

**That bug is already fixed.** PR #24 (`58d8e6d`) extracted the panel into `web/src/components/ServerSettings.tsx`, which initializes the input from the store (`useState(serverUrl)`), drops the fallback (`value={input}`), and gates Save only on the testing state (`disabled={status.kind === 'testing'}`) — so it can no longer get stuck. #18 was simply never closed.

This PR adds the missing **regression guard** so the behavior stays fixed.

## The test

A logged-out spec in `e2e/auth.spec.ts` that:
1. seeds `localStorage.server_url = http://localhost:3000` so the panel initializes with a non-empty value (the original repro condition),
2. opens Server Settings and asserts the field shows that value,
3. asserts **Test & Save** is enabled on load, and
4. re-types the identical value and asserts it stays enabled.

## Verification

Full E2E suite green on both projects (Desktop Chrome + iPhone 14): **163 passed, 0 failed**. New test passes on both.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)