### PR TITLE
Exact weight inputs (0.1 precision) + centralize weight display/input (#39)

### DIFF
--- a/web/src/components/AddProgramModal.tsx
+++ b/web/src/components/AddProgramModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Plus, X, Trash2, AlertCircle, BookOpen, FileText, Zap, Target } from 'lucide-react'
 import { programAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayToLbs } from '../stores/settings'
+import WeightInput from './WeightInput'
 import ExercisePicker from './ExercisePicker'
 import * as types from '../types'
 
@@ -265,19 +266,7 @@ export default function AddProgramModal({ isOpen, onClose, onSuccess }: Props) {
                           </div>
                           <div className="flex-1 min-w-0">
                             <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Target Weight</label>
-                            <div className="relative">
-                              <input
-                                type="number"
-                                inputMode="decimal"
-                                value={set.target_weight || ''}
-                                onChange={e => updateSet(exIdx, setIdx, 'target_weight', e.target.value)}
-                                placeholder="135"
-                                className="input text-sm w-full pr-7"
-                                min="0"
-                                step="0.5"
-                              />
-                              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">{wUnit}</span>
-                            </div>
+                            <WeightInput stepper={false} size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
                           </div>
                           <button
                             type="button"

--- a/web/src/components/AddWorkoutModal.tsx
+++ b/web/src/components/AddWorkoutModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Plus, X, Trash2, AlertCircle, Dumbbell, Clock, FileText, Zap, Target, Gauge, BookOpen } from 'lucide-react'
 import { workoutAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayToLbs } from '../stores/settings'
+import WeightInput from './WeightInput'
 import ExercisePicker from './ExercisePicker'
 import ProgramPicker from './ProgramPicker'
 import * as types from '../types'
@@ -380,21 +381,7 @@ export default function AddWorkoutModal({ isOpen, onClose, onSuccess }: Props) {
                           {/* Weight */}
                           <div className="flex-1 min-w-0">
                             <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                            <div className="relative">
-                              <input
-                                type="number"
-                                inputMode="decimal"
-                                value={set.weight || ''}
-                                onChange={e => updateSet(exIdx, setIdx, 'weight', e.target.value)}
-                                placeholder="225"
-                                className="input text-sm w-full pr-7"
-                                min="0"
-                                step="0.5"
-                              />
-                              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">
-                                {wUnit}
-                              </span>
-                            </div>
+                            <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                           </div>
 
                           {/* Remove set button */}

--- a/web/src/components/EditProgramModal.tsx
+++ b/web/src/components/EditProgramModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Plus, X, Trash2, AlertCircle, BookOpen, FileText, Zap, Target } from 'lucide-react'
 import { programAPI } from '../services/api'
 import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import WeightInput from './WeightInput'
 import ExercisePicker from './ExercisePicker'
 import * as types from '../types'
 
@@ -277,10 +278,7 @@ export default function EditProgramModal({ isOpen, onClose, onSuccess, programId
                           </div>
                           <div className="flex-1 min-w-0">
                             <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Target Weight</label>
-                            <div className="relative">
-                              <input type="number" inputMode="decimal" value={set.target_weight || ''} onChange={e => updateSet(exIdx, setIdx, 'target_weight', e.target.value)} placeholder="135" className="input text-sm w-full pr-7" min="0" step="0.5" />
-                              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">{wUnit}</span>
-                            </div>
+                            <WeightInput stepper={false} size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
                           </div>
                           <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                             <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/components/EditWeightModal.tsx
+++ b/web/src/components/EditWeightModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { X, Scale, AlertCircle, Save } from 'lucide-react'
 import { weightAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayToLbs, displayWeight } from '../stores/settings'
+import WeightInput from './WeightInput'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { isPositiveNumber } from '../utils/numberUtils'
@@ -98,17 +99,8 @@ export default function EditWeightModal({ isOpen, onClose, onSuccess, log }: Pro
 
           <div>
             <label className="label">Weight</label>
-            <div className="relative mt-1">
-              <input
-                type="number"
-                value={weight}
-                onChange={e => setWeight(e.target.value)}
-                step="0.1"
-                min="0"
-                className="input pr-10"
-                autoFocus
-              />
-              <span className="absolute right-3.5 top-1/2 -translate-y-1/2 text-xs text-tx-muted">{wUnit}</span>
+            <div className="mt-1">
+              <WeightInput value={weight} onChange={setWeight} unit={wUnit} autoFocus />
             </div>
           </div>
 

--- a/web/src/components/EditWeightModal.tsx
+++ b/web/src/components/EditWeightModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Scale, AlertCircle, Save } from 'lucide-react'
 import { weightAPI } from '../services/api'
-import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import { useSettingsStore, weightShort, displayToLbs, displayWeight } from '../stores/settings'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { isPositiveNumber } from '../utils/numberUtils'
@@ -28,7 +28,7 @@ export default function EditWeightModal({ isOpen, onClose, onSuccess, log }: Pro
 
   useEffect(() => {
     if (!isOpen || !log) return
-    setWeight(String(Math.round(lbsToDisplay(log.weight, settings.weight_unit))))
+    setWeight(String(displayWeight(log.weight, settings.weight_unit)))
     setLoggedAt(isoToDayInput(log.logged_at))
     setNotes(log.notes ?? '')
     setError('')

--- a/web/src/components/EditWorkoutModal.tsx
+++ b/web/src/components/EditWorkoutModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Plus, X, Trash2, AlertCircle, Dumbbell, Clock, FileText, Zap, Target, Gauge } from 'lucide-react'
 import { workoutAPI, exerciseAPI } from '../services/api'
 import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import WeightInput from './WeightInput'
 import ExercisePicker from './ExercisePicker'
 import * as types from '../types'
 
@@ -398,21 +399,7 @@ export default function EditWorkoutModal({ isOpen, onClose, onSuccess, workoutId
                           {/* Weight */}
                           <div className="flex-1 min-w-0">
                             <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                            <div className="relative">
-                              <input
-                                type="number"
-                                inputMode="decimal"
-                                value={set.weight || ''}
-                                onChange={e => updateSet(exIdx, setIdx, 'weight', e.target.value)}
-                                placeholder="225"
-                                className="input text-sm w-full pr-7"
-                                min="0"
-                                step="0.5"
-                              />
-                              <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">
-                                {wUnit}
-                              </span>
-                            </div>
+                            <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                           </div>
 
                           {/* Remove set button */}

--- a/web/src/components/WeightInput.test.tsx
+++ b/web/src/components/WeightInput.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import WeightInput from './WeightInput'
+
+describe('WeightInput', () => {
+  it('stepper=false renders a bare field with no +/- buttons', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="lbs" stepper={false} />)
+    expect(screen.queryByLabelText(/decrease/i)).toBeNull()
+    expect(screen.queryByLabelText(/increase/i)).toBeNull()
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).value).toBe('100')
+  })
+
+  it('renders +/- buttons by default (stepper mode)', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="lbs" />)
+    expect(screen.getByLabelText(/decrease/i)).toBeTruthy()
+    expect(screen.getByLabelText(/increase/i)).toBeTruthy()
+  })
+
+  it('+ adjusts by step and emits a string', () => {
+    const onChange = vi.fn()
+    render(<WeightInput value="100" onChange={onChange} unit="lbs" step={0.1} />)
+    fireEvent.click(screen.getByLabelText(/increase/i))
+    expect(onChange).toHaveBeenCalledWith('100.1')
+  })
+
+  it('clamps at 0 — never goes negative', () => {
+    const onChange = vi.fn()
+    render(<WeightInput value="0" onChange={onChange} unit="lbs" step={0.1} />)
+    fireEvent.click(screen.getByLabelText(/decrease/i))
+    expect(onChange).toHaveBeenCalledWith('0')
+  })
+
+  it('passes the typed value straight through as a string (caller owns conversion)', () => {
+    const onChange = vi.fn()
+    render(<WeightInput value="" onChange={onChange} unit="lbs" stepper={false} />)
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '170.3' } })
+    expect(onChange).toHaveBeenCalledWith('170.3')
+  })
+
+  it('shows the unit suffix', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="kg" stepper={false} />)
+    expect(screen.getByText('kg')).toBeTruthy()
+  })
+})

--- a/web/src/components/WeightInput.test.tsx
+++ b/web/src/components/WeightInput.test.tsx
@@ -41,4 +41,24 @@ describe('WeightInput', () => {
     render(<WeightInput value="100" onChange={() => {}} unit="kg" stepper={false} />)
     expect(screen.getByText('kg')).toBeTruthy()
   })
+
+  it('default + button steps by 0.5 (locks STEP_DEFAULT — bodyweight ergonomics)', () => {
+    const onChange = vi.fn()
+    render(<WeightInput value="100" onChange={onChange} unit="lbs" />) // no step prop
+    fireEvent.click(screen.getByLabelText(/increase/i))
+    expect(onChange).toHaveBeenCalledWith('100.5')
+  })
+
+  it('the field always accepts 0.1 precision regardless of the button step', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="lbs" step={2.5} />)
+    // Button step is 2.5, but the input's typing precision stays 0.1.
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).step).toBe('0.1')
+  })
+
+  it('disabled disables the field and both buttons', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="lbs" disabled />)
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).disabled).toBe(true)
+    expect((screen.getByLabelText(/decrease/i) as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByLabelText(/increase/i) as HTMLButtonElement).disabled).toBe(true)
+  })
 })

--- a/web/src/components/WeightInput.tsx
+++ b/web/src/components/WeightInput.tsx
@@ -6,11 +6,19 @@ interface Props {
   unit: string
   step?: number
   autoFocus?: boolean
-  size?: 'md' | 'lg'
+  size?: 'sm' | 'md' | 'lg'
+  /** Show the +/- stepper buttons (prominent inputs). Off = bare field for compact rows. */
+  stepper?: boolean
+  placeholder?: string
+  disabled?: boolean
 }
 
-const STEP_DEFAULT = 0.5
+const STEP_DEFAULT = 0.1
 
+// Single component for every weight input in the app. Conversion-agnostic: the
+// caller owns lbs↔display unit (pass display-unit strings in/out). `stepper`
+// toggles the prominent +/- layout (bodyweight, gym mode) vs a bare field for
+// compact sets-table rows. All weight inputs share step=0.1 + the unit suffix.
 export default function WeightInput({
   value,
   onChange,
@@ -18,6 +26,9 @@ export default function WeightInput({
   step = STEP_DEFAULT,
   autoFocus = false,
   size = 'md',
+  stepper = true,
+  placeholder = '0.0',
+  disabled = false,
 }: Props) {
   const adjust = (delta: number) => {
     const current = parseFloat(value)
@@ -28,41 +39,46 @@ export default function WeightInput({
 
   const inputSize = size === 'lg'
     ? 'text-3xl py-4 font-display font-bold'
-    : 'text-base py-2.5'
+    : size === 'sm'
+      ? 'text-sm py-2.5'
+      : 'text-base py-2.5'
+  // Compact contexts (bare field or sm) use tighter unit padding.
+  const compact = !stepper || size === 'sm'
+  const pad = compact ? 'pr-7' : 'pr-12'
+  const unitPos = compact ? 'right-2' : 'right-3.5'
+
+  const field = (
+    <div className="relative flex-1 min-w-0">
+      <input
+        type="number"
+        inputMode="decimal"
+        enterKeyHint="done"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        step={step}
+        min="0"
+        autoFocus={autoFocus}
+        disabled={disabled}
+        className={`input ${inputSize} ${pad} text-center w-full tabular-nums ${disabled ? 'opacity-40' : ''}`}
+        placeholder={placeholder}
+      />
+      <span className={`absolute ${unitPos} top-1/2 -translate-y-1/2 text-xs text-tx-muted pointer-events-none`}>{unit}</span>
+    </div>
+  )
+
+  if (!stepper) return field
+
   const buttonSize = size === 'lg' ? 'p-4' : 'p-2.5'
   const iconSize = size === 'lg' ? 'w-6 h-6' : 'w-4 h-4'
+  const btn = `${buttonSize} bg-surface-overlay border border-surface-border rounded-lg text-tx-secondary hover:bg-surface-muted active:scale-95 transition-all flex items-center justify-center flex-shrink-0 disabled:opacity-30`
 
   return (
     <div className="flex items-stretch gap-2">
-      <button
-        type="button"
-        onClick={() => adjust(-step)}
-        className={`${buttonSize} bg-surface-overlay border border-surface-border rounded-lg text-tx-secondary hover:bg-surface-muted active:scale-95 transition-all flex items-center justify-center flex-shrink-0`}
-        aria-label={`Decrease by ${step}`}
-      >
+      <button type="button" onClick={() => adjust(-step)} disabled={disabled} className={btn} aria-label={`Decrease by ${step}`}>
         <Minus className={iconSize} />
       </button>
-      <div className="relative flex-1 min-w-0">
-        <input
-          type="number"
-          inputMode="decimal"
-          enterKeyHint="done"
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          step={step}
-          min="0"
-          autoFocus={autoFocus}
-          className={`input ${inputSize} pr-12 text-center w-full tabular-nums`}
-          placeholder="0.0"
-        />
-        <span className="absolute right-3.5 top-1/2 -translate-y-1/2 text-xs text-tx-muted">{unit}</span>
-      </div>
-      <button
-        type="button"
-        onClick={() => adjust(step)}
-        className={`${buttonSize} bg-surface-overlay border border-surface-border rounded-lg text-tx-secondary hover:bg-surface-muted active:scale-95 transition-all flex items-center justify-center flex-shrink-0`}
-        aria-label={`Increase by ${step}`}
-      >
+      {field}
+      <button type="button" onClick={() => adjust(step)} disabled={disabled} className={btn} aria-label={`Increase by ${step}`}>
         <Plus className={iconSize} />
       </button>
     </div>

--- a/web/src/components/WeightInput.tsx
+++ b/web/src/components/WeightInput.tsx
@@ -4,6 +4,7 @@ interface Props {
   value: string
   onChange: (next: string) => void
   unit: string
+  /** Increment for the +/- stepper buttons. Typing is always 0.1-precision regardless. */
   step?: number
   autoFocus?: boolean
   size?: 'sm' | 'md' | 'lg'
@@ -13,7 +14,11 @@ interface Props {
   disabled?: boolean
 }
 
-const STEP_DEFAULT = 0.1
+// The field always accepts 0.1 precision (the #39 feature); the +/- buttons step
+// by `step` — a larger, ergonomic increment — so gym mode can jump by 2.5 while you
+// can still type an exact 0.1 value. Bodyweight keeps the original 0.5 button feel.
+const INPUT_STEP = 0.1
+const STEP_DEFAULT = 0.5
 
 // Single component for every weight input in the app. Conversion-agnostic: the
 // caller owns lbs↔display unit (pass display-unit strings in/out). `stepper`
@@ -55,7 +60,7 @@ export default function WeightInput({
         enterKeyHint="done"
         value={value}
         onChange={e => onChange(e.target.value)}
-        step={step}
+        step={INPUT_STEP}
         min="0"
         autoFocus={autoFocus}
         disabled={disabled}

--- a/web/src/pages/ActiveWorkout.tsx
+++ b/web/src/pages/ActiveWorkout.tsx
@@ -6,7 +6,8 @@ import {
   AlertCircle, ChevronRight, ChevronLeft, Info,
 } from 'lucide-react'
 import { useWorkoutSession } from '../stores/workoutSession'
-import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import { useSettingsStore, weightShort, displayToLbs, displayWeight } from '../stores/settings'
+import WeightInput from '../components/WeightInput'
 import { workoutAPI } from '../services/api'
 import * as types from '../types'
 import { muscleColor } from '../utils/exerciseUtils'
@@ -346,19 +347,14 @@ export default function ActiveWorkout() {
                         />
 
                         {/* Weight */}
-                        <div className="relative">
-                          <input
-                            type="number"
-                            inputMode="decimal"
-                            value={set.actual_weight ? lbsToDisplay(set.actual_weight, wUnit) : ''}
-                            onChange={e => updateSet(exIdx, setIdx, 'actual_weight', displayToLbs(Number(e.target.value) || 0, wUnit))}
-                            placeholder={set.target_weight > 0 ? String(lbsToDisplay(set.target_weight, wUnit)) : '—'}
-                            className={`input text-base text-center py-3 w-full pr-7 transition-opacity ${set.completed ? 'opacity-40' : ''}`}
-                            disabled={set.completed}
-                            step="0.5"
-                          />
-                          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted pointer-events-none">{wUnit}</span>
-                        </div>
+                        <WeightInput
+                          stepper={false}
+                          value={set.actual_weight ? String(displayWeight(set.actual_weight, wUnit)) : ''}
+                          onChange={v => updateSet(exIdx, setIdx, 'actual_weight', displayToLbs(Number(v) || 0, wUnit))}
+                          unit={wUnit}
+                          placeholder={set.target_weight > 0 ? String(displayWeight(set.target_weight, wUnit)) : '—'}
+                          disabled={set.completed}
+                        />
 
                         {/* Complete toggle */}
                         <button

--- a/web/src/pages/AddProgram.tsx
+++ b/web/src/pages/AddProgram.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Plus, ArrowLeft, Trash2, AlertCircle, BookOpen, FileText, Zap, Target } from 'lucide-react'
 import { programAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayToLbs } from '../stores/settings'
+import WeightInput from '../components/WeightInput'
 import ExercisePicker from '../components/ExercisePicker'
 import * as types from '../types'
 
@@ -234,10 +235,7 @@ export default function AddProgram() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Target Weight</label>
-                          <div className="relative">
-                            <input type="number" inputMode="decimal" value={set.target_weight || ''} onChange={e => updateSet(exIdx, setIdx, 'target_weight', e.target.value)} placeholder="135" className="input text-sm w-full pr-7" min="0" step="0.5" />
-                            <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">{wUnit}</span>
-                          </div>
+                          <WeightInput stepper={false} size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
                         </div>
                         <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/pages/AddWorkout.tsx
+++ b/web/src/pages/AddWorkout.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Plus, ArrowLeft, Trash2, AlertCircle, Dumbbell, Clock, FileText, Zap, Target, Gauge, BookOpen, CalendarDays } from 'lucide-react'
 import { workoutAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayToLbs } from '../stores/settings'
+import WeightInput from '../components/WeightInput'
 import ExercisePicker from '../components/ExercisePicker'
 import ProgramPicker from '../components/ProgramPicker'
 import * as types from '../types'
@@ -231,10 +232,7 @@ export default function AddWorkout() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                          <div className="relative">
-                            <input type="number" inputMode="decimal" value={set.weight || ''} onChange={e => updateSet(exIdx, setIdx, 'weight', e.target.value)} placeholder="225" className="input text-sm w-full pr-7" min="0" step="0.5" />
-                            <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">{wUnit}</span>
-                          </div>
+                          <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                         </div>
                         <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -15,7 +15,7 @@ import QuickWeighInSheet from '../components/QuickWeighInSheet'
 import { workoutAPI, foodAPI, weightAPI, userAPI } from '../services/api'
 import { useWorkoutSession } from '../stores/workoutSession'
 import { useAuthStore } from '../stores/auth'
-import { useSettingsStore, weightShort, lbsToDisplay, displayWeight, displayVolume } from '../stores/settings'
+import { useSettingsStore, weightShort, displayWeight, displayVolume } from '../stores/settings'
 import { useNavigate, Link } from 'react-router-dom'
 import * as types from '../types'
 import { muscleColor } from '../utils/exerciseUtils'
@@ -244,7 +244,7 @@ export default function Dashboard() {
   // Weight sparkline
   const sparkData = [...weightLogs].reverse().map(l => ({
     date: format(new Date(l.logged_at), 'M/d'),
-    weight: Math.round(lbsToDisplay(l.weight, settings.weight_unit)),
+    weight: displayWeight(l.weight, settings.weight_unit),
   }))
 
   const username = user?.email?.split('@')[0] ?? 'there'

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -15,7 +15,7 @@ import QuickWeighInSheet from '../components/QuickWeighInSheet'
 import { workoutAPI, foodAPI, weightAPI, userAPI } from '../services/api'
 import { useWorkoutSession } from '../stores/workoutSession'
 import { useAuthStore } from '../stores/auth'
-import { useSettingsStore, weightShort, lbsToDisplay } from '../stores/settings'
+import { useSettingsStore, weightShort, lbsToDisplay, displayWeight, displayVolume } from '../stores/settings'
 import { useNavigate, Link } from 'react-router-dom'
 import * as types from '../types'
 import { muscleColor } from '../utils/exerciseUtils'
@@ -179,7 +179,7 @@ export default function Dashboard() {
   // Volume chart: slice by selected period, oldest→newest
   const chartData = workouts.slice(0, Number(volumePeriod)).reverse().map(w => ({
     date: format(new Date(w.started_at), 'M/d'),
-    volume: Math.round(lbsToDisplay(calcVolume(w), settings.weight_unit)),
+    volume: displayVolume(calcVolume(w), settings.weight_unit),
     name: w.name,
   }))
 
@@ -468,7 +468,7 @@ export default function Dashboard() {
         {lastWorkout ? (() => {
           const exs = lastWorkout.exercises ?? []
           const totalSets = exs.reduce((s, ex) => s + (ex.sets ?? []).length, 0)
-          const totalVolume = Math.round(lbsToDisplay(calcVolume(lastWorkout), settings.weight_unit))
+          const totalVolume = displayVolume(calcVolume(lastWorkout), settings.weight_unit)
           const mins = Math.round(lastWorkout.duration / 60)
           return (
             <div className="card p-4 overflow-hidden min-w-0 cursor-pointer active:scale-[0.99] transition-transform"
@@ -517,7 +517,7 @@ export default function Dashboard() {
                       </div>
                       {best && (
                         <span className="text-xs text-tx-muted tabular-nums flex-shrink-0">
-                          {sets.length}×{best.weight > 0 ? ` ${Math.round(lbsToDisplay(best.weight, settings.weight_unit))}${wUnit}` : ' BW'}
+                          {sets.length}×{best.weight > 0 ? ` ${displayWeight(best.weight, settings.weight_unit)}${wUnit}` : ' BW'}
                         </span>
                       )}
                     </div>
@@ -712,7 +712,7 @@ export default function Dashboard() {
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-baseline gap-1.5">
                 <span className="text-2xl font-bold text-tx-primary tabular-nums leading-none">
-                  {Math.round(lbsToDisplay(weightLogs[0].weight, settings.weight_unit))}
+                  {displayWeight(weightLogs[0].weight, settings.weight_unit)}
                 </span>
                 <span className="text-sm text-tx-muted">{wUnit}</span>
               </div>
@@ -724,7 +724,7 @@ export default function Dashboard() {
                   }
                   return (
                     <span className={`text-xs tabular-nums ${delta < 0 ? 'text-success-400' : 'text-error-400'}`}>
-                      7d · {delta < 0 ? '↓' : '↑'}{Math.abs(Math.round(lbsToDisplay(delta, settings.weight_unit)))} {wUnit}
+                      7d · {delta < 0 ? '↓' : '↑'}{Math.abs(displayWeight(delta, settings.weight_unit))} {wUnit}
                     </span>
                   )
                 })()}
@@ -752,7 +752,7 @@ export default function Dashboard() {
 
       <QuickWeighInSheet
         isOpen={sheetOpen}
-        lastValue={weightLogs[0] ? Math.round(lbsToDisplay(weightLogs[0].weight, settings.weight_unit)) : null}
+        lastValue={weightLogs[0] ? displayWeight(weightLogs[0].weight, settings.weight_unit) : null}
         lastLog={weightLogs[0] ?? null}
         onClose={() => setSheetOpen(false)}
         onSuccess={(log) => {

--- a/web/src/pages/EditProgram.tsx
+++ b/web/src/pages/EditProgram.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Plus, ArrowLeft, Trash2, AlertCircle, BookOpen, FileText, Zap, Target, Dumbbell } from 'lucide-react'
 import { programAPI } from '../services/api'
 import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import WeightInput from '../components/WeightInput'
 import ExercisePicker from '../components/ExercisePicker'
 import * as types from '../types'
 
@@ -234,10 +235,7 @@ export default function EditProgram() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Target Weight</label>
-                          <div className="relative">
-                            <input type="number" inputMode="decimal" value={set.target_weight || ''} onChange={e => updateSet(exIdx, setIdx, 'target_weight', e.target.value)} placeholder="135" className="input text-sm w-full pr-7" min="0" step="0.5" />
-                            <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">{wUnit}</span>
-                          </div>
+                          <WeightInput stepper={false} size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
                         </div>
                         <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/pages/EditWorkout.tsx
+++ b/web/src/pages/EditWorkout.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Plus, ArrowLeft, Trash2, AlertCircle, Dumbbell, Clock, FileText, Zap, Target, Gauge } from 'lucide-react'
 import { workoutAPI } from '../services/api'
 import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import WeightInput from '../components/WeightInput'
 import ExercisePicker from '../components/ExercisePicker'
 import * as types from '../types'
 
@@ -234,10 +235,7 @@ export default function EditWorkout() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                          <div className="relative">
-                            <input type="number" inputMode="decimal" value={set.weight || ''} onChange={e => updateSet(exIdx, setIdx, 'weight', e.target.value)} placeholder="225" className="input text-sm w-full pr-7" min="0" step="0.5" />
-                            <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted font-medium pointer-events-none">{wUnit}</span>
-                          </div>
+                          <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                         </div>
                         <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/pages/ExerciseDetail.tsx
+++ b/web/src/pages/ExerciseDetail.tsx
@@ -6,7 +6,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'rec
 import Model, { IExerciseData } from 'react-body-highlighter'
 import { exerciseAPI } from '../services/api'
 import { useWorkoutSession } from '../stores/workoutSession'
-import { useSettingsStore, weightShort, lbsToDisplay } from '../stores/settings'
+import { useSettingsStore, weightShort, displayWeight } from '../stores/settings'
 import { useTheme } from '../hooks/useTheme'
 import PeriodSelector from '../components/PeriodSelector'
 import * as types from '../types'
@@ -199,11 +199,11 @@ export default function ExerciseDetail() {
             <p className="text-xs font-semibold text-tx-muted uppercase tracking-wider">Your Best</p>
           </div>
           <div className="flex items-end gap-2">
-            <span className="text-2xl font-bold text-tx-primary tabular-nums">{Math.round(lbsToDisplay(pr.weight, wUnit))}</span>
+            <span className="text-2xl font-bold text-tx-primary tabular-nums">{displayWeight(pr.weight, wUnit)}</span>
             <span className="text-sm text-tx-muted mb-0.5">{wUnit} × {pr.reps} reps</span>
           </div>
           <p className="text-xs text-tx-muted mt-1">
-            Est. 1RM: {Math.round(lbsToDisplay(pr.estimated_1rm, wUnit))} {wUnit} · {format(new Date(pr.date), 'MMM d, yyyy')}
+            Est. 1RM: {displayWeight(pr.estimated_1rm, wUnit)} {wUnit} · {format(new Date(pr.date), 'MMM d, yyyy')}
           </p>
         </div>
       )}
@@ -212,7 +212,7 @@ export default function ExerciseDetail() {
       {history.length >= 2 && (() => {
         const chartData = [...filteredHistory].reverse().map(h => ({
           date: format(new Date(h.date), 'M/d'),
-          weight: Math.round(lbsToDisplay(h.max_weight, wUnit)),
+          weight: displayWeight(h.max_weight, wUnit),
         }))
         return (
           <div className="card p-4">

--- a/web/src/pages/GymModeWorkout.tsx
+++ b/web/src/pages/GymModeWorkout.tsx
@@ -11,6 +11,8 @@ import { muscleColor, muscleColorBordered, EQUIPMENT_LABEL, muscleToBodySlugs } 
 import { useTheme } from '../hooks/useTheme'
 import { useWorkoutSession } from '../stores/workoutSession'
 import { workoutAPI } from '../services/api'
+import WeightInput from '../components/WeightInput'
+import { displayWeight, displayToLbs } from '../stores/settings'
 
 function buildBodyData(exercise: types.Exercise): IExerciseData[] {
   const primarySlugs = muscleToBodySlugs(exercise.muscle_group)
@@ -575,25 +577,15 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
           {/* Weight */}
           <div className="flex flex-col items-center gap-2">
             <p className="text-xs font-semibold text-tx-muted uppercase tracking-wider">Weight ({wUnit})</p>
-            <div className="flex items-center gap-2 w-full">
-              <button
-                onClick={() => updateSet(activeIdx, clampedSetIdx, 'actual_weight', Math.max(0, (set.actual_weight || 0) - 2.5))}
+            <div className="w-full">
+              <WeightInput
+                size="lg"
+                value={set.actual_weight ? String(displayWeight(set.actual_weight, wUnit)) : ''}
+                onChange={v => updateSet(activeIdx, clampedSetIdx, 'actual_weight', displayToLbs(Number(v) || 0, wUnit))}
+                unit={wUnit}
+                placeholder={set.target_weight > 0 ? String(displayWeight(set.target_weight, wUnit)) : '0'}
                 disabled={set.completed}
-                className="w-11 h-11 rounded-xl bg-surface-muted hover:bg-surface-muted/80 border border-surface-border flex items-center justify-center text-xl font-bold text-tx-secondary transition-colors disabled:opacity-30"
-              >−</button>
-              <input
-                type="number" inputMode="decimal"
-                value={set.actual_weight || ''}
-                onChange={e => updateSet(activeIdx, clampedSetIdx, 'actual_weight', Number(e.target.value) || 0)}
-                placeholder={set.target_weight > 0 ? String(set.target_weight) : '0'}
-                className={`input text-2xl font-bold text-center flex-1 py-3 transition-opacity ${set.completed ? 'opacity-40' : ''}`}
-                disabled={set.completed} step="2.5"
               />
-              <button
-                onClick={() => updateSet(activeIdx, clampedSetIdx, 'actual_weight', (set.actual_weight || 0) + 2.5)}
-                disabled={set.completed}
-                className="w-11 h-11 rounded-xl bg-surface-muted hover:bg-surface-muted/80 border border-surface-border flex items-center justify-center text-xl font-bold text-tx-secondary transition-colors disabled:opacity-30"
-              >+</button>
             </div>
           </div>
         </div>

--- a/web/src/pages/GymModeWorkout.tsx
+++ b/web/src/pages/GymModeWorkout.tsx
@@ -580,6 +580,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
             <div className="w-full">
               <WeightInput
                 size="lg"
+                step={2.5}
                 value={set.actual_weight ? String(displayWeight(set.actual_weight, wUnit)) : ''}
                 onChange={v => updateSet(activeIdx, clampedSetIdx, 'actual_weight', displayToLbs(Number(v) || 0, wUnit))}
                 unit={wUnit}

--- a/web/src/pages/ProgramDetail.tsx
+++ b/web/src/pages/ProgramDetail.tsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react'
 import { programAPI } from '../services/api'
 import { useWorkoutSession } from '../stores/workoutSession'
-import { useSettingsStore, weightShort, lbsToDisplay } from '../stores/settings'
+import { useSettingsStore, weightShort, displayWeight } from '../stores/settings'
 import * as types from '../types'
 import { muscleColor } from '../utils/exerciseUtils'
 
@@ -194,7 +194,7 @@ export default function ProgramDetail() {
         {exs.map((ex) => {
           const sets = ex.sets ?? []
           const maxTargetLbs = sets.length > 0 ? Math.max(...sets.map(s => s.target_weight || 0)) : 0
-          const maxTarget = Math.round(lbsToDisplay(maxTargetLbs, wUnit))
+          const maxTarget = displayWeight(maxTargetLbs, wUnit)
 
           return (
             <button
@@ -238,7 +238,7 @@ export default function ProgramDetail() {
                       <div key={i} className={`px-2.5 py-1.5 rounded-lg text-xs font-semibold tabular-nums leading-none ${
                         isBest ? 'bg-brand-500/15 text-brand-300 ring-1 ring-brand-500/25' : 'bg-surface-raised text-tx-secondary'
                       }`}>
-                        {set.target_reps > 0 ? set.target_reps : '—'} × {set.target_weight > 0 ? `${Math.round(lbsToDisplay(set.target_weight, wUnit))} ${wUnit}` : 'BW'}
+                        {set.target_reps > 0 ? set.target_reps : '—'} × {set.target_weight > 0 ? `${displayWeight(set.target_weight, wUnit)} ${wUnit}` : 'BW'}
                       </div>
                     )
                   })}

--- a/web/src/pages/Weight.tsx
+++ b/web/src/pages/Weight.tsx
@@ -12,7 +12,7 @@ import { useServerInfiniteList } from '../hooks/useServerInfiniteList'
 import { isPositiveNumber } from '../utils/numberUtils'
 import { todayStr, dayToIsoNoon, isoToDayInput } from '../utils/dateUtils'
 import { weightAPI } from '../services/api'
-import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs, displayWeight, round1 } from '../stores/settings'
 import * as types from '../types'
 
 const PERIODS = ['7d', '30d', '90d', 'All'] as const
@@ -101,7 +101,7 @@ function TrendChart({ points, wUnit }: { points: ChartPoint[]; wUnit: string }) 
   // Callout: flip left if dot near right edge, flip below if dot near top
   const calloutFlipH = last[0] > W * 0.65
   const calloutFlipV = last[1] < PT + 30
-  const calloutLabel = String(Math.round(points[points.length - 1].weight))
+  const calloutLabel = String(round1(points[points.length - 1].weight))
   const calloutW = calloutLabel.length * 9 + 16
   const calloutX = calloutFlipH ? last[0] - calloutW - 8 : last[0] + 8
   const calloutY = calloutFlipV ? last[1] + 10 : last[1] - 28
@@ -121,7 +121,7 @@ function TrendChart({ points, wUnit }: { points: ChartPoint[]; wUnit: string }) 
         >
           <div className="bg-surface-raised border border-surface-border rounded-xl px-3 py-2 shadow-card text-xs whitespace-nowrap">
             <p className="font-bold tabular-nums text-tx-primary text-sm">
-              {Math.round(activePoint.weight)} <span className="font-normal text-tx-muted">{wUnit}</span>
+              {round1(activePoint.weight)} <span className="font-normal text-tx-muted">{wUnit}</span>
             </p>
             <p className="text-tx-muted mt-0.5">{format(activePoint.date, 'MMM d, yyyy')}</p>
           </div>
@@ -249,7 +249,7 @@ export default function Weight() {
   const prefillDoneRef = useRef(false)
   useEffect(() => {
     if (!prefillDoneRef.current && items.length > 0) {
-      setNewWeight(String(Math.round(lbsToDisplay(items[0].weight, settings.weight_unit))))
+      setNewWeight(String(displayWeight(items[0].weight, settings.weight_unit)))
       prefillDoneRef.current = true
     }
   }, [items])
@@ -289,7 +289,7 @@ export default function Weight() {
         notes: newNotes.trim(),
         logged_at: dayToIsoNoon(newDate),
       })
-      setNewWeight(String(Math.round(lbsToDisplay(real.weight, settings.weight_unit))))
+      setNewWeight(String(displayWeight(real.weight, settings.weight_unit)))
       setNewNotes('')
       setNewDate(todayStr())
       setShowNotes(false)
@@ -334,11 +334,11 @@ export default function Weight() {
     ? (stats!.max ?? 0)
     : (periodValues.length > 0 ? Math.max(...periodValues) : 0)
 
-  const current = lbsToDisplay(currentLbs, settings.weight_unit)
-  const change = Math.round(lbsToDisplay(changeLbs, settings.weight_unit))
-  const avg = Math.round(lbsToDisplay(avgLbs, settings.weight_unit))
-  const min = Math.round(lbsToDisplay(minLbs, settings.weight_unit))
-  const max = Math.round(lbsToDisplay(maxLbs, settings.weight_unit))
+  const current = displayWeight(currentLbs, settings.weight_unit)
+  const change = displayWeight(changeLbs, settings.weight_unit)
+  const avg = displayWeight(avgLbs, settings.weight_unit)
+  const min = displayWeight(minLbs, settings.weight_unit)
+  const max = displayWeight(maxLbs, settings.weight_unit)
 
   const trendIcon = change === 0 ? Minus : change < 0 ? TrendingDown : TrendingUp
   const TrendIcon = trendIcon
@@ -373,7 +373,7 @@ export default function Weight() {
             <h2 className="section-title">Log Weight</h2>
           </div>
           {items.length > 0 && (
-            <span className="text-[11px] text-tx-muted">last: {Math.round(lbsToDisplay(items[0].weight, settings.weight_unit))} {wUnit}</span>
+            <span className="text-[11px] text-tx-muted">last: {displayWeight(items[0].weight, settings.weight_unit)} {wUnit}</span>
           )}
         </div>
         <form ref={logFormRef} onSubmit={handleLog} className="space-y-3">
@@ -422,7 +422,7 @@ export default function Weight() {
             <div className="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-400" role="alert">
               <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
               <div className="flex-1 min-w-0">
-                <p className="font-medium">Already logged on {format(new Date(items[0].logged_at), 'MMM d')} ({Math.round(lbsToDisplay(items[0].weight, settings.weight_unit))} {wUnit}). Log again anyway?</p>
+                <p className="font-medium">Already logged on {format(new Date(items[0].logged_at), 'MMM d')} ({displayWeight(items[0].weight, settings.weight_unit)} {wUnit}). Log again anyway?</p>
                 <div className="flex gap-2 mt-2">
                   <button
                     type="button"
@@ -474,7 +474,7 @@ export default function Weight() {
               <div>
                 <p className="stat-label mb-2">Current Weight</p>
                 <div className="flex items-end gap-2">
-                  <span className="stat-value text-5xl">{Math.round(current)}</span>
+                  <span className="stat-value text-5xl">{current}</span>
                   <span className="text-tx-muted text-lg mb-1">{wUnit}</span>
                 </div>
               </div>
@@ -537,8 +537,8 @@ export default function Weight() {
             {items.map((entry, i) => {
               const next = items[i + 1]
               const deltaLbs = next ? entry.weight - next.weight : 0
-              const displayW = lbsToDisplay(entry.weight, settings.weight_unit)
-              const displayDelta = lbsToDisplay(Math.abs(deltaLbs), settings.weight_unit)
+              const displayW = displayWeight(entry.weight, settings.weight_unit)
+              const displayDelta = displayWeight(Math.abs(deltaLbs), settings.weight_unit)
               return (
                 <Link
                   key={entry.id}

--- a/web/src/pages/WeightDetail.tsx
+++ b/web/src/pages/WeightDetail.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { format } from 'date-fns'
 import { ArrowLeft, Scale, Trash2, Edit2, Save, X, AlertCircle, Loader } from 'lucide-react'
 import { weightAPI } from '../services/api'
-import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs } from '../stores/settings'
+import { useSettingsStore, weightShort, displayToLbs, displayWeight } from '../stores/settings'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { isPositiveNumber } from '../utils/numberUtils'
@@ -42,7 +42,7 @@ export default function WeightDetail() {
     weightAPI.get(Number(id))
       .then(data => {
         setLog(data)
-        setEditWeight(String(Math.round(lbsToDisplay(data.weight, settings.weight_unit))))
+        setEditWeight(String(displayWeight(data.weight, settings.weight_unit)))
         setEditDate(isoToDayInput(data.logged_at))
         setEditNotes(data.notes ?? '')
       })
@@ -52,7 +52,7 @@ export default function WeightDetail() {
 
   const startEdit = () => {
     if (!log) return
-    setEditWeight(String(Math.round(lbsToDisplay(log.weight, settings.weight_unit))))
+    setEditWeight(String(displayWeight(log.weight, settings.weight_unit)))
     setEditDate(isoToDayInput(log.logged_at))
     setEditNotes(log.notes ?? '')
     setEditError('')
@@ -158,7 +158,7 @@ export default function WeightDetail() {
             ) : (
               <>
                 <div className="flex items-end gap-2">
-                  <span className="stat-value text-5xl tabular-nums">{Math.round(lbsToDisplay(log.weight, settings.weight_unit))}</span>
+                  <span className="stat-value text-5xl tabular-nums">{displayWeight(log.weight, settings.weight_unit)}</span>
                   <span className="text-tx-muted text-lg mb-1">{wUnit}</span>
                 </div>
                 <p className="text-sm text-tx-muted mt-1">
@@ -248,7 +248,7 @@ export default function WeightDetail() {
             <div className="mx-auto w-10 h-1 rounded-full bg-surface-muted mb-4 sm:hidden" />
             <h3 className="font-display font-bold text-lg text-tx-primary mb-1">Delete Entry?</h3>
             <p className="text-sm text-tx-muted mb-5">
-              {format(new Date(log.logged_at), 'MMMM d, yyyy')} · {Math.round(lbsToDisplay(log.weight, settings.weight_unit))} {wUnit} will be permanently deleted.
+              {format(new Date(log.logged_at), 'MMMM d, yyyy')} · {displayWeight(log.weight, settings.weight_unit)} {wUnit} will be permanently deleted.
             </p>
             <div className="flex gap-3">
               <button

--- a/web/src/pages/WorkoutDetail.tsx
+++ b/web/src/pages/WorkoutDetail.tsx
@@ -6,7 +6,7 @@ import {
   ArrowLeft, Clock, Dumbbell, TrendingUp, Edit2, Trash2, ChevronRight, AlertCircle, Loader,
 } from 'lucide-react'
 import { workoutAPI } from '../services/api'
-import { useSettingsStore, weightShort, lbsToDisplay } from '../stores/settings'
+import { useSettingsStore, weightShort, displayWeight, displayVolume } from '../stores/settings'
 import * as types from '../types'
 import { muscleColor } from '../utils/exerciseUtils'
 
@@ -17,7 +17,7 @@ function SetChip({ set, isBest, unit }: { set: types.Set; isBest: boolean; unit:
         ? 'bg-brand-500/15 text-brand-300 ring-1 ring-brand-500/25'
         : 'bg-surface-raised text-tx-secondary'
     }`}>
-      {set.reps > 0 ? set.reps : '—'} × {set.weight > 0 ? `${Math.round(lbsToDisplay(set.weight, unit))} ${unit}` : 'BW'}
+      {set.reps > 0 ? set.reps : '—'} × {set.weight > 0 ? `${displayWeight(set.weight, unit)} ${unit}` : 'BW'}
     </div>
   )
 }
@@ -82,10 +82,10 @@ export default function WorkoutDetail() {
   }
 
   const exs = workout.exercises ?? []
-  const totalVolume = Math.round(lbsToDisplay(
+  const totalVolume = displayVolume(
     exs.reduce((s, ex) => s + (ex.sets ?? []).reduce((ss, set) => ss + set.reps * set.weight, 0), 0),
     wUnit
-  ))
+  )
   const totalSets = exs.reduce((s, ex) => s + (ex.sets ?? []).length, 0)
   const durationMin = Math.round(workout.duration / 60)
 
@@ -194,8 +194,8 @@ export default function WorkoutDetail() {
         {exs.map((ex, idx) => {
           const sets = ex.sets ?? []
           const maxWeightLbs = sets.length > 0 ? Math.max(...sets.map(s => s.weight || 0)) : 0
-          const maxWeight = Math.round(lbsToDisplay(maxWeightLbs, wUnit))
-          const exVol = Math.round(lbsToDisplay(sets.reduce((s, set) => s + (set.reps || 0) * (set.weight || 0), 0), wUnit))
+          const maxWeight = displayWeight(maxWeightLbs, wUnit)
+          const exVol = displayVolume(sets.reduce((s, set) => s + (set.reps || 0) * (set.weight || 0), 0), wUnit)
 
           return (
             <button

--- a/web/src/pages/Workouts.tsx
+++ b/web/src/pages/Workouts.tsx
@@ -8,7 +8,7 @@ import EmptyState from '../components/ui/EmptyState'
 import PageHeader from '../components/ui/PageHeader'
 import { useServerInfiniteList } from '../hooks/useServerInfiniteList'
 import { workoutAPI } from '../services/api'
-import { useSettingsStore, weightShort, lbsToDisplay } from '../stores/settings'
+import { useSettingsStore, weightShort, displayVolume } from '../stores/settings'
 import * as types from '../types'
 import { muscleColor } from '../utils/exerciseUtils'
 
@@ -32,11 +32,11 @@ function WorkoutCard({ workout, onEdit, onDelete }: { workout: types.Workout; on
     return () => document.removeEventListener('mousedown', handler)
   }, [])
   const durationMin = Math.round(workout.duration / 60)
-  const totalVolume = Math.round(lbsToDisplay(
+  const totalVolume = displayVolume(
     workout.exercises?.reduce((total, e) =>
       total + (e.sets?.reduce((s, set) => s + (set.reps || 0) * (set.weight || 0), 0) || 0), 0) || 0,
     wUnit
-  ))
+  )
 
   const handleDelete = async () => {
     setDeleting(true)

--- a/web/src/stores/settings.test.ts
+++ b/web/src/stores/settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { round1, displayWeight, displayVolume } from './settings'
+
+describe('round1', () => {
+  it('rounds to one decimal place', () => {
+    expect(round1(170)).toBe(170)
+    expect(round1(170.34)).toBe(170.3)
+    expect(round1(170.35)).toBe(170.4) // round-half-up
+    expect(round1(170.04)).toBe(170)   // trailing .0 drops (170, not 170.0)
+  })
+})
+
+describe('displayWeight', () => {
+  it('returns lbs unchanged (to 0.1) when unit is lbs', () => {
+    expect(displayWeight(170.3, 'lbs')).toBe(170.3)
+    expect(displayWeight(170, 'lbs')).toBe(170)
+  })
+
+  it('converts lbs→kg and rounds to 0.1 (no floating-point noise)', () => {
+    // 77 lbs / 2.20462 = 34.927… → 34.9
+    expect(displayWeight(77, 'kg')).toBe(34.9)
+    // 100 lbs / 2.20462 = 45.359… → 45.4
+    expect(displayWeight(100, 'kg')).toBe(45.4)
+  })
+
+  it('preserves 0.1 precision that the old Math.round (integer) destroyed', () => {
+    // Regression for #39: 170.3 lbs must not collapse to 170.
+    expect(displayWeight(170.3, 'lbs')).not.toBe(170)
+    expect(displayWeight(170.3, 'lbs')).toBe(170.3)
+  })
+})
+
+describe('displayVolume', () => {
+  it('always returns a whole number — volumes never want 0.1', () => {
+    expect(displayVolume(12345.6, 'lbs')).toBe(12346)
+    expect(Number.isInteger(displayVolume(9999.9, 'lbs'))).toBe(true)
+    expect(Number.isInteger(displayVolume(5000, 'kg'))).toBe(true)
+  })
+
+  it('lbs passthrough (rounded to integer)', () => {
+    expect(displayVolume(5000, 'lbs')).toBe(5000)
+  })
+
+  it('converts lbs→kg and rounds to a whole number', () => {
+    // 5000 lbs / 2.20462 = 2267.96… → 2268
+    expect(displayVolume(5000, 'kg')).toBe(2268)
+  })
+})

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -62,3 +62,16 @@ export const lbsToDisplay = (lbs: number, unit: string): number =>
 
 export const displayToLbs = (val: number, unit: string): number =>
   unit === 'kg' ? val * 2.20462 : val
+
+// Round to 0.1. Used for weight display/inputs: enough precision to log exact
+// weights (#39) without floating-point noise from the kg conversion.
+export const round1 = (n: number): number => Math.round(n * 10) / 10
+
+// Weight in the user's unit, rounded to 0.1 — use everywhere a weight is shown
+// or pre-filled into an input (replaces the old Math.round that forced integers).
+export const displayWeight = (lbs: number, unit: string): number => round1(lbsToDisplay(lbs, unit))
+
+// Volume/aggregate (sum of reps×weight) in the user's unit, as a whole number.
+// Volumes are large and never want 0.1 precision — keep this distinct from
+// displayWeight so the two can't be confused.
+export const displayVolume = (lbs: number, unit: string): number => Math.round(lbsToDisplay(lbs, unit))


### PR DESCRIPTION
Closes #39 — log/show weights at 0.1 precision, and consolidate the duplicated weight logic into one place.

## Problem
Weights were inconsistent across the app: single weights were integer-rounded on display (a logged 135.5 set/PR/bodyweight showed as "135"), and ~10 input sites had mixed steps (0.5 / 2.5 / 0.1). Gym mode's weight input had **no kg↔lbs conversion at all**, so kg users stored wrong values.

## Changes
**Display (commit 1)** — one numeric helper per kind in `settings.ts`:
- `displayWeight` (0.1) for every single weight; new `displayVolume` (whole number) for aggregates — kept distinct so volumes can't accidentally go fractional.
- Swept WorkoutDetail, Workouts, ExerciseDetail, ProgramDetail, Dashboard, Weight.

**Input (commit 2)** — one component for every weight input:
- Extended `WeightInput` with `stepper?` (bare field for compact sets-table rows vs the +/- layout) and a `sm` size; standardized **step = 0.1**.
- Routed all weight inputs through it: bodyweight (incl. EditWeightModal), set weights (Active/Add/Edit Workout + modals), target weights (Add/Edit Program + modals), gym mode.
- `WeightInput` stays conversion-agnostic (caller owns lbs↔display) — which **fixes the gym-mode kg bug** as a side effect (it now converts like ActiveWorkout). Food/serving inputs untouched.

## Tests
- Unit: `settings.test.ts` (round1/displayWeight/displayVolume, incl. "never fractional" + the #39 0.1 regression).
- Component: `WeightInput.test.tsx` (stepper on/off, ± adjust + clamp at 0, string passthrough).
- No new e2e (logic lives in unit/component, per discussion); full e2e run green (88 passed) as a regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)