### PR TITLE
fix(web): no kg round-trip drift on weight edits

### DIFF
--- a/web/src/components/EditWeightModal.tsx
+++ b/web/src/components/EditWeightModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Scale, AlertCircle, Save } from 'lucide-react'
 import { weightAPI } from '../services/api'
-import { useSettingsStore, weightShort, displayToLbs, displayWeight , weightError, maxWeight } from '../stores/settings'
+import { useSettingsStore, weightShort, displayWeight, weightError, maxWeight, resolveWeightLbs } from '../stores/settings'
 import WeightInput from './WeightInput'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
@@ -52,7 +52,7 @@ export default function EditWeightModal({ isOpen, onClose, onSuccess, log }: Pro
     setError('')
     try {
       await weightAPI.update(log.id, {
-        weight: displayToLbs(w, settings.weight_unit),
+        weight: resolveWeightLbs(weight, log.weight, settings.weight_unit),
         notes: notes.trim(),
         logged_at: dayToIsoNoon(loggedAt),
       })

--- a/web/src/pages/WeightDetail.tsx
+++ b/web/src/pages/WeightDetail.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { format } from 'date-fns'
 import { ArrowLeft, Scale, Trash2, Edit2, Save, X, AlertCircle, Loader } from 'lucide-react'
 import { weightAPI } from '../services/api'
-import { useSettingsStore, weightShort, displayToLbs, displayWeight , weightError, maxWeight } from '../stores/settings'
+import { useSettingsStore, weightShort, displayWeight, weightError, maxWeight, resolveWeightLbs } from '../stores/settings'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { todayStr, dayToIsoNoon, isoToDayInput } from '../utils/dateUtils'
@@ -71,7 +71,7 @@ export default function WeightDetail() {
     setEditError('')
     try {
       const updated = await weightAPI.update(log.id, {
-        weight: displayToLbs(w, settings.weight_unit),
+        weight: resolveWeightLbs(editWeight, log.weight, settings.weight_unit),
         notes: editNotes.trim(),
         logged_at: dayToIsoNoon(editDate),
       })

--- a/web/src/stores/settings.test.ts
+++ b/web/src/stores/settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { round1, displayWeight, displayVolume, weightError, isValidWeight, maxWeight } from './settings'
+import { round1, displayWeight, displayVolume, weightError, isValidWeight, maxWeight, resolveWeightLbs, displayToLbs } from './settings'
 
 describe('round1', () => {
   it('rounds to one decimal place', () => {
@@ -71,5 +71,18 @@ describe('weight validation (mirrors backend gt=0, lte=2000 lbs)', () => {
     expect(isValidWeight(907, 'kg')).toBe(true)          // 907 kg = 1999.6 lb
     expect(isValidWeight(910, 'kg')).toBe(false)         // 910 kg = 2006 lb
     expect(weightError(910, 'kg')).toMatch(/under 907 kg/)
+  })
+})
+
+describe('resolveWeightLbs (no drift when an edit leaves the shown value unchanged)', () => {
+  it('keeps the original lbs exactly when the shown value is unchanged', () => {
+    // 180 lb shows as 81.6 kg; re-saving "81.6" must stay 180, not drift to 179.9.
+    expect(resolveWeightLbs('81.6', 180, 'kg')).toBe(180)
+    expect(resolveWeightLbs('180', 180, 'lbs')).toBe(180)
+  })
+
+  it('converts only when the user actually changes the shown value', () => {
+    expect(resolveWeightLbs('82', 180, 'kg')).toBe(displayToLbs(82, 'kg'))   // changed → convert
+    expect(resolveWeightLbs('176', 180, 'lbs')).toBe(176)                    // changed → convert
   })
 })

--- a/web/src/stores/settings.ts
+++ b/web/src/stores/settings.ts
@@ -94,3 +94,14 @@ export const weightError = (value: number, unit: string): string | null => {
 }
 
 export const isValidWeight = (value: number, unit: string): boolean => weightError(value, unit) === null
+
+// Resolve the lbs value to store when saving an edited weight. Weights are shown
+// rounded to 0.1 in the display unit, so re-converting the shown value back to lbs
+// drifts (e.g. 180 lb → 81.6 kg → 179.9 lb). If the shown value is unchanged from
+// the original's rounded display, keep the original lbs exactly; only convert when
+// the user actually changed it. `displayValue` is the (possibly-edited) field string.
+export const resolveWeightLbs = (displayValue: string, originalLbs: number, unit: string): number => {
+  const shown = parseFloat(displayValue)
+  if (Number.isFinite(shown) && shown === displayWeight(originalLbs, unit)) return originalLbs
+  return displayToLbs(shown, unit)
+}


### PR DESCRIPTION
## Problem
Weights display rounded to 0.1 in the user's unit. Editing + re-saving re-converted the *rounded* shown value back to lbs, so an unchanged edit drifted: **180 lb → 81.6 kg → 179.9 lb**.

## Fix
`resolveWeightLbs(displayValue, originalLbs, unit)` — if the shown value is unchanged from the original's rounded display, keep the original lbs exactly; only convert when the user actually changed it. Wired into `EditWeightModal` + `WeightDetail` (the bodyweight edit forms). Display keeps rounding; the stored value only changes when intended.

## Scope (from an app-wide audit)
- **Bodyweight edits** (EditWeightModal, WeightDetail): had the drift → fixed.
- **Set/target edits** (Edit/Add Workout+Program): load full precision, so **no drift** — but show ugly long kg decimals. Separate cosmetic concern, left for a follow-up.
- **ActiveWorkout/GymMode**: per-keystroke save, untouched weights aren't re-saved → negligible.

## Tests
Unit: `resolveWeightLbs` (unchanged-keeps-original + changed-converts, lbs + kg). 57 unit total, type-check clean. Edit form confirmed to show the rounded value live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)