### PR TITLE
test(e2e): remove hard waits, wait on real signals (refs #44)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -90,6 +90,11 @@ E2E. E2E is reserved for "the user opens the page, does X, and sees Y."
 - **Determinism.** Pin `TZ` for any local↔UTC date logic (see `vitest.config.ts`).
   Don't share mutable state across tests that may run in parallel — each test owns
   its own data.
+- **No hard waits in E2E.** Never `page.waitForTimeout(...)` — it's slow when the
+  app is fast and flaky when it's slow. Wait on a *real signal* instead: a
+  web-first assertion (`await expect(locator).toBeVisible()` auto-retries), a
+  navigation (`waitForURL`), or the actual network call
+  (`page.waitForResponse(r => r.url().includes('/api/v1/weight') && r.request().method() === 'POST')`).
 - **WHY-comments.** Explain non-obvious test setup in the same explanatory style as
   the rest of the codebase.
 

--- a/web/e2e/food.spec.ts
+++ b/web/e2e/food.spec.ts
@@ -152,9 +152,11 @@ test.describe('Food', () => {
   test('Macro History section renders with period selector', async ({ page }) => {
     await expect(page.getByText('Macro History')).toBeVisible()
     for (const period of ['7d', '30d', '90d']) {
-      await page.getByRole('button', { name: period, exact: true }).click()
-      await page.waitForTimeout(300)
-      await expect(page.getByRole('heading', { name: 'Nutrition' })).toBeVisible()
+      const periodBtn = page.getByRole('button', { name: period, exact: true })
+      await periodBtn.click()
+      // The selected period button takes the active style — a deterministic
+      // signal the switch registered, with no fixed sleep or data dependency.
+      await expect(periodBtn).toHaveClass(/bg-surface-raised/)
     }
   })
 

--- a/web/e2e/programs.spec.ts
+++ b/web/e2e/programs.spec.ts
@@ -109,7 +109,6 @@ test.describe('Programs', () => {
     await expect(page.getByText(SEED_SEARCH_PROGRAM_NAME).first()).toBeVisible({ timeout: 5000 })
     const searchInput = page.getByPlaceholder(/search programs/i)
     await searchInput.fill('SearchTarget')
-    await page.waitForTimeout(500)
     await expect(page.getByText(SEED_SEARCH_PROGRAM_NAME).first()).toBeVisible()
     await expect(page.getByText(SEED_PROGRAM_NAME)).not.toBeVisible()
   })
@@ -117,10 +116,8 @@ test.describe('Programs', () => {
   test('clearing search restores full list', async ({ page }) => {
     const searchInput = page.getByPlaceholder(/search programs/i)
     await searchInput.fill('SearchTarget')
-    await page.waitForTimeout(500)
     await expect(page.getByText(SEED_SEARCH_PROGRAM_NAME).first()).toBeVisible()
     await searchInput.fill('')
-    await page.waitForTimeout(500)
     await expect(page.getByText(SEED_PROGRAM_NAME)).toBeVisible()
     await expect(page.getByText(SEED_SEARCH_PROGRAM_NAME).first()).toBeVisible()
   })
@@ -130,7 +127,6 @@ test.describe('Programs', () => {
     const searchInput = page.getByPlaceholder(/search programs/i)
     await searchInput.click()
     await searchInput.type('S')
-    await page.waitForTimeout(500)
     await expect(searchInput).toBeFocused()
   })
 

--- a/web/e2e/weight.spec.ts
+++ b/web/e2e/weight.spec.ts
@@ -66,9 +66,11 @@ test.describe('Weight', () => {
   test('period selector switches chart range without crash', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Weight', exact: true })).toBeVisible()
     for (const period of ['7d', '90d', 'All', '30d']) {
-      await page.getByRole('button', { name: period, exact: true }).click()
-      await page.waitForTimeout(300)
-      // Page should still be showing the weight heading — no crash/remount
+      const periodBtn = page.getByRole('button', { name: period, exact: true })
+      await periodBtn.click()
+      // Selected period takes the active style (deterministic, no data
+      // dependency), and the page is still alive — replaces a fixed sleep.
+      await expect(periodBtn).toHaveClass(/bg-surface-raised/)
       await expect(page.getByRole('heading', { name: 'Weight', exact: true })).toBeVisible()
     }
   })
@@ -85,8 +87,11 @@ test.describe('Weight', () => {
     const weightInput = page.locator('input[inputmode="decimal"]').first()
     await weightInput.fill('170')
 
-    await page.getByRole('button', { name: /log weight/i }).click()
-    await page.waitForTimeout(500)
+    // Wait for the actual save (POST /weight) instead of a fixed sleep.
+    await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/v1/weight') && r.request().method() === 'POST'),
+      page.getByRole('button', { name: /log weight/i }).click(),
+    ])
 
     // Entry should appear in history
     await expect(page.getByText(/history/i)).toBeVisible({ timeout: 5000 })

--- a/web/e2e/workouts.spec.ts
+++ b/web/e2e/workouts.spec.ts
@@ -111,7 +111,6 @@ test.describe('Workouts', () => {
     const optionsBtn = page.getByRole('button', { name: /options/i }).first()
     if (await optionsBtn.isVisible()) {
       await optionsBtn.click()
-      await page.waitForTimeout(300)
       await page.getByRole('button', { name: /delete workout/i }).first().click()
     } else {
       const deleteButtons = page.getByRole('button', { name: /delete/i })
@@ -133,7 +132,6 @@ test.describe('Workouts', () => {
     await expect(page.getByText(SEED_SEARCH_WORKOUT_NAME).first()).toBeVisible({ timeout: 5000 })
     const searchInput = page.getByPlaceholder(/search workouts/i)
     await searchInput.fill('SearchTarget')
-    await page.waitForTimeout(500)
     await expect(page.getByText(SEED_SEARCH_WORKOUT_NAME).first()).toBeVisible()
     await expect(page.getByText(SEED_WORKOUT_NAME)).not.toBeVisible()
   })
@@ -141,10 +139,8 @@ test.describe('Workouts', () => {
   test('clearing search restores full list', async ({ page }) => {
     const searchInput = page.getByPlaceholder(/search workouts/i)
     await searchInput.fill('SearchTarget')
-    await page.waitForTimeout(500)
     await expect(page.getByText(SEED_SEARCH_WORKOUT_NAME).first()).toBeVisible()
     await searchInput.fill('')
-    await page.waitForTimeout(500)
     await expect(page.getByText(SEED_WORKOUT_NAME)).toBeVisible()
     await expect(page.getByText(SEED_SEARCH_WORKOUT_NAME).first()).toBeVisible()
   })
@@ -154,15 +150,18 @@ test.describe('Workouts', () => {
     const searchInput = page.getByPlaceholder(/search workouts/i)
     await searchInput.click()
     await searchInput.type('S')
-    await page.waitForTimeout(500)
     await expect(searchInput).toBeFocused()
   })
 
   test('weight unit displays consistently', async ({ page }) => {
     await page.goto('/settings')
     const kgButton = page.getByRole('button', { name: 'kg' })
-    await kgButton.click()
-    await page.waitForTimeout(500)
+    // Wait for the settings save (PUT /settings) before navigating, so /workouts
+    // reads the updated unit — a real signal, not a fixed sleep.
+    await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/v1/settings') && r.request().method() === 'PUT'),
+      kgButton.click(),
+    ])
 
     await page.goto('/workouts')
     const volumeElements = page.locator('text=/\\d+ kg/')


### PR DESCRIPTION
## What
Removes all **13 `page.waitForTimeout()`** hard waits — Playwright's #1 flakiness anti-pattern (slow when the app is fast, flaky when it's slow). Each is replaced with a *real* signal:

| Tests | Was | Now |
|---|---|---|
| search / clear / focus (programs, workouts) | `waitForTimeout(500)` | deleted — the following `toBeVisible` / `not.toBeVisible` / `toBeFocused` already auto-retry |
| period selectors (food, weight) | `waitForTimeout(300)` | assert the selected button takes its active style (`toHaveClass(/bg-surface-raised/)`) — deterministic, no chart-data dependency |
| log weight | `waitForTimeout(500)` | `waitForResponse(POST /weight)` |
| weight-unit toggle | `waitForTimeout(500)` | `waitForResponse(PUT /settings)` before navigating |
| kebab-menu delete | `waitForTimeout(300)` | deleted — the next `click()` auto-waits |

Codifies a **"no hard waits"** rule in `docs/TESTING.md` with the correct alternatives.

## Why
You asked whether we're following E2E best practices. Mostly yes (pyramid, API seeding, web-first assertions, project split, contracts-in-Go), but hard waits were a real gap — and they were contributing to the flakiness we saw when trying to parallelize. This closes that gap. (The remaining best-practice gap is **test isolation** — file-level shared seeding + broad cleanups — which is a larger follow-up.)

## Verification
Full suite green (single-worker): **88 passed, 0 failed**. No app/behavior change — test-only.

Refs #44