### PR TITLE
docs: add TESTING.md — test layer strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,9 @@ navigation; reserve E2E for full user journeys against the running stack. Unit
 files are `src/**/*.test.ts(x)`; E2E specs are `e2e/**/*.spec.ts`. Keep the two
 suffixes/locations distinct so the runners never pick up each other's files.
 
+For the full layer model (unit / integration / e2e), where a new test belongs, and
+how to run each, see [docs/TESTING.md](docs/TESTING.md).
+
 Never commit with failing tests. Fix root cause — don't skip or comment out.
 
 ---

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,101 @@
+# Testing Strategy
+
+How Lyftr tests are organized, where a new test belongs, and how to run them. The
+goal is a **test pyramid**: many fast unit tests, a solid layer of integration
+tests, and a thin layer of end-to-end tests. Fast layers carry most of the
+coverage so the suite stays quick and reliable as the app grows.
+
+```
+        ╱ E2E ╲            few   — real browser, real user journeys (minutes)
+      ╱─────────╲
+    ╱ Integration ╲        some  — API handler + real DB (sub-second)
+  ╱─────────────────╲
+╱       Unit          ╲    many  — pure logic, no I/O (milliseconds)
+```
+
+## The layers
+
+### 1. Unit — pure logic, no I/O
+A single function/module in isolation; no database, no network, no browser.
+
+- **Frontend (Vitest):** `web/src/**/*.test.ts(x)`, jsdom environment.
+  Examples: `normalizeServerUrl`, `isPositiveNumber`, `dateUtils`, `formatVersion`,
+  Zustand store reducers, hook behavior (`useServerInfo`).
+- **Backend (`go test`):** pure functions with no DB/gin dependency.
+  Targets: `utils/jwt` (token generate/validate, expiry, wrong-secret, type
+  enforcement), `utils/password` (bcrypt round-trip), and any calculation logic
+  extracted out of handlers.
+- **Run:** `cd web && npm run test:unit` · `cd backend && go test ./utils/...`
+- **Speed:** milliseconds. Write lots of these.
+
+### 2. Integration — API handler + router + real SQLite
+Go `controllers/*_test.go`: table-driven, booting the real router against a real
+(embedded, in-process) SQLite schema — **no mocks**. This is the home for **API
+contract tests**: status codes, request validation, `user_id` ownership scoping,
+response shape, and DB persistence.
+
+- **Run:** `cd backend && go test ./...`
+- **Speed:** ~0.2s for the whole suite — fast because SQLite is embedded, not a
+  separate service.
+- **Naming note:** the CI job is historically labelled "Go unit tests"; by this
+  doc's taxonomy these are **integration tests** (they exercise more than one unit
+  and do real DB I/O). Go has *both* a unit layer (above) and this integration
+  layer.
+
+### 3. E2E — real browser, real user journeys
+Playwright (`web/e2e/*.spec.ts`), run under chromium and an iPhone-14 profile.
+For multi-step things a user actually does in the UI: register/login, log a
+workout, gym mode, the barcode scanner, the Settings server editor.
+
+- **Run:** `cd web && npm run test:e2e`
+- **Speed:** minutes. Keep this layer **thin** — it's the slowest and most fragile.
+
+## Where does a new test go?
+
+> **Rule: push each test to the lowest layer that can meaningfully cover it.**
+
+- Pure function — formatting, validation, a calculation, a store reducer → **unit**
+- Endpoint behavior — status code, validation error, ownership scoping, what's
+  persisted, response shape → **integration (Go)**
+- A multi-step flow a user performs in the browser → **e2e**
+
+Concretely: a "does `GET /food/search` return the right shape?" check is an
+**integration** test, not E2E. "Is this URL string valid?" is a **unit** test, not
+E2E. E2E is reserved for "the user opens the page, does X, and sees Y."
+
+## Rules that keep the pyramid healthy
+
+- **Move-then-verify, never delete-and-hope.** Don't remove a higher-layer test
+  until equivalent lower-layer coverage exists *and is green*. (E.g. the
+  `auth.spec` scheme/invalid-URL E2E cases are only safe to drop because
+  `stores/server.test.ts` now covers `normalizeServerUrl` directly.)
+- **Every test pins a distinct case or path.** No filler, no testing the framework,
+  no re-running the same assertion "through another door."
+- **Determinism.** Pin `TZ` for any local↔UTC date logic (see `vitest.config.ts`).
+  Don't share mutable state across tests that may run in parallel — each test owns
+  its own data.
+- **WHY-comments.** Explain non-obvious test setup in the same explanatory style as
+  the rest of the codebase.
+
+## Running everything
+
+| Layer | Command | Where |
+|---|---|---|
+| Frontend unit | `npm run test:unit` (`--coverage` for a report) | `web/` |
+| Backend unit + integration | `go test ./...` | `backend/` |
+| E2E (dev server) | `npm run test:e2e` | `web/` |
+| E2E (docker stack) | `npm run test:e2e:docker` | `web/` |
+
+CI runs all of these on every PR (see `.github/workflows/ci.yml`).
+
+## Current state & roadmap
+
+- ✅ **Frontend unit** layer established (Vitest).
+- 🔜 **Backend unit** layer — pure-logic gaps to fill: `utils/jwt`, `utils/password`,
+  and calculations currently inline in `GetDailyStats` / `GetWeightStats` (extract →
+  unit-test the math).
+- ✅ **Integration** — 82 Go controller tests.
+- 🔧 **E2E** — being rebalanced (API-contract tests moving down to Go) and
+  parallelized (per-test user isolation → multiple workers).
+
+Tracked in the testing-architecture overhaul issue.


### PR DESCRIPTION
## What
Adds `docs/TESTING.md` — the canonical testing strategy, and the anchor for the testing-architecture overhaul (#44).

Defines the pyramid and, most usefully, **where a new test belongs**:
> push each test to the lowest layer that can meaningfully cover it.

- **Unit** (Vitest frontend + pure-logic Go) — no I/O
- **Integration** (Go `controllers/*_test.go`, real embedded SQLite) — API contracts; clarifies these are integration tests even though the CI job is labelled "Go unit tests", and that Go has *both* a unit and an integration layer
- **E2E** (Playwright) — real user journeys only

Also documents the **move-then-verify** rule (never delete a higher-layer test until equivalent lower-layer coverage is green), determinism rules (pin `TZ`, per-test isolation), and a run-commands table. Linked from `CONTRIBUTING.md`.

Docs-only; no code changes.

Refs #44