### PR TITLE
refactor: move all SQL into per-entity store classes (repository pattern)

### DIFF
--- a/backend/controllers/active_session.go
+++ b/backend/controllers/active_session.go
@@ -2,9 +2,7 @@ package controllers
 
 import (
 	"database/sql"
-	"time"
 
-	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/middleware"
 	"github.com/Cawlumm/lyftr-backend/utils"
 	"github.com/gin-gonic/gin"
@@ -12,17 +10,12 @@ import (
 
 func (h *Handler) GetActiveSession(c *gin.Context) {
 	uid := middleware.UserID(c)
-	var data string
-	var updatedAt time.Time
-	err := db.DB.QueryRow(
-		`SELECT data, updated_at FROM active_sessions WHERE user_id = ?`, uid,
-	).Scan(&data, &updatedAt)
+	data, updatedAt, err := h.s.ActiveSession.Get(uid)
 	if err == sql.ErrNoRows {
 		utils.OK(c, nil)
 		return
 	}
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
 		return
 	}
 	c.JSON(200, gin.H{"data": gin.H{"data": data, "updated_at": updatedAt}})
@@ -37,14 +30,7 @@ func (h *Handler) UpsertActiveSession(c *gin.Context) {
 		utils.BadRequest(c, err.Error())
 		return
 	}
-	_, err := db.DB.Exec(
-		`INSERT INTO active_sessions (user_id, data, updated_at)
-		 VALUES (?, ?, CURRENT_TIMESTAMP)
-		 ON CONFLICT(user_id) DO UPDATE SET data = excluded.data, updated_at = CURRENT_TIMESTAMP`,
-		uid, body.Data,
-	)
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, h.s.ActiveSession.Upsert(uid, body.Data)) {
 		return
 	}
 	utils.OK(c, gin.H{"saved": true})
@@ -52,6 +38,8 @@ func (h *Handler) UpsertActiveSession(c *gin.Context) {
 
 func (h *Handler) DeleteActiveSession(c *gin.Context) {
 	uid := middleware.UserID(c)
-	db.DB.Exec(`DELETE FROM active_sessions WHERE user_id = ?`, uid)
+	if utils.DBError(c, h.s.ActiveSession.Delete(uid)) {
+		return
+	}
 	utils.OK(c, gin.H{"deleted": true})
 }

--- a/backend/controllers/active_session.go
+++ b/backend/controllers/active_session.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetActiveSession(c *gin.Context) {
+func (h *Handler) GetActiveSession(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var data string
 	var updatedAt time.Time
@@ -28,7 +28,7 @@ func GetActiveSession(c *gin.Context) {
 	c.JSON(200, gin.H{"data": gin.H{"data": data, "updated_at": updatedAt}})
 }
 
-func UpsertActiveSession(c *gin.Context) {
+func (h *Handler) UpsertActiveSession(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var body struct {
 		Data string `json:"data" binding:"required"`
@@ -50,7 +50,7 @@ func UpsertActiveSession(c *gin.Context) {
 	utils.OK(c, gin.H{"saved": true})
 }
 
-func DeleteActiveSession(c *gin.Context) {
+func (h *Handler) DeleteActiveSession(c *gin.Context) {
 	uid := middleware.UserID(c)
 	db.DB.Exec(`DELETE FROM active_sessions WHERE user_id = ?`, uid)
 	utils.OK(c, gin.H{"deleted": true})

--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"database/sql"
 
-	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/models"
 	"github.com/Cawlumm/lyftr-backend/utils"
 	"github.com/gin-gonic/gin"
@@ -29,19 +28,14 @@ func (h *Handler) Register(c *gin.Context) {
 		return
 	}
 
-	res, err := db.DB.Exec(
-		`INSERT INTO users (email, password_hash) VALUES (?, ?)`,
-		req.Email, hash,
-	)
-	if err != nil {
-		utils.BadRequest(c, "email already registered")
+	userID, err := h.s.User.Create(req.Email, hash)
+	if utils.IsUniqueViolation(err) {
+		utils.Conflict(c, "email already registered")
 		return
 	}
-
-	userID, _ := res.LastInsertId()
-
-	// Create default settings
-	db.DB.Exec(`INSERT INTO user_settings (user_id) VALUES (?)`, userID)
+	if utils.DBError(c, err) {
+		return
+	}
 
 	access, refresh, err := utils.GenerateTokenPair(userID, req.Email)
 	if err != nil {
@@ -64,18 +58,16 @@ func (h *Handler) Login(c *gin.Context) {
 		return
 	}
 
-	var user models.User
-	err := db.DB.QueryRow(
-		`SELECT id, email, password_hash, created_at, updated_at FROM users WHERE email = ?`,
-		req.Email,
-	).Scan(&user.ID, &user.Email, &user.Password, &user.CreatedAt, &user.UpdatedAt)
-
-	if err == sql.ErrNoRows || !utils.CheckPassword(req.Password, user.Password) {
+	user, err := h.s.User.GetByEmail(req.Email)
+	if err == sql.ErrNoRows {
 		utils.Unauthorized(c, "invalid email or password")
 		return
 	}
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
+		return
+	}
+	if !utils.CheckPassword(req.Password, user.Password) {
+		utils.Unauthorized(c, "invalid email or password")
 		return
 	}
 

--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -12,7 +12,7 @@ import (
 
 var validate = validator.New()
 
-func Register(c *gin.Context) {
+func (h *Handler) Register(c *gin.Context) {
 	var req models.RegisterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, err.Error())
@@ -53,7 +53,7 @@ func Register(c *gin.Context) {
 	utils.Created(c, models.AuthResponse{Token: access, RefreshToken: refresh, User: user})
 }
 
-func Login(c *gin.Context) {
+func (h *Handler) Login(c *gin.Context) {
 	var req models.LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, err.Error())
@@ -89,7 +89,7 @@ func Login(c *gin.Context) {
 	utils.OK(c, models.AuthResponse{Token: access, RefreshToken: refresh, User: user})
 }
 
-func RefreshToken(c *gin.Context) {
+func (h *Handler) RefreshToken(c *gin.Context) {
 	var req models.RefreshRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, err.Error())

--- a/backend/controllers/cascade_test.go
+++ b/backend/controllers/cascade_test.go
@@ -1,0 +1,34 @@
+package controllers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Cawlumm/lyftr-backend/db"
+)
+
+// TestDeleteAccountCascadesChildren guards that DeleteAccount relies on ON DELETE
+// CASCADE — i.e. foreign keys must stay enforced. This is the behavioral guard
+// for keeping foreign_keys(on) in the production DSN (PR #32 dropped it; we
+// re-added it). The harness runs with foreign_keys=on, matching production.
+func TestDeleteAccountCascadesChildren(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+	if _, err := db.DB.Exec(`INSERT INTO weight_logs (user_id, weight) VALUES (?, 180)`, uid); err != nil {
+		t.Fatalf("seed weight log: %v", err)
+	}
+
+	c, w := newContext(uid, http.MethodDelete, "/api/v1/me", nil)
+	th.DeleteAccount(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DeleteAccount: expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	var n int
+	if err := db.DB.QueryRow(`SELECT COUNT(*) FROM weight_logs WHERE user_id = ?`, uid).Scan(&n); err != nil {
+		t.Fatalf("count after delete: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("child weight_logs not cascade-deleted: got %d, want 0 (foreign keys off?)", n)
+	}
+}

--- a/backend/controllers/concurrency_test.go
+++ b/backend/controllers/concurrency_test.go
@@ -1,0 +1,74 @@
+package controllers
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Cawlumm/lyftr-backend/db"
+)
+
+// Regression test for #30: list handlers used to run nested queries while a
+// parent rows cursor was still open, so each request needed multiple pool
+// connections at once. With the pool capped at N, N concurrent requests
+// deadlocked the pool permanently. The fix (in WorkoutStore.loadExercises) scans
+// parents fully and closes the cursor before loading children, so one connection
+// per request suffices.
+func TestListWorkoutsConcurrentDoesNotExhaustPool(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+	exID := createTestExercise(t)
+
+	// Two workouts with exercises and sets so the nested loaders actually run.
+	for w := 0; w < 2; w++ {
+		res, err := db.DB.Exec(
+			`INSERT INTO workouts (user_id, name) VALUES (?, ?)`, uid, fmt.Sprintf("Workout %d", w),
+		)
+		if err != nil {
+			t.Fatalf("insert workout: %v", err)
+		}
+		wid, _ := res.LastInsertId()
+		weRes, err := db.DB.Exec(
+			`INSERT INTO workout_exercises (workout_id, exercise_id, order_index) VALUES (?, ?, 0)`, wid, exID,
+		)
+		if err != nil {
+			t.Fatalf("insert workout_exercise: %v", err)
+		}
+		weid, _ := weRes.LastInsertId()
+		if _, err := db.DB.Exec(
+			`INSERT INTO sets (workout_exercise_id, set_number, reps, weight) VALUES (?, 1, 5, 135)`, weid,
+		); err != nil {
+			t.Fatalf("insert set: %v", err)
+		}
+	}
+
+	// Small pool + more concurrent requests than connections: the old nested
+	// cursor pattern deadlocks here; the fixed code must finish promptly.
+	db.DB.SetMaxOpenConns(2)
+	const concurrency = 6
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c, w := newContext(uid, "GET", "/workouts", nil)
+				th.ListWorkouts(c)
+				if w.Code != 200 {
+					t.Errorf("ListWorkouts returned %d", w.Code)
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent ListWorkouts deadlocked the connection pool (#30 regression)")
+	}
+}

--- a/backend/controllers/concurrency_test.go
+++ b/backend/controllers/concurrency_test.go
@@ -72,3 +72,56 @@ func TestListWorkoutsConcurrentDoesNotExhaustPool(t *testing.T) {
 		t.Fatal("concurrent ListWorkouts deadlocked the connection pool (#30 regression)")
 	}
 }
+
+// TestListProgramsConcurrentDoesNotExhaustPool is the program-side twin of the
+// workout test above (ProgramStore.loadExercises uses the same close-then-load fix).
+func TestListProgramsConcurrentDoesNotExhaustPool(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+	exID := createTestExercise(t)
+
+	res, err := db.DB.Exec(`INSERT INTO programs (user_id, name) VALUES (?, 'PPL')`, uid)
+	if err != nil {
+		t.Fatalf("insert program: %v", err)
+	}
+	pid, _ := res.LastInsertId()
+	peRes, err := db.DB.Exec(
+		`INSERT INTO program_exercises (program_id, exercise_id, order_index) VALUES (?, ?, 0)`, pid, exID,
+	)
+	if err != nil {
+		t.Fatalf("insert program_exercise: %v", err)
+	}
+	peid, _ := peRes.LastInsertId()
+	if _, err := db.DB.Exec(
+		`INSERT INTO program_sets (program_exercise_id, set_number, target_reps, target_weight) VALUES (?, 1, 5, 135)`, peid,
+	); err != nil {
+		t.Fatalf("insert program_set: %v", err)
+	}
+
+	db.DB.SetMaxOpenConns(2)
+	const concurrency = 6
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c, w := newContext(uid, "GET", "/programs", nil)
+				th.ListPrograms(c)
+				if w.Code != 200 {
+					t.Errorf("ListPrograms returned %d", w.Code)
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent ListPrograms deadlocked the connection pool (#30 regression)")
+	}
+}

--- a/backend/controllers/exercises.go
+++ b/backend/controllers/exercises.go
@@ -1,56 +1,29 @@
 package controllers
 
 import (
-	"encoding/json"
+	"database/sql"
 	"strconv"
 
-	"github.com/Cawlumm/lyftr-backend/db"
-	"github.com/Cawlumm/lyftr-backend/models"
-	"github.com/Cawlumm/lyftr-backend/seed"
+	"github.com/Cawlumm/lyftr-backend/middleware"
+	"github.com/Cawlumm/lyftr-backend/stores"
 	"github.com/Cawlumm/lyftr-backend/utils"
 	"github.com/gin-gonic/gin"
 )
 
 func (h *Handler) ListExercises(c *gin.Context) {
-	query := `SELECT id, name, muscle_group, secondary_muscles, category, equipment, description, image_url
-	          FROM exercises WHERE 1=1`
-	args := []any{}
-
-	if q := c.Query("q"); q != "" {
-		query += " AND name LIKE ?"
-		args = append(args, "%"+q+"%")
+	f := stores.ExerciseFilter{
+		Query:       c.Query("q"),
+		MuscleGroup: c.Query("muscle_group"),
+		Category:    c.Query("category"),
+		Equipment:   c.Query("equipment"),
+		Limit:       100,
 	}
-	if mg := c.Query("muscle_group"); mg != "" {
-		query += " AND muscle_group = ?"
-		args = append(args, mg)
-	}
-	if cat := c.Query("category"); cat != "" {
-		query += " AND category = ?"
-		args = append(args, cat)
-	}
-	if eq := c.Query("equipment"); eq != "" {
-		query += " AND equipment = ?"
-		args = append(args, eq)
-	}
-
-	limit := 100
 	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 2000 {
-		limit = l
+		f.Limit = l
 	}
-	query += " ORDER BY name LIMIT ?"
-	args = append(args, limit)
-
-	rows, err := db.DB.Query(query, args...)
-	if err != nil {
-		utils.InternalError(c)
+	exercises, err := h.s.Exercise.List(f)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	exercises := []models.Exercise{}
-	for rows.Next() {
-		e := scanExercise(rows)
-		exercises = append(exercises, e)
 	}
 	utils.OK(c, exercises)
 }
@@ -61,136 +34,82 @@ func (h *Handler) GetExercise(c *gin.Context) {
 		utils.BadRequest(c, "invalid exercise id")
 		return
 	}
-
-	row := db.DB.QueryRow(
-		`SELECT id, name, muscle_group, secondary_muscles, category, equipment, description, image_url
-		 FROM exercises WHERE id = ?`, id,
-	)
-	e := scanExercise(row)
-	if e.ID == 0 {
+	e, err := h.s.Exercise.Get(id)
+	if err == sql.ErrNoRows {
 		utils.NotFound(c, "exercise not found")
+		return
+	}
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.OK(c, e)
 }
 
 func (h *Handler) GetExercisePRs(c *gin.Context) {
-	userID := c.GetInt64("user_id")
+	uid := middleware.UserID(c)
 	exerciseID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
 		utils.BadRequest(c, "invalid exercise id")
 		return
 	}
-
-	row := db.DB.QueryRow(`
-		SELECT s.weight, s.reps, w.started_at, w.id
-		FROM sets s
-		JOIN workout_exercises we ON we.id = s.workout_exercise_id
-		JOIN workouts w ON w.id = we.workout_id
-		WHERE w.user_id = ? AND we.exercise_id = ? AND s.is_warmup = 0 AND s.weight > 0
-		ORDER BY s.weight DESC, s.reps DESC
-		LIMIT 1
-	`, userID, exerciseID)
-
-	var weight float64
-	var reps int
-	var date string
-	var workoutID int64
-	if err := row.Scan(&weight, &reps, &date, &workoutID); err != nil {
+	pr, err := h.s.Workout.PRForExercise(uid, exerciseID)
+	if err == sql.ErrNoRows {
 		utils.OK(c, nil)
 		return
 	}
-
-	estimated1RM := weight * (1 + float64(reps)/30.0)
+	if utils.DBError(c, err) {
+		return
+	}
 	utils.OK(c, gin.H{
-		"weight":        weight,
-		"reps":          reps,
-		"estimated_1rm": estimated1RM,
-		"date":          date,
-		"workout_id":    workoutID,
+		"weight":        pr.Weight,
+		"reps":          pr.Reps,
+		"estimated_1rm": pr.Weight * (1 + float64(pr.Reps)/30.0),
+		"date":          pr.Date,
+		"workout_id":    pr.WorkoutID,
 	})
 }
 
 func (h *Handler) GetExerciseHistory(c *gin.Context) {
-	userID := c.GetInt64("user_id")
+	uid := middleware.UserID(c)
 	exerciseID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
 		utils.BadRequest(c, "invalid exercise id")
 		return
 	}
-
 	limit := 20
 	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 100 {
 		limit = l
 	}
-
-	rows, err := db.DB.Query(`
-		SELECT w.started_at, MAX(s.weight), SUM(s.reps * s.weight), COUNT(s.id)
-		FROM sets s
-		JOIN workout_exercises we ON we.id = s.workout_exercise_id
-		JOIN workouts w ON w.id = we.workout_id
-		WHERE w.user_id = ? AND we.exercise_id = ? AND s.is_warmup = 0
-		GROUP BY w.id
-		ORDER BY w.started_at DESC
-		LIMIT ?
-	`, userID, exerciseID, limit)
-	if err != nil {
-		utils.InternalError(c)
+	history, err := h.s.Workout.HistoryForExercise(uid, exerciseID, limit)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	type point struct {
-		Date        string  `json:"date"`
-		MaxWeight   float64 `json:"max_weight"`
-		TotalVolume float64 `json:"total_volume"`
-		SetsCount   int     `json:"sets_count"`
-	}
-	history := []point{}
-	for rows.Next() {
-		var p point
-		rows.Scan(&p.Date, &p.MaxWeight, &p.TotalVolume, &p.SetsCount)
-		history = append(history, p)
 	}
 	utils.OK(c, history)
 }
 
 // SyncExercises is an admin-only endpoint to re-pull from ExerciseDB.
 func (h *Handler) SyncExercises(c *gin.Context) {
-	if err := seed.SyncExercises(db.DB); err != nil {
+	if err := h.s.Exercise.Sync(); err != nil {
 		utils.BadRequest(c, err.Error())
 		return
 	}
-	var count int
-	db.DB.QueryRow(`SELECT COUNT(*) FROM exercises`).Scan(&count)
+	count, err := h.s.Exercise.Count()
+	if utils.DBError(c, err) {
+		return
+	}
 	utils.OK(c, gin.H{"synced": true, "total": count})
 }
 
 // ExerciseSeedStatus returns exercise count and whether seeding is running.
 func (h *Handler) ExerciseSeedStatus(c *gin.Context) {
-	utils.OK(c, seed.GetSeedStatus(db.DB))
+	utils.OK(c, h.s.Exercise.SeedStatus())
 }
 
 // ResetExercises wipes the exercises table and triggers a fresh seed in background.
 func (h *Handler) ResetExercises(c *gin.Context) {
-	if err := seed.WipeAndReseed(db.DB); err != nil {
+	if err := h.s.Exercise.Reset(); err != nil {
 		utils.BadRequest(c, err.Error())
 		return
 	}
 	utils.OK(c, gin.H{"reset": true, "message": "exercises wiped, re-seeding in background"})
-}
-
-type scanner interface {
-	Scan(dest ...any) error
-}
-
-func scanExercise(row scanner) models.Exercise {
-	var e models.Exercise
-	var secondaryRaw string
-	row.Scan(&e.ID, &e.Name, &e.MuscleGroup, &secondaryRaw, &e.Category, &e.Equipment, &e.Description, &e.ImageURL)
-	json.Unmarshal([]byte(secondaryRaw), &e.SecondaryMuscles)
-	if e.SecondaryMuscles == nil {
-		e.SecondaryMuscles = []string{}
-	}
-	return e
 }

--- a/backend/controllers/exercises.go
+++ b/backend/controllers/exercises.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ListExercises(c *gin.Context) {
+func (h *Handler) ListExercises(c *gin.Context) {
 	query := `SELECT id, name, muscle_group, secondary_muscles, category, equipment, description, image_url
 	          FROM exercises WHERE 1=1`
 	args := []any{}
@@ -55,7 +55,7 @@ func ListExercises(c *gin.Context) {
 	utils.OK(c, exercises)
 }
 
-func GetExercise(c *gin.Context) {
+func (h *Handler) GetExercise(c *gin.Context) {
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
 		utils.BadRequest(c, "invalid exercise id")
@@ -74,7 +74,7 @@ func GetExercise(c *gin.Context) {
 	utils.OK(c, e)
 }
 
-func GetExercisePRs(c *gin.Context) {
+func (h *Handler) GetExercisePRs(c *gin.Context) {
 	userID := c.GetInt64("user_id")
 	exerciseID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -111,7 +111,7 @@ func GetExercisePRs(c *gin.Context) {
 	})
 }
 
-func GetExerciseHistory(c *gin.Context) {
+func (h *Handler) GetExerciseHistory(c *gin.Context) {
 	userID := c.GetInt64("user_id")
 	exerciseID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -156,7 +156,7 @@ func GetExerciseHistory(c *gin.Context) {
 }
 
 // SyncExercises is an admin-only endpoint to re-pull from ExerciseDB.
-func SyncExercises(c *gin.Context) {
+func (h *Handler) SyncExercises(c *gin.Context) {
 	if err := seed.SyncExercises(db.DB); err != nil {
 		utils.BadRequest(c, err.Error())
 		return
@@ -167,12 +167,12 @@ func SyncExercises(c *gin.Context) {
 }
 
 // ExerciseSeedStatus returns exercise count and whether seeding is running.
-func ExerciseSeedStatus(c *gin.Context) {
+func (h *Handler) ExerciseSeedStatus(c *gin.Context) {
 	utils.OK(c, seed.GetSeedStatus(db.DB))
 }
 
 // ResetExercises wipes the exercises table and triggers a fresh seed in background.
-func ResetExercises(c *gin.Context) {
+func (h *Handler) ResetExercises(c *gin.Context) {
 	if err := seed.WipeAndReseed(db.DB); err != nil {
 		utils.BadRequest(c, err.Error())
 		return

--- a/backend/controllers/exercises_test.go
+++ b/backend/controllers/exercises_test.go
@@ -43,7 +43,7 @@ func TestGetExercisePRs_noHistory(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, fmt.Sprintf("/api/v1/exercises/%d/prs", exID), nil)
 	setParam(c, "id", fmt.Sprintf("%d", exID))
-	GetExercisePRs(c)
+	th.GetExercisePRs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -65,7 +65,7 @@ func TestGetExercisePRs_returnsBestSet(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, fmt.Sprintf("/api/v1/exercises/%d/prs", exID), nil)
 	setParam(c, "id", fmt.Sprintf("%d", exID))
-	GetExercisePRs(c)
+	th.GetExercisePRs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -96,7 +96,7 @@ func TestGetExercisePRs_ignoresWarmup(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, fmt.Sprintf("/api/v1/exercises/%d/prs", exID), nil)
 	setParam(c, "id", fmt.Sprintf("%d", exID))
-	GetExercisePRs(c)
+	th.GetExercisePRs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -123,7 +123,7 @@ func TestGetExercisePRs_isolatesUser(t *testing.T) {
 
 	c, w := newContext(uid1, http.MethodGet, fmt.Sprintf("/api/v1/exercises/%d/prs", exID), nil)
 	setParam(c, "id", fmt.Sprintf("%d", exID))
-	GetExercisePRs(c)
+	th.GetExercisePRs(c)
 
 	resp := decodeResponse(t, w)
 	data := resp["data"].(map[string]any)
@@ -138,7 +138,7 @@ func TestGetExercisePRs_invalidID(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/exercises/bad/prs", nil)
 	setParam(c, "id", "bad")
-	GetExercisePRs(c)
+	th.GetExercisePRs(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -152,7 +152,7 @@ func TestGetExerciseHistory_empty(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, fmt.Sprintf("/api/v1/exercises/%d/history", exID), nil)
 	setParam(c, "id", fmt.Sprintf("%d", exID))
-	GetExerciseHistory(c)
+	th.GetExerciseHistory(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -178,7 +178,7 @@ func TestGetExerciseHistory_returnsSessionsGrouped(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, fmt.Sprintf("/api/v1/exercises/%d/history", exID), nil)
 	setParam(c, "id", fmt.Sprintf("%d", exID))
-	GetExerciseHistory(c)
+	th.GetExerciseHistory(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())

--- a/backend/controllers/food.go
+++ b/backend/controllers/food.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/middleware"
 	"github.com/Cawlumm/lyftr-backend/models"
 	"github.com/Cawlumm/lyftr-backend/utils"
@@ -24,18 +24,6 @@ var offClient = &http.Client{Timeout: 5 * time.Second}
 
 const offUserAgent = "Lyftr/1.0 (https://lyftr.app; nutrition-tracker)"
 
-// scanFoodLog scans all food_log columns including fiber and image_url.
-func scanFoodLog(row interface{ Scan(...any) error }, f *models.FoodLog) error {
-	return row.Scan(
-		&f.ID, &f.UserID, &f.Name, &f.Meal,
-		&f.Calories, &f.Protein, &f.Carbs, &f.Fat, &f.Fiber,
-		&f.Servings, &f.ServingSize, &f.Barcode, &f.ImageURL,
-		&f.LoggedAt, &f.CreatedAt,
-	)
-}
-
-const foodLogSelect = `SELECT id, user_id, name, meal, calories, protein, carbs, fat, fiber, servings, serving_size, barcode, image_url, logged_at, created_at FROM food_logs`
-
 func (h *Handler) ListFoodLogs(c *gin.Context) {
 	uid := middleware.UserID(c)
 
@@ -44,24 +32,9 @@ func (h *Handler) ListFoodLogs(c *gin.Context) {
 		date = time.Now().Format("2006-01-02")
 	}
 
-	rows, err := db.DB.Query(
-		foodLogSelect+` WHERE user_id = ? AND substr(logged_at, 1, 10) = ? ORDER BY logged_at ASC`,
-		uid, date,
-	)
-	if err != nil {
-		log.Printf("[food/list] db error: %v", err)
-		utils.InternalError(c)
+	logs, err := h.s.Food.ListByDay(uid, date)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	logs := []models.FoodLog{}
-	for rows.Next() {
-		var f models.FoodLog
-		if err := scanFoodLog(rows, &f); err != nil {
-			log.Printf("[food/list] scan error: %v", err)
-		}
-		logs = append(logs, f)
 	}
 	utils.OK(c, logs)
 }
@@ -74,10 +47,12 @@ func (h *Handler) GetFoodLog(c *gin.Context) {
 		return
 	}
 
-	var f models.FoodLog
-	row := db.DB.QueryRow(foodLogSelect+` WHERE id = ? AND user_id = ?`, lid, uid)
-	if err := scanFoodLog(row, &f); err != nil {
+	f, err := h.s.Food.Get(uid, lid)
+	if err == sql.ErrNoRows {
 		utils.NotFound(c, "log entry not found")
+		return
+	}
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.OK(c, f)
@@ -118,24 +93,8 @@ func (h *Handler) LogFood(c *gin.Context) {
 		req.Servings = 1
 	}
 
-	res, err := db.DB.Exec(
-		`INSERT INTO food_logs (user_id, name, meal, calories, protein, carbs, fat, fiber, servings, serving_size, barcode, image_url, logged_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		uid, req.Name, req.Meal, req.Calories, req.Protein, req.Carbs, req.Fat, req.Fiber,
-		req.Servings, req.ServingSize, req.Barcode, req.ImageURL, req.LoggedAt,
-	)
-	if err != nil {
-		log.Printf("[food/log] db error: %v", err)
-		utils.InternalError(c)
-		return
-	}
-
-	id, _ := res.LastInsertId()
-	var f models.FoodLog
-	row := db.DB.QueryRow(foodLogSelect+` WHERE id = ? AND user_id = ?`, id, uid)
-	if err := scanFoodLog(row, &f); err != nil {
-		log.Printf("[food/log] scan error: %v", err)
-		utils.InternalError(c)
+	f, err := h.s.Food.Create(uid, req)
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.Created(c, f)
@@ -178,28 +137,14 @@ func (h *Handler) UpdateFoodLog(c *gin.Context) {
 		req.Servings = 1
 	}
 
-	res, err := db.DB.Exec(
-		`UPDATE food_logs SET name=?, meal=?, calories=?, protein=?, carbs=?, fat=?, fiber=?,
-		 servings=?, serving_size=?, barcode=?, image_url=?, logged_at=?
-		 WHERE id=? AND user_id=?`,
-		req.Name, req.Meal, req.Calories, req.Protein, req.Carbs, req.Fat, req.Fiber,
-		req.Servings, req.ServingSize, req.Barcode, req.ImageURL, req.LoggedAt,
-		lid, uid,
-	)
-	if err != nil {
-		log.Printf("[food/update] db error: %v", err)
-		utils.InternalError(c)
-		return
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
+	f, err := h.s.Food.Update(uid, lid, req)
+	if err == sql.ErrNoRows {
 		utils.NotFound(c, "log entry not found")
 		return
 	}
-
-	var f models.FoodLog
-	row := db.DB.QueryRow(foodLogSelect+` WHERE id = ? AND user_id = ?`, lid, uid)
-	scanFoodLog(row, &f)
+	if utils.DBError(c, err) {
+		return
+	}
 	utils.OK(c, f)
 }
 
@@ -211,13 +156,10 @@ func (h *Handler) DeleteFoodLog(c *gin.Context) {
 		return
 	}
 
-	res, err := db.DB.Exec(`DELETE FROM food_logs WHERE id = ? AND user_id = ?`, lid, uid)
-	if err != nil {
-		log.Printf("[food/delete] db error: %v", err)
-		utils.InternalError(c)
+	n, err := h.s.Food.Delete(uid, lid)
+	if utils.DBError(c, err) {
 		return
 	}
-	n, _ := res.RowsAffected()
 	if n == 0 {
 		utils.NotFound(c, "log entry not found")
 		return
@@ -232,29 +174,14 @@ func (h *Handler) GetDailyStats(c *gin.Context) {
 		date = time.Now().Format("2006-01-02")
 	}
 
-	var stats models.DailyStats
+	stats, err := h.s.Food.DailyMacros(uid, date)
+	if utils.DBError(c, err) {
+		return
+	}
 	stats.Date = date
-
-	if err := db.DB.QueryRow(
-		`SELECT COALESCE(SUM(calories),0), COALESCE(SUM(protein),0),
-		        COALESCE(SUM(carbs),0), COALESCE(SUM(fat),0), COALESCE(SUM(fiber),0)
-		 FROM food_logs WHERE user_id = ? AND substr(logged_at, 1, 10) = ?`,
-		uid, date,
-	).Scan(&stats.TotalCalories, &stats.TotalProtein, &stats.TotalCarbs, &stats.TotalFat, &stats.TotalFiber); err != nil {
-		log.Printf("[food/stats] scan error (macros): %v", err)
-		utils.InternalError(c)
+	if stats.WorkoutCount, err = h.s.Workout.CountOn(uid, date); utils.DBError(c, err) {
 		return
 	}
-
-	if err := db.DB.QueryRow(
-		`SELECT COUNT(*) FROM workouts WHERE user_id = ? AND substr(started_at, 1, 10) = ?`,
-		uid, date,
-	).Scan(&stats.WorkoutCount); err != nil {
-		log.Printf("[food/stats] scan error (workouts): %v", err)
-		utils.InternalError(c)
-		return
-	}
-
 	utils.OK(c, stats)
 }
 
@@ -266,30 +193,9 @@ func (h *Handler) GetFoodHistory(c *gin.Context) {
 		days = d
 	}
 
-	rows, err := db.DB.Query(
-		`SELECT substr(logged_at, 1, 10) as d,
-		        COALESCE(SUM(calories),0), COALESCE(SUM(protein),0),
-		        COALESCE(SUM(carbs),0), COALESCE(SUM(fat),0)
-		 FROM food_logs
-		 WHERE user_id = ? AND logged_at >= date('now', ?)
-		 GROUP BY d ORDER BY d ASC`,
-		uid, fmt.Sprintf("-%d days", days),
-	)
-	if err != nil {
-		log.Printf("[food/history] db error: %v", err)
-		utils.InternalError(c)
+	points, err := h.s.Food.History(uid, days)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	points := []models.FoodHistoryPoint{}
-	for rows.Next() {
-		var p models.FoodHistoryPoint
-		if err := rows.Scan(&p.Date, &p.Calories, &p.Protein, &p.Carbs, &p.Fat); err != nil {
-			log.Printf("food/history scan: %v", err)
-			continue
-		}
-		points = append(points, p)
 	}
 	utils.OK(c, points)
 }
@@ -555,27 +461,9 @@ func (h *Handler) LookupBarcode(c *gin.Context) {
 func (h *Handler) ListSavedFoods(c *gin.Context) {
 	uid := middleware.UserID(c)
 
-	rows, err := db.DB.Query(
-		`SELECT id, user_id, name, brand, calories, protein, carbs, fat, fiber, serving_size, barcode, created_at
-		 FROM saved_foods WHERE user_id = ? ORDER BY name ASC`,
-		uid,
-	)
-	if err != nil {
-		log.Printf("[food/saved/list] db error: %v", err)
-		utils.InternalError(c)
+	foods, err := h.s.Food.ListSaved(uid)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	foods := []models.SavedFood{}
-	for rows.Next() {
-		var f models.SavedFood
-		if err := rows.Scan(&f.ID, &f.UserID, &f.Name, &f.Brand, &f.Calories, &f.Protein, &f.Carbs, &f.Fat,
-			&f.Fiber, &f.ServingSize, &f.Barcode, &f.CreatedAt); err != nil {
-			log.Printf("food/saved/list scan: %v", err)
-			continue
-		}
-		foods = append(foods, f)
 	}
 	utils.OK(c, foods)
 }
@@ -608,27 +496,8 @@ func (h *Handler) CreateSavedFood(c *gin.Context) {
 		return
 	}
 
-	res, err := db.DB.Exec(
-		`INSERT INTO saved_foods (user_id, name, brand, calories, protein, carbs, fat, fiber, serving_size, barcode)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		uid, req.Name, req.Brand, req.Calories, req.Protein, req.Carbs, req.Fat, req.Fiber,
-		req.ServingSize, req.Barcode,
-	)
-	if err != nil {
-		log.Printf("[food/saved/create] db error: %v", err)
-		utils.InternalError(c)
-		return
-	}
-
-	id, _ := res.LastInsertId()
-	var f models.SavedFood
-	if err := db.DB.QueryRow(
-		`SELECT id, user_id, name, brand, calories, protein, carbs, fat, fiber, serving_size, barcode, created_at
-		 FROM saved_foods WHERE id = ?`, id,
-	).Scan(&f.ID, &f.UserID, &f.Name, &f.Brand, &f.Calories, &f.Protein, &f.Carbs, &f.Fat,
-		&f.Fiber, &f.ServingSize, &f.Barcode, &f.CreatedAt); err != nil {
-		log.Printf("[food/saved/create] scan error: %v", err)
-		utils.InternalError(c)
+	f, err := h.s.Food.CreateSaved(uid, req)
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.Created(c, f)
@@ -642,13 +511,10 @@ func (h *Handler) DeleteSavedFood(c *gin.Context) {
 		return
 	}
 
-	res, err := db.DB.Exec(`DELETE FROM saved_foods WHERE id = ? AND user_id = ?`, fid, uid)
-	if err != nil {
-		log.Printf("[food/saved/delete] db error: %v", err)
-		utils.InternalError(c)
+	n, err := h.s.Food.DeleteSaved(uid, fid)
+	if utils.DBError(c, err) {
 		return
 	}
-	n, _ := res.RowsAffected()
 	if n == 0 {
 		utils.NotFound(c, "saved food not found")
 		return

--- a/backend/controllers/food.go
+++ b/backend/controllers/food.go
@@ -36,7 +36,7 @@ func scanFoodLog(row interface{ Scan(...any) error }, f *models.FoodLog) error {
 
 const foodLogSelect = `SELECT id, user_id, name, meal, calories, protein, carbs, fat, fiber, servings, serving_size, barcode, image_url, logged_at, created_at FROM food_logs`
 
-func ListFoodLogs(c *gin.Context) {
+func (h *Handler) ListFoodLogs(c *gin.Context) {
 	uid := middleware.UserID(c)
 
 	date := c.Query("date")
@@ -66,7 +66,7 @@ func ListFoodLogs(c *gin.Context) {
 	utils.OK(c, logs)
 }
 
-func GetFoodLog(c *gin.Context) {
+func (h *Handler) GetFoodLog(c *gin.Context) {
 	uid := middleware.UserID(c)
 	lid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -83,7 +83,7 @@ func GetFoodLog(c *gin.Context) {
 	utils.OK(c, f)
 }
 
-func LogFood(c *gin.Context) {
+func (h *Handler) LogFood(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var req models.LogFoodRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -141,7 +141,7 @@ func LogFood(c *gin.Context) {
 	utils.Created(c, f)
 }
 
-func UpdateFoodLog(c *gin.Context) {
+func (h *Handler) UpdateFoodLog(c *gin.Context) {
 	uid := middleware.UserID(c)
 	lid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -203,7 +203,7 @@ func UpdateFoodLog(c *gin.Context) {
 	utils.OK(c, f)
 }
 
-func DeleteFoodLog(c *gin.Context) {
+func (h *Handler) DeleteFoodLog(c *gin.Context) {
 	uid := middleware.UserID(c)
 	lid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -225,7 +225,7 @@ func DeleteFoodLog(c *gin.Context) {
 	utils.OK(c, gin.H{"deleted": true})
 }
 
-func GetDailyStats(c *gin.Context) {
+func (h *Handler) GetDailyStats(c *gin.Context) {
 	uid := middleware.UserID(c)
 	date := c.Query("date")
 	if date == "" {
@@ -258,7 +258,7 @@ func GetDailyStats(c *gin.Context) {
 	utils.OK(c, stats)
 }
 
-func GetFoodHistory(c *gin.Context) {
+func (h *Handler) GetFoodHistory(c *gin.Context) {
 	uid := middleware.UserID(c)
 
 	days := 30
@@ -408,7 +408,7 @@ func doOFFRequest(ctx context.Context, rawURL string) ([]byte, int, error) {
 	return body, resp.StatusCode, err
 }
 
-func SearchFood(c *gin.Context) {
+func (h *Handler) SearchFood(c *gin.Context) {
 	q := c.Query("q")
 	if q == "" {
 		utils.BadRequest(c, "q is required")
@@ -488,7 +488,7 @@ type offBarcodeResponse struct {
 	Product offProduct `json:"product"`
 }
 
-func LookupBarcode(c *gin.Context) {
+func (h *Handler) LookupBarcode(c *gin.Context) {
 	code := c.Param("code")
 	if code == "" {
 		utils.BadRequest(c, "barcode is required")
@@ -552,7 +552,7 @@ func LookupBarcode(c *gin.Context) {
 
 // ─── Saved Foods ──────────────────────────────────────────────────────────────
 
-func ListSavedFoods(c *gin.Context) {
+func (h *Handler) ListSavedFoods(c *gin.Context) {
 	uid := middleware.UserID(c)
 
 	rows, err := db.DB.Query(
@@ -580,7 +580,7 @@ func ListSavedFoods(c *gin.Context) {
 	utils.OK(c, foods)
 }
 
-func CreateSavedFood(c *gin.Context) {
+func (h *Handler) CreateSavedFood(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var req models.SaveFoodRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -634,7 +634,7 @@ func CreateSavedFood(c *gin.Context) {
 	utils.Created(c, f)
 }
 
-func DeleteSavedFood(c *gin.Context) {
+func (h *Handler) DeleteSavedFood(c *gin.Context) {
 	uid := middleware.UserID(c)
 	fid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {

--- a/backend/controllers/food.go
+++ b/backend/controllers/food.go
@@ -343,11 +343,11 @@ func (h *Handler) SearchFood(c *gin.Context) {
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			log.Printf("[food/search] OFF timeout after %dms", elapsed.Milliseconds())
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "food search timed out — try again"})
+			utils.ServiceUnavailable(c, "food search timed out — try again")
 			return
 		}
 		log.Printf("[food/search] OFF network error: %v", err)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "could not reach food database"})
+		utils.ServiceUnavailable(c, "could not reach food database")
 		return
 	}
 
@@ -359,11 +359,11 @@ func (h *Handler) SearchFood(c *gin.Context) {
 		return
 	case status >= 500:
 		log.Printf("[food/search] OFF upstream error: %d", status)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "food search temporarily unavailable"})
+		utils.ServiceUnavailable(c, "food search temporarily unavailable")
 		return
 	case status != 200:
 		log.Printf("[food/search] OFF unexpected status: %d", status)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "food search temporarily unavailable"})
+		utils.ServiceUnavailable(c, "food search temporarily unavailable")
 		return
 	}
 
@@ -421,11 +421,11 @@ func (h *Handler) LookupBarcode(c *gin.Context) {
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			log.Printf("[food/barcode] OFF timeout after %dms", elapsed.Milliseconds())
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "barcode lookup timed out — try again"})
+			utils.ServiceUnavailable(c, "barcode lookup timed out — try again")
 			return
 		}
 		log.Printf("[food/barcode] OFF network error: %v", err)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "could not reach food database"})
+		utils.ServiceUnavailable(c, "could not reach food database")
 		return
 	}
 
@@ -437,7 +437,7 @@ func (h *Handler) LookupBarcode(c *gin.Context) {
 		return
 	case status >= 500:
 		log.Printf("[food/barcode] OFF upstream error: %d", status)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "barcode lookup temporarily unavailable"})
+		utils.ServiceUnavailable(c, "barcode lookup temporarily unavailable")
 		return
 	}
 

--- a/backend/controllers/food_test.go
+++ b/backend/controllers/food_test.go
@@ -82,7 +82,7 @@ func TestListFoodLogs_empty(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food", nil)
-	ListFoodLogs(c)
+	th.ListFoodLogs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -108,7 +108,7 @@ func TestListFoodLogs_scopedByDateAndUser(t *testing.T) {
 
 	date := today.Format("2006-01-02")
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food?date="+date, nil)
-	ListFoodLogs(c)
+	th.ListFoodLogs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -133,7 +133,7 @@ func TestGetFoodLog_success(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	GetFoodLog(c)
+	th.GetFoodLog(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -153,7 +153,7 @@ func TestGetFoodLog_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	GetFoodLog(c)
+	th.GetFoodLog(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user get, got %d", w.Code)
@@ -166,7 +166,7 @@ func TestGetFoodLog_invalidID(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/abc", nil)
 	setParam(c, "id", "abc")
-	GetFoodLog(c)
+	th.GetFoodLog(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid id, got %d", w.Code)
@@ -185,7 +185,7 @@ func TestLogFood_success(t *testing.T) {
 		"fiber": 5.0, "servings": 1.0, "serving_size": "1 cup",
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food", body)
-	LogFood(c)
+	th.LogFood(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -215,7 +215,7 @@ func TestLogFood_defaultsServingsToOne(t *testing.T) {
 		"calories": 95.0, "protein": 0.5, "carbs": 25.0, "fat": 0.3,
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food", body)
-	LogFood(c)
+	th.LogFood(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -233,7 +233,7 @@ func TestLogFood_missingName(t *testing.T) {
 
 	body := map[string]any{"meal": "breakfast", "calories": 300.0}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food", body)
-	LogFood(c)
+	th.LogFood(c)
 
 	if w.Code == http.StatusCreated {
 		t.Fatal("expected error for missing name, got 201")
@@ -249,7 +249,7 @@ func TestLogFood_nameTooLong(t *testing.T) {
 		"calories": 100.0, "protein": 5.0, "carbs": 10.0, "fat": 3.0,
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food", body)
-	LogFood(c)
+	th.LogFood(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for name > 200 chars, got %d", w.Code)
@@ -266,7 +266,7 @@ func TestLogFood_imageURLTooLong(t *testing.T) {
 		"image_url": "https://" + strings.Repeat("a", 494),
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food", body)
-	LogFood(c)
+	th.LogFood(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for image_url > 500 chars, got %d", w.Code)
@@ -283,7 +283,7 @@ func TestLogFood_barcodeTooLong(t *testing.T) {
 		"barcode": strings.Repeat("1", 51),
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food", body)
-	LogFood(c)
+	th.LogFood(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for barcode > 50 chars, got %d", w.Code)
@@ -303,7 +303,7 @@ func TestUpdateFoodLog_success(t *testing.T) {
 	}
 	c, w := newContext(uid, http.MethodPatch, "/api/v1/food/"+fmt.Sprint(id), body)
 	setParam(c, "id", fmt.Sprint(id))
-	UpdateFoodLog(c)
+	th.UpdateFoodLog(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -333,7 +333,7 @@ func TestUpdateFoodLog_ownershipEnforced(t *testing.T) {
 	}
 	c, w := newContext(uid, http.MethodPatch, "/api/v1/food/"+fmt.Sprint(id), body)
 	setParam(c, "id", fmt.Sprint(id))
-	UpdateFoodLog(c)
+	th.UpdateFoodLog(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user update, got %d", w.Code)
@@ -355,7 +355,7 @@ func TestUpdateFoodLog_notFound(t *testing.T) {
 	}
 	c, w := newContext(uid, http.MethodPatch, "/api/v1/food/9999", body)
 	setParam(c, "id", "9999")
-	UpdateFoodLog(c)
+	th.UpdateFoodLog(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for missing entry, got %d", w.Code)
@@ -371,7 +371,7 @@ func TestDeleteFoodLog_success(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/food/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	DeleteFoodLog(c)
+	th.DeleteFoodLog(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -391,7 +391,7 @@ func TestDeleteFoodLog_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/food/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	DeleteFoodLog(c)
+	th.DeleteFoodLog(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user delete, got %d", w.Code)
@@ -411,7 +411,7 @@ func TestGetDailyStats_empty(t *testing.T) {
 
 	date := time.Now().Format("2006-01-02")
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/stats?date="+date, nil)
-	GetDailyStats(c)
+	th.GetDailyStats(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -435,7 +435,7 @@ func TestGetDailyStats_sumsMacrosCorrectly(t *testing.T) {
 
 	date := today.Format("2006-01-02")
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/stats?date="+date, nil)
-	GetDailyStats(c)
+	th.GetDailyStats(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -467,7 +467,7 @@ func TestGetDailyStats_scopedByUser(t *testing.T) {
 
 	date := today.Format("2006-01-02")
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/stats?date="+date, nil)
-	GetDailyStats(c)
+	th.GetDailyStats(c)
 
 	resp := decodeResponse(t, w)
 	data := resp["data"].(map[string]any)
@@ -483,7 +483,7 @@ func TestGetFoodHistory_empty(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/history?days=7", nil)
-	GetFoodHistory(c)
+	th.GetFoodHistory(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -507,7 +507,7 @@ func TestGetFoodHistory_groupsByDay(t *testing.T) {
 	insertFoodLog(t, uid, "Old", "dinner", 500, 30, 60, 12, now.AddDate(0, 0, -10))
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/history?days=7", nil)
-	GetFoodHistory(c)
+	th.GetFoodHistory(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -533,7 +533,7 @@ func TestGetFoodHistory_defaultsDaysTo30(t *testing.T) {
 	insertFoodLog(t, uid, "Included", "lunch", 500, 30, 60, 15, time.Now().AddDate(0, 0, -20))
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/history", nil)
-	GetFoodHistory(c)
+	th.GetFoodHistory(c)
 
 	resp := decodeResponse(t, w)
 	data := resp["data"].([]any)
@@ -658,7 +658,7 @@ func TestLookupBarcode_invalidFormat(t *testing.T) {
 	for _, code := range []string{"abc", "123", "12345678901234567", "../etc"} {
 		c, w := newContext(uid, http.MethodGet, "/api/v1/food/barcode/"+code, nil)
 		setParam(c, "code", code)
-		LookupBarcode(c)
+		th.LookupBarcode(c)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("code %q: expected 400, got %d", code, w.Code)
 		}
@@ -677,7 +677,7 @@ func TestLookupBarcode_success(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/barcode/051500255186", nil)
 	setParam(c, "code", "051500255186")
-	LookupBarcode(c)
+	th.LookupBarcode(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -703,7 +703,7 @@ func TestLookupBarcode_productNotFound(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/barcode/012345678901", nil)
 	setParam(c, "code", "012345678901")
-	LookupBarcode(c)
+	th.LookupBarcode(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for unknown barcode, got %d", w.Code)
@@ -720,7 +720,7 @@ func TestLookupBarcode_rateLimited(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/barcode/012345678901", nil)
 	setParam(c, "code", "012345678901")
-	LookupBarcode(c)
+	th.LookupBarcode(c)
 
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 forwarded, got %d", w.Code)
@@ -734,7 +734,7 @@ func TestSearchFood_missingQuery(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/search", nil)
-	SearchFood(c)
+	th.SearchFood(c)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing q, got %d", w.Code)
@@ -752,7 +752,7 @@ func TestSearchFood_success(t *testing.T) {
 	})
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/search?q=milk", nil)
-	SearchFood(c)
+	th.SearchFood(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -778,7 +778,7 @@ func TestSearchFood_rateLimited(t *testing.T) {
 	})
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/search?q=pizza", nil)
-	SearchFood(c)
+	th.SearchFood(c)
 
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 forwarded, got %d", w.Code)
@@ -794,7 +794,7 @@ func TestSearchFood_upstreamError(t *testing.T) {
 	})
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/search?q=pizza", nil)
-	SearchFood(c)
+	th.SearchFood(c)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 for OFF 5xx, got %d", w.Code)
@@ -808,7 +808,7 @@ func TestListSavedFoods_empty(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/saved", nil)
-	ListSavedFoods(c)
+	th.ListSavedFoods(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -831,7 +831,7 @@ func TestListSavedFoods_alphabeticalAndScopedByUser(t *testing.T) {
 	insertSavedFood(t, other, "Should not appear")
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/food/saved", nil)
-	ListSavedFoods(c)
+	th.ListSavedFoods(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -863,7 +863,7 @@ func TestCreateSavedFood_success(t *testing.T) {
 		"fiber": 0.0, "serving_size": "1 container (170g)",
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food/saved", body)
-	CreateSavedFood(c)
+	th.CreateSavedFood(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -884,7 +884,7 @@ func TestCreateSavedFood_missingName(t *testing.T) {
 
 	body := map[string]any{"calories": 100.0, "protein": 5.0, "carbs": 10.0, "fat": 3.0}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/food/saved", body)
-	CreateSavedFood(c)
+	th.CreateSavedFood(c)
 
 	if w.Code == http.StatusCreated {
 		t.Fatal("expected error for missing name, got 201")
@@ -900,7 +900,7 @@ func TestDeleteSavedFood_success(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/food/saved/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	DeleteSavedFood(c)
+	th.DeleteSavedFood(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -920,7 +920,7 @@ func TestDeleteSavedFood_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/food/saved/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	DeleteSavedFood(c)
+	th.DeleteSavedFood(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user delete, got %d", w.Code)

--- a/backend/controllers/handler.go
+++ b/backend/controllers/handler.go
@@ -1,0 +1,11 @@
+package controllers
+
+import "github.com/Cawlumm/lyftr-backend/stores"
+
+// Handler carries the injected stores. Every HTTP handler is a method on Handler
+// so it reaches the database only through h.s.<Entity>, never the global db.DB.
+type Handler struct {
+	s *stores.Stores
+}
+
+func NewHandler(s *stores.Stores) *Handler { return &Handler{s: s} }

--- a/backend/controllers/programs.go
+++ b/backend/controllers/programs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ListPrograms(c *gin.Context) {
+func (h *Handler) ListPrograms(c *gin.Context) {
 	uid := middleware.UserID(c)
 
 	limit := 20
@@ -54,7 +54,7 @@ func ListPrograms(c *gin.Context) {
 	utils.OK(c, programs)
 }
 
-func GetProgram(c *gin.Context) {
+func (h *Handler) GetProgram(c *gin.Context) {
 	uid := middleware.UserID(c)
 	pid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -79,7 +79,7 @@ func GetProgram(c *gin.Context) {
 	utils.OK(c, p)
 }
 
-func CreateProgram(c *gin.Context) {
+func (h *Handler) CreateProgram(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var req models.CreateProgramRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -155,7 +155,7 @@ func CreateProgram(c *gin.Context) {
 	utils.Created(c, p)
 }
 
-func UpdateProgram(c *gin.Context) {
+func (h *Handler) UpdateProgram(c *gin.Context) {
 	uid := middleware.UserID(c)
 	pid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -248,7 +248,7 @@ func UpdateProgram(c *gin.Context) {
 	utils.OK(c, p)
 }
 
-func DeleteProgram(c *gin.Context) {
+func (h *Handler) DeleteProgram(c *gin.Context) {
 	uid := middleware.UserID(c)
 	pid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {

--- a/backend/controllers/programs.go
+++ b/backend/controllers/programs.go
@@ -57,6 +57,10 @@ func (h *Handler) CreateProgram(c *gin.Context) {
 		return
 	}
 	p, err := h.s.Program.Create(uid, req)
+	if utils.IsForeignKeyViolation(err) {
+		utils.BadRequest(c, "one or more exercises do not exist")
+		return
+	}
 	if utils.DBError(c, err) {
 		return
 	}
@@ -82,6 +86,10 @@ func (h *Handler) UpdateProgram(c *gin.Context) {
 	p, err := h.s.Program.Update(uid, pid, req)
 	if err == sql.ErrNoRows {
 		utils.NotFound(c, "program not found")
+		return
+	}
+	if utils.IsForeignKeyViolation(err) {
+		utils.BadRequest(c, "one or more exercises do not exist")
 		return
 	}
 	if utils.DBError(c, err) {

--- a/backend/controllers/programs.go
+++ b/backend/controllers/programs.go
@@ -3,53 +3,26 @@ package controllers
 import (
 	"database/sql"
 	"strconv"
-	"strings"
 
-	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/middleware"
 	"github.com/Cawlumm/lyftr-backend/models"
+	"github.com/Cawlumm/lyftr-backend/stores"
 	"github.com/Cawlumm/lyftr-backend/utils"
 	"github.com/gin-gonic/gin"
 )
 
 func (h *Handler) ListPrograms(c *gin.Context) {
 	uid := middleware.UserID(c)
-
-	limit := 20
-	offset := 0
+	f := stores.ProgramFilter{Limit: 20, Query: c.Query("q")}
 	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 100 {
-		limit = l
+		f.Limit = l
 	}
 	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o >= 0 {
-		offset = o
+		f.Offset = o
 	}
-	q := c.Query("q")
-
-	var rows *sql.Rows
-	var err error
-	if q != "" {
-		rows, err = db.DB.Query(
-			`SELECT id, user_id, name, notes, created_at FROM programs WHERE user_id = ? AND LOWER(name) LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
-			uid, "%"+strings.ToLower(q)+"%", limit, offset,
-		)
-	} else {
-		rows, err = db.DB.Query(
-			`SELECT id, user_id, name, notes, created_at FROM programs WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
-			uid, limit, offset,
-		)
-	}
-	if err != nil {
-		utils.InternalError(c)
+	programs, err := h.s.Program.List(uid, f)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	programs := []models.Program{}
-	for rows.Next() {
-		var p models.Program
-		rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt)
-		p.Exercises = loadProgramExercises(p.ID)
-		programs = append(programs, p)
 	}
 	utils.OK(c, programs)
 }
@@ -61,21 +34,14 @@ func (h *Handler) GetProgram(c *gin.Context) {
 		utils.BadRequest(c, "invalid program id")
 		return
 	}
-
-	var p models.Program
-	err = db.DB.QueryRow(
-		`SELECT id, user_id, name, notes, created_at FROM programs WHERE id = ? AND user_id = ?`, pid, uid,
-	).Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt)
+	p, err := h.s.Program.Get(uid, pid)
 	if err == sql.ErrNoRows {
 		utils.NotFound(c, "program not found")
 		return
 	}
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
 		return
 	}
-
-	p.Exercises = loadProgramExercises(pid)
 	utils.OK(c, p)
 }
 
@@ -90,68 +56,10 @@ func (h *Handler) CreateProgram(c *gin.Context) {
 		utils.ValidationError(c, err)
 		return
 	}
-
-	tx, err := db.DB.Begin()
-	if err != nil {
-		utils.InternalError(c)
+	p, err := h.s.Program.Create(uid, req)
+	if utils.DBError(c, err) {
 		return
 	}
-	defer tx.Rollback()
-
-	res, err := tx.Exec(
-		`INSERT INTO programs (user_id, name, notes) VALUES (?, ?, ?)`,
-		uid, req.Name, req.Notes,
-	)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-	pid, err := res.LastInsertId()
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	for i, ex := range req.Exercises {
-		exRes, err := tx.Exec(
-			`INSERT INTO program_exercises (program_id, exercise_id, order_index, notes) VALUES (?, ?, ?, ?)`,
-			pid, ex.ExerciseID, i, ex.Notes,
-		)
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		peid, err := exRes.LastInsertId()
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		for j, s := range ex.Sets {
-			sn := s.SetNumber
-			if sn == 0 {
-				sn = j + 1
-			}
-			_, err := tx.Exec(
-				`INSERT INTO program_sets (program_exercise_id, set_number, target_reps, target_weight) VALUES (?, ?, ?, ?)`,
-				peid, sn, s.TargetReps, s.TargetWeight,
-			)
-			if err != nil {
-				utils.InternalError(c)
-				return
-			}
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	var p models.Program
-	db.DB.QueryRow(
-		`SELECT id, user_id, name, notes, created_at FROM programs WHERE id = ?`, pid,
-	).Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt)
-	p.Exercises = loadProgramExercises(pid)
 	utils.Created(c, p)
 }
 
@@ -162,7 +70,6 @@ func (h *Handler) UpdateProgram(c *gin.Context) {
 		utils.BadRequest(c, "invalid program id")
 		return
 	}
-
 	var req models.CreateProgramRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, err.Error())
@@ -172,79 +79,14 @@ func (h *Handler) UpdateProgram(c *gin.Context) {
 		utils.ValidationError(c, err)
 		return
 	}
-
-	var existing models.Program
-	err = db.DB.QueryRow(
-		`SELECT id FROM programs WHERE id = ? AND user_id = ?`, pid, uid,
-	).Scan(&existing.ID)
+	p, err := h.s.Program.Update(uid, pid, req)
 	if err == sql.ErrNoRows {
 		utils.NotFound(c, "program not found")
 		return
 	}
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
 		return
 	}
-
-	tx, err := db.DB.Begin()
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-	defer tx.Rollback()
-
-	_, err = tx.Exec(`UPDATE programs SET name = ?, notes = ? WHERE id = ?`, req.Name, req.Notes, pid)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	_, err = tx.Exec(`DELETE FROM program_exercises WHERE program_id = ?`, pid)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	for i, ex := range req.Exercises {
-		exRes, err := tx.Exec(
-			`INSERT INTO program_exercises (program_id, exercise_id, order_index, notes) VALUES (?, ?, ?, ?)`,
-			pid, ex.ExerciseID, i, ex.Notes,
-		)
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		peid, err := exRes.LastInsertId()
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		for j, s := range ex.Sets {
-			sn := s.SetNumber
-			if sn == 0 {
-				sn = j + 1
-			}
-			_, err := tx.Exec(
-				`INSERT INTO program_sets (program_exercise_id, set_number, target_reps, target_weight) VALUES (?, ?, ?, ?)`,
-				peid, sn, s.TargetReps, s.TargetWeight,
-			)
-			if err != nil {
-				utils.InternalError(c)
-				return
-			}
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	var p models.Program
-	db.DB.QueryRow(
-		`SELECT id, user_id, name, notes, created_at FROM programs WHERE id = ?`, pid,
-	).Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt)
-	p.Exercises = loadProgramExercises(pid)
 	utils.OK(c, p)
 }
 
@@ -255,65 +97,13 @@ func (h *Handler) DeleteProgram(c *gin.Context) {
 		utils.BadRequest(c, "invalid program id")
 		return
 	}
-
-	res, err := db.DB.Exec(`DELETE FROM programs WHERE id = ? AND user_id = ?`, pid, uid)
-	if err != nil {
-		utils.InternalError(c)
+	n, err := h.s.Program.Delete(uid, pid)
+	if utils.DBError(c, err) {
 		return
 	}
-	n, _ := res.RowsAffected()
 	if n == 0 {
 		utils.NotFound(c, "program not found")
 		return
 	}
 	utils.OK(c, gin.H{"deleted": true})
-}
-
-func loadProgramExercises(programID int64) []models.ProgramExercise {
-	rows, err := db.DB.Query(
-		`SELECT pe.id, pe.program_id, pe.exercise_id, pe.order_index, pe.notes,
-		        e.name, e.muscle_group, e.category, e.equipment, e.image_url
-		 FROM program_exercises pe
-		 JOIN exercises e ON e.id = pe.exercise_id
-		 WHERE pe.program_id = ? ORDER BY pe.order_index`,
-		programID,
-	)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-
-	var exercises []models.ProgramExercise
-	for rows.Next() {
-		var pe models.ProgramExercise
-		rows.Scan(
-			&pe.ID, &pe.ProgramID, &pe.ExerciseID, &pe.OrderIndex, &pe.Notes,
-			&pe.Exercise.Name, &pe.Exercise.MuscleGroup, &pe.Exercise.Category,
-			&pe.Exercise.Equipment, &pe.Exercise.ImageURL,
-		)
-		pe.Exercise.ID = pe.ExerciseID
-		pe.Sets = loadProgramSets(pe.ID)
-		exercises = append(exercises, pe)
-	}
-	return exercises
-}
-
-func loadProgramSets(programExerciseID int64) []models.ProgramSet {
-	rows, err := db.DB.Query(
-		`SELECT id, program_exercise_id, set_number, target_reps, target_weight
-		 FROM program_sets WHERE program_exercise_id = ? ORDER BY set_number`,
-		programExerciseID,
-	)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-
-	var sets []models.ProgramSet
-	for rows.Next() {
-		var s models.ProgramSet
-		rows.Scan(&s.ID, &s.ProgramExerciseID, &s.SetNumber, &s.TargetReps, &s.TargetWeight)
-		sets = append(sets, s)
-	}
-	return sets
 }

--- a/backend/controllers/programs_test.go
+++ b/backend/controllers/programs_test.go
@@ -13,7 +13,7 @@ func TestListPrograms_empty(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/programs", nil)
-	ListPrograms(c)
+	th.ListPrograms(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -50,7 +50,7 @@ func TestCreateProgram_success(t *testing.T) {
 	}
 
 	c, w := newContext(uid, http.MethodPost, "/api/v1/programs", body)
-	CreateProgram(c)
+	th.CreateProgram(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -86,7 +86,7 @@ func TestCreateProgram_missingName(t *testing.T) {
 		"exercises": []map[string]any{},
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/programs", body)
-	CreateProgram(c)
+	th.CreateProgram(c)
 
 	if w.Code == http.StatusCreated {
 		t.Fatal("expected error for empty name, got 201")
@@ -104,7 +104,7 @@ func TestGetProgram_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/programs/"+fmt.Sprint(pid), nil)
 	setParam(c, "id", fmt.Sprint(pid))
-	GetProgram(c)
+	th.GetProgram(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user access, got %d", w.Code)
@@ -122,7 +122,7 @@ func TestDeleteProgram_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/programs/"+fmt.Sprint(pid), nil)
 	setParam(c, "id", fmt.Sprint(pid))
-	DeleteProgram(c)
+	th.DeleteProgram(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user delete, got %d", w.Code)
@@ -166,7 +166,7 @@ func TestUpdateProgram_replacesExercises(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodPut, "/api/v1/programs/"+fmt.Sprint(pid), body)
 	setParam(c, "id", fmt.Sprint(pid))
-	UpdateProgram(c)
+	th.UpdateProgram(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -203,7 +203,7 @@ func TestCreateProgram_setNumberNormalized(t *testing.T) {
 	}
 
 	c, w := newContext(uid, http.MethodPost, "/api/v1/programs", body)
-	CreateProgram(c)
+	th.CreateProgram(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -231,7 +231,7 @@ func TestListPrograms_filtersBySearchQuery(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/programs?q=push", nil)
 	c.Request.URL.RawQuery = "q=push" // case-insensitive LIKE on name, scoped by user
-	ListPrograms(c)
+	th.ListPrograms(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())

--- a/backend/controllers/review_fixes_test.go
+++ b/backend/controllers/review_fixes_test.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestGetMe_deletedAccountReturns401 covers the review fix: GetMe used to fall
+// through utils.DBError (which ignores sql.ErrNoRows) and return 200 with an
+// empty user for a deleted-but-still-authenticated account. It must now 401.
+func TestGetMe_deletedAccountReturns401(t *testing.T) {
+	setupTestDB(t)
+	// No user row with this id exists — account deleted, JWT still valid.
+	c, w := newContext(99999, http.MethodGet, "/api/v1/me", nil)
+	th.GetMe(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing user, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateWorkout_unknownExerciseReturns400 covers the review fix: with foreign
+// keys now enforced, a workout referencing a non-existent exercise must surface as
+// a clean 400, not a 500 (FK violation) or a silent dangling insert.
+func TestCreateWorkout_unknownExerciseReturns400(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+	body := map[string]any{
+		"name": "Test Workout",
+		"exercises": []map[string]any{
+			{"exercise_id": 99999, "sets": []map[string]any{{"reps": 5, "weight": 100}}},
+		},
+	}
+	c, w := newContext(uid, http.MethodPost, "/api/v1/workouts", body)
+	th.CreateWorkout(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown exercise_id, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/backend/controllers/server.go
+++ b/backend/controllers/server.go
@@ -11,7 +11,7 @@ import (
 // "test connection" behind the in-app server selector. It runs under the same
 // CORS policy as the rest of the API, so a successful probe honestly predicts
 // that authenticated requests from the same origin will be allowed too.
-func ServerInfo(c *gin.Context) {
+func (h *Handler) ServerInfo(c *gin.Context) {
 	utils.OK(c, gin.H{
 		"name":    "lyftr",
 		"version": config.C.Version,

--- a/backend/controllers/server_test.go
+++ b/backend/controllers/server_test.go
@@ -11,7 +11,7 @@ func TestServerInfo(t *testing.T) {
 	config.C = &config.Config{Version: "9.9.9"}
 
 	c, w := newContext(0, "GET", "/api/v1/info", nil)
-	ServerInfo(c)
+	th.ServerInfo(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)

--- a/backend/controllers/sqlite_lock_test.go
+++ b/backend/controllers/sqlite_lock_test.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"database/sql"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/Cawlumm/lyftr-backend/db"
+	"github.com/Cawlumm/lyftr-backend/stores"
+	"github.com/Cawlumm/lyftr-backend/utils"
+	_ "modernc.org/sqlite"
+)
+
+// setupFileDB points db.DB at a fresh on-disk database with busy_timeout(0), so a
+// contended write lock surfaces as SQLITE_BUSY immediately instead of waiting. It
+// also rebuilds the DI handler (th) bound to this DB.
+func setupFileDB(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "lock.db")
+	var err error
+	db.DB, err = sql.Open("sqlite", path+"?_pragma=busy_timeout(0)")
+	if err != nil {
+		t.Fatalf("open file db: %v", err)
+	}
+	db.DB.SetMaxOpenConns(1)
+	if err = db.DB.Ping(); err != nil {
+		t.Fatalf("ping file db: %v", err)
+	}
+	if err = applySchema(); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+	th = NewHandler(stores.New(db.DB))
+	t.Cleanup(func() { db.DB.Close() })
+	return path
+}
+
+// TestRegister_lockedDBReturns503 reproduces issue #25: when the database is
+// locked, Register must return a retryable 503 — not a misleading "email already
+// registered" (which is what a blanket "any Exec error == duplicate" produced).
+func TestRegister_lockedDBReturns503(t *testing.T) {
+	path := setupFileDB(t)
+
+	// Hold a write lock on a separate connection so Register's INSERT can't proceed.
+	locker, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(0)")
+	if err != nil {
+		t.Fatalf("open locker: %v", err)
+	}
+	defer locker.Close()
+	tx, err := locker.Begin()
+	if err != nil {
+		t.Fatalf("begin lock tx: %v", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO users (email, password_hash) VALUES ('lock@example.com', 'h')`); err != nil {
+		t.Fatalf("acquire write lock: %v", err)
+	}
+	defer tx.Rollback()
+
+	c, w := newContext(0, http.MethodPost, "/api/v1/auth/register",
+		map[string]string{"email": "new@example.com", "password": "password123"})
+	th.Register(c)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("locked DB: expected 503, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestRegister_duplicateEmailReturns409 confirms a genuine duplicate is still a
+// conflict, and is now distinguishable from the lock case above.
+func TestRegister_duplicateEmailReturns409(t *testing.T) {
+	setupTestDB(t)
+	createTestUser(t) // inserts test@example.com
+
+	c, w := newContext(0, http.MethodPost, "/api/v1/auth/register",
+		map[string]string{"email": "test@example.com", "password": "password123"})
+	th.Register(c)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate email: expected 409, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestDBErrorClassifiers checks the shared classifier against real modernc errors.
+func TestDBErrorClassifiers(t *testing.T) {
+	setupTestDB(t)
+	createTestUser(t)
+
+	_, err := db.DB.Exec(`INSERT INTO users (email, password_hash) VALUES ('test@example.com', 'h')`)
+	if err == nil {
+		t.Fatal("expected a UNIQUE violation")
+	}
+	if !utils.IsUniqueViolation(err) {
+		t.Errorf("IsUniqueViolation(%v) = false, want true", err)
+	}
+	if utils.IsLocked(err) {
+		t.Errorf("IsLocked(%v) = true, want false", err)
+	}
+}

--- a/backend/controllers/testhelper_test.go
+++ b/backend/controllers/testhelper_test.go
@@ -11,9 +11,14 @@ import (
 	"testing"
 
 	"github.com/Cawlumm/lyftr-backend/db"
+	"github.com/Cawlumm/lyftr-backend/stores"
 	"github.com/gin-gonic/gin"
 	_ "modernc.org/sqlite"
 )
+
+// th is the DI handler under test, rebuilt per test in setupTestDB so it binds
+// the fresh per-test db.DB.
+var th *Handler
 
 func setupTestDB(t *testing.T) {
 	t.Helper()
@@ -29,6 +34,7 @@ func setupTestDB(t *testing.T) {
 	if err = applySchema(); err != nil {
 		t.Fatalf("apply schema: %v", err)
 	}
+	th = NewHandler(stores.New(db.DB))
 	t.Cleanup(func() { db.DB.Close() })
 }
 
@@ -40,6 +46,14 @@ CREATE TABLE IF NOT EXISTS users (
   password_hash TEXT NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS user_settings (
+  user_id        INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  weight_unit    TEXT    NOT NULL DEFAULT 'lbs',
+  calorie_target INTEGER NOT NULL DEFAULT 2000,
+  protein_target INTEGER NOT NULL DEFAULT 150,
+  carb_target    INTEGER NOT NULL DEFAULT 250,
+  fat_target     INTEGER NOT NULL DEFAULT 65
 );
 CREATE TABLE IF NOT EXISTS exercises (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/controllers/testhelper_test.go
+++ b/backend/controllers/testhelper_test.go
@@ -23,7 +23,9 @@ var th *Handler
 func setupTestDB(t *testing.T) {
 	t.Helper()
 	var err error
-	dbName := fmt.Sprintf("file:testdb_%d?mode=memory&cache=shared&_foreign_keys=on", rand.Int63())
+	// modernc ignores the mattn-style _foreign_keys=on; use the _pragma form so the
+	// harness actually enforces foreign keys, matching the production DSN.
+	dbName := fmt.Sprintf("file:testdb_%d?mode=memory&cache=shared&_pragma=foreign_keys(on)", rand.Int63())
 	db.DB, err = sql.Open("sqlite", dbName)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/backend/controllers/user.go
+++ b/backend/controllers/user.go
@@ -1,7 +1,8 @@
 package controllers
 
 import (
-	"github.com/Cawlumm/lyftr-backend/db"
+	"database/sql"
+
 	"github.com/Cawlumm/lyftr-backend/middleware"
 	"github.com/Cawlumm/lyftr-backend/models"
 	"github.com/Cawlumm/lyftr-backend/utils"
@@ -10,12 +11,8 @@ import (
 
 func (h *Handler) GetMe(c *gin.Context) {
 	uid := middleware.UserID(c)
-	var u models.User
-	err := db.DB.QueryRow(
-		`SELECT id, email, created_at, updated_at FROM users WHERE id = ?`, uid,
-	).Scan(&u.ID, &u.Email, &u.CreatedAt, &u.UpdatedAt)
-	if err != nil {
-		utils.InternalError(c)
+	u, err := h.s.User.GetMe(uid)
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.OK(c, u)
@@ -23,17 +20,16 @@ func (h *Handler) GetMe(c *gin.Context) {
 
 func (h *Handler) GetSettings(c *gin.Context) {
 	uid := middleware.UserID(c)
-	var s models.UserSettings
-	err := db.DB.QueryRow(
-		`SELECT user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target
-		 FROM user_settings WHERE user_id = ?`, uid,
-	).Scan(&s.UserID, &s.WeightUnit, &s.CalorieTarget, &s.ProteinTarget, &s.CarbTarget, &s.FatTarget)
-	if err != nil {
-		// Return defaults if not found
+	s, err := h.s.User.GetSettings(uid)
+	if err == sql.ErrNoRows {
+		// No row yet — return the defaults.
 		utils.OK(c, models.UserSettings{
 			UserID: uid, WeightUnit: "lbs",
 			CalorieTarget: 2000, ProteinTarget: 150, CarbTarget: 250, FatTarget: 65,
 		})
+		return
+	}
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.OK(c, s)
@@ -46,27 +42,16 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		utils.BadRequest(c, err.Error())
 		return
 	}
-
-	db.DB.Exec(
-		`INSERT INTO user_settings (user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target)
-		 VALUES (?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(user_id) DO UPDATE SET
-		   weight_unit    = excluded.weight_unit,
-		   calorie_target = excluded.calorie_target,
-		   protein_target = excluded.protein_target,
-		   carb_target    = excluded.carb_target,
-		   fat_target     = excluded.fat_target`,
-		uid, req.WeightUnit, req.CalorieTarget, req.ProteinTarget, req.CarbTarget, req.FatTarget,
-	)
-
-	h.GetSettings(c)
+	s, err := h.s.User.UpsertSettings(uid, req)
+	if utils.DBError(c, err) {
+		return
+	}
+	utils.OK(c, s)
 }
 
 func (h *Handler) DeleteAccount(c *gin.Context) {
 	uid := middleware.UserID(c)
-	_, err := db.DB.Exec(`DELETE FROM users WHERE id = ?`, uid)
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, h.s.User.Delete(uid)) {
 		return
 	}
 	utils.OK(c, gin.H{"deleted": true})

--- a/backend/controllers/user.go
+++ b/backend/controllers/user.go
@@ -12,6 +12,10 @@ import (
 func (h *Handler) GetMe(c *gin.Context) {
 	uid := middleware.UserID(c)
 	u, err := h.s.User.GetMe(uid)
+	if err == sql.ErrNoRows {
+		utils.Unauthorized(c, "account no longer exists")
+		return
+	}
 	if utils.DBError(c, err) {
 		return
 	}

--- a/backend/controllers/user.go
+++ b/backend/controllers/user.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetMe(c *gin.Context) {
+func (h *Handler) GetMe(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var u models.User
 	err := db.DB.QueryRow(
@@ -21,7 +21,7 @@ func GetMe(c *gin.Context) {
 	utils.OK(c, u)
 }
 
-func GetSettings(c *gin.Context) {
+func (h *Handler) GetSettings(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var s models.UserSettings
 	err := db.DB.QueryRow(
@@ -39,7 +39,7 @@ func GetSettings(c *gin.Context) {
 	utils.OK(c, s)
 }
 
-func UpdateSettings(c *gin.Context) {
+func (h *Handler) UpdateSettings(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var req models.UpdateSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -59,10 +59,10 @@ func UpdateSettings(c *gin.Context) {
 		uid, req.WeightUnit, req.CalorieTarget, req.ProteinTarget, req.CarbTarget, req.FatTarget,
 	)
 
-	GetSettings(c)
+	h.GetSettings(c)
 }
 
-func DeleteAccount(c *gin.Context) {
+func (h *Handler) DeleteAccount(c *gin.Context) {
 	uid := middleware.UserID(c)
 	_, err := db.DB.Exec(`DELETE FROM users WHERE id = ?`, uid)
 	if err != nil {

--- a/backend/controllers/weight.go
+++ b/backend/controllers/weight.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ListWeightLogs(c *gin.Context) {
+func (h *Handler) ListWeightLogs(c *gin.Context) {
 	uid := middleware.UserID(c)
 	limit := 90
 	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 1000 {
@@ -71,7 +71,7 @@ func ListWeightLogs(c *gin.Context) {
 	utils.OK(c, logs)
 }
 
-func LogWeight(c *gin.Context) {
+func (h *Handler) LogWeight(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var req models.LogWeightRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -135,7 +135,7 @@ func LogWeight(c *gin.Context) {
 	utils.Created(c, log)
 }
 
-func GetWeightLog(c *gin.Context) {
+func (h *Handler) GetWeightLog(c *gin.Context) {
 	uid := middleware.UserID(c)
 	lid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -154,7 +154,7 @@ func GetWeightLog(c *gin.Context) {
 	utils.OK(c, log)
 }
 
-func UpdateWeightLog(c *gin.Context) {
+func (h *Handler) UpdateWeightLog(c *gin.Context) {
 	uid := middleware.UserID(c)
 	lid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -218,7 +218,7 @@ func UpdateWeightLog(c *gin.Context) {
 	utils.OK(c, log)
 }
 
-func DeleteWeightLog(c *gin.Context) {
+func (h *Handler) DeleteWeightLog(c *gin.Context) {
 	uid := middleware.UserID(c)
 	lid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -239,7 +239,7 @@ func DeleteWeightLog(c *gin.Context) {
 	utils.OK(c, gin.H{"deleted": true})
 }
 
-func GetWeightStats(c *gin.Context) {
+func (h *Handler) GetWeightStats(c *gin.Context) {
 	uid := middleware.UserID(c)
 
 	var (

--- a/backend/controllers/weight.go
+++ b/backend/controllers/weight.go
@@ -5,68 +5,48 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/middleware"
 	"github.com/Cawlumm/lyftr-backend/models"
+	"github.com/Cawlumm/lyftr-backend/stores"
 	"github.com/Cawlumm/lyftr-backend/utils"
 	"github.com/gin-gonic/gin"
 )
 
 func (h *Handler) ListWeightLogs(c *gin.Context) {
 	uid := middleware.UserID(c)
-	limit := 90
+	f := stores.WeightFilter{Limit: 90}
 	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 1000 {
-		limit = l
+		f.Limit = l
 	}
-	offset := 0
 	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o >= 0 {
-		offset = o
+		f.Offset = o
 	}
-
-	q := `SELECT id, user_id, weight, notes, logged_at, created_at
-	      FROM weight_logs WHERE user_id = ?`
-	args := []any{uid}
 
 	// Date params are calendar days in the user's local timezone. We don't know
-	// the client's UTC offset, so for bare YYYY-MM-DD we widen the window by
-	// ±12h to cover any plausible client TZ. Callers that want exact bounds can
-	// pass a full RFC3339 timestamp instead.
+	// the client's UTC offset, so for bare YYYY-MM-DD we widen the window by ±12h
+	// to cover any plausible client TZ. A full RFC3339 timestamp is used exactly.
 	if from := c.Query("from"); from != "" {
 		if t, exact, ok := parseDayOrTime(from); ok {
 			lo := t
 			if !exact {
 				lo = t.Add(-12 * time.Hour)
 			}
-			q += ` AND logged_at >= ?`
-			args = append(args, lo)
+			f.From = &lo
 		}
 	}
 	if to := c.Query("to"); to != "" {
 		if t, exact, ok := parseDayOrTime(to); ok {
 			hi := t
 			if !exact {
-				// 24h of the day itself + 12h padding for west-of-UTC clocks.
 				hi = t.Add(36 * time.Hour)
 			}
-			q += ` AND logged_at < ?`
-			args = append(args, hi)
+			f.To = &hi
 		}
 	}
-	q += ` ORDER BY logged_at DESC, id DESC LIMIT ? OFFSET ?`
-	args = append(args, limit, offset)
 
-	rows, err := db.DB.Query(q, args...)
-	if err != nil {
-		utils.InternalError(c)
+	logs, err := h.s.Weight.List(uid, f)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	logs := []models.WeightLog{}
-	for rows.Next() {
-		var w models.WeightLog
-		rows.Scan(&w.ID, &w.UserID, &w.Weight, &w.Notes, &w.LoggedAt, &w.CreatedAt)
-		logs = append(logs, w)
 	}
 	utils.OK(c, logs)
 }
@@ -82,54 +62,10 @@ func (h *Handler) LogWeight(c *gin.Context) {
 		utils.ValidationError(c, err)
 		return
 	}
+	req.LoggedAt = normalizeLoggedAt(req.LoggedAt)
 
-	if req.LoggedAt.IsZero() {
-		req.LoggedAt = time.Now()
-	}
-	// Always store in UTC: keeps the wire format consistent across deployments
-	// and lets a client-supplied offset timestamp round-trip cleanly (a non-UTC
-	// time.Time otherwise fails to scan back, 500ing the request).
-	req.LoggedAt = req.LoggedAt.UTC()
-
-	// One weight entry per calendar day: if the user already logged this day,
-	// update that entry in place instead of creating a duplicate. Match on a
-	// [dayStart, nextDay) range rather than SQLite date(), because timestamps are
-	// stored in Go's time.String() format ("... +0000 UTC") which date() can't parse.
-	dayStart := time.Date(req.LoggedAt.Year(), req.LoggedAt.Month(), req.LoggedAt.Day(), 0, 0, 0, 0, req.LoggedAt.Location())
-	dayEnd := dayStart.AddDate(0, 0, 1)
-	var id int64
-	err := db.DB.QueryRow(
-		`SELECT id FROM weight_logs WHERE user_id = ? AND logged_at >= ? AND logged_at < ? ORDER BY id DESC LIMIT 1`,
-		uid, dayStart, dayEnd,
-	).Scan(&id)
-	switch err {
-	case nil:
-		if _, uerr := db.DB.Exec(
-			`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ?`,
-			req.Weight, req.Notes, req.LoggedAt, id,
-		); uerr != nil {
-			utils.InternalError(c)
-			return
-		}
-	case sql.ErrNoRows:
-		res, ierr := db.DB.Exec(
-			`INSERT INTO weight_logs (user_id, weight, notes, logged_at) VALUES (?, ?, ?, ?)`,
-			uid, req.Weight, req.Notes, req.LoggedAt,
-		)
-		if ierr != nil {
-			utils.InternalError(c)
-			return
-		}
-		id, _ = res.LastInsertId()
-	default:
-		utils.InternalError(c)
-		return
-	}
-	var log models.WeightLog
-	if err := db.DB.QueryRow(
-		`SELECT id, user_id, weight, notes, logged_at, created_at FROM weight_logs WHERE id = ?`, id,
-	).Scan(&log.ID, &log.UserID, &log.Weight, &log.Notes, &log.LoggedAt, &log.CreatedAt); err != nil {
-		utils.InternalError(c)
+	log, err := h.s.Weight.UpsertForDay(uid, req)
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.Created(c, log)
@@ -142,13 +78,12 @@ func (h *Handler) GetWeightLog(c *gin.Context) {
 		utils.BadRequest(c, "invalid id")
 		return
 	}
-
-	var log models.WeightLog
-	if err := db.DB.QueryRow(
-		`SELECT id, user_id, weight, notes, logged_at, created_at FROM weight_logs WHERE id = ? AND user_id = ?`,
-		lid, uid,
-	).Scan(&log.ID, &log.UserID, &log.Weight, &log.Notes, &log.LoggedAt, &log.CreatedAt); err != nil {
+	log, err := h.s.Weight.Get(uid, lid)
+	if err == sql.ErrNoRows {
 		utils.NotFound(c, "log entry not found")
+		return
+	}
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.OK(c, log)
@@ -161,7 +96,6 @@ func (h *Handler) UpdateWeightLog(c *gin.Context) {
 		utils.BadRequest(c, "invalid id")
 		return
 	}
-
 	var req models.LogWeightRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, err.Error())
@@ -171,48 +105,14 @@ func (h *Handler) UpdateWeightLog(c *gin.Context) {
 		utils.ValidationError(c, err)
 		return
 	}
+	req.LoggedAt = normalizeLoggedAt(req.LoggedAt)
 
-	if req.LoggedAt.IsZero() {
-		req.LoggedAt = time.Now()
-	}
-	// Always store in UTC: keeps the wire format consistent across deployments
-	// and lets a client-supplied offset timestamp round-trip cleanly (a non-UTC
-	// time.Time otherwise fails to scan back, 500ing the request).
-	req.LoggedAt = req.LoggedAt.UTC()
-
-	res, err := db.DB.Exec(
-		`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ? AND user_id = ?`,
-		req.Weight, req.Notes, req.LoggedAt, lid, uid,
-	)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
+	log, err := h.s.Weight.Update(uid, lid, req)
+	if err == sql.ErrNoRows {
 		utils.NotFound(c, "log entry not found")
 		return
 	}
-
-	// One weight per day: if this edit moved the entry onto a day that already
-	// had another entry, drop the other(s) so the day keeps a single entry —
-	// consistent with LogWeight's upsert. Done after the update succeeds so a
-	// not-found/unauthorized edit never deletes anything.
-	dayStart := time.Date(req.LoggedAt.Year(), req.LoggedAt.Month(), req.LoggedAt.Day(), 0, 0, 0, 0, req.LoggedAt.Location())
-	dayEnd := dayStart.AddDate(0, 0, 1)
-	if _, err := db.DB.Exec(
-		`DELETE FROM weight_logs WHERE user_id = ? AND id != ? AND logged_at >= ? AND logged_at < ?`,
-		uid, lid, dayStart, dayEnd,
-	); err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	var log models.WeightLog
-	if err := db.DB.QueryRow(
-		`SELECT id, user_id, weight, notes, logged_at, created_at FROM weight_logs WHERE id = ?`, lid,
-	).Scan(&log.ID, &log.UserID, &log.Weight, &log.Notes, &log.LoggedAt, &log.CreatedAt); err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
 		return
 	}
 	utils.OK(c, log)
@@ -225,13 +125,10 @@ func (h *Handler) DeleteWeightLog(c *gin.Context) {
 		utils.BadRequest(c, "invalid id")
 		return
 	}
-
-	res, err := db.DB.Exec(`DELETE FROM weight_logs WHERE id = ? AND user_id = ?`, lid, uid)
-	if err != nil {
-		utils.InternalError(c)
+	n, err := h.s.Weight.Delete(uid, lid)
+	if utils.DBError(c, err) {
 		return
 	}
-	n, _ := res.RowsAffected()
 	if n == 0 {
 		utils.NotFound(c, "log entry not found")
 		return
@@ -241,38 +138,34 @@ func (h *Handler) DeleteWeightLog(c *gin.Context) {
 
 func (h *Handler) GetWeightStats(c *gin.Context) {
 	uid := middleware.UserID(c)
-
-	var (
-		latest, oldest, minW, maxW, avgW sql.NullFloat64
-		count                            int
-	)
-	db.DB.QueryRow(
-		`SELECT
-		  (SELECT weight FROM weight_logs WHERE user_id = ? ORDER BY logged_at DESC, id DESC LIMIT 1),
-		  (SELECT weight FROM weight_logs WHERE user_id = ? ORDER BY logged_at ASC, id ASC LIMIT 1),
-		  MIN(weight), MAX(weight), AVG(weight), COUNT(*)
-		 FROM weight_logs WHERE user_id = ?`,
-		uid, uid, uid,
-	).Scan(&latest, &oldest, &minW, &maxW, &avgW, &count)
-
-	change7 := changeOver(uid, 7)
-	change30 := changeOver(uid, 30)
-
+	stats, err := h.s.Weight.Stats(uid)
+	if utils.DBError(c, err) {
+		return
+	}
 	utils.OK(c, gin.H{
-		"latest":        latest.Float64,
-		"starting":      oldest.Float64,
-		"min":           minW.Float64,
-		"max":           maxW.Float64,
-		"avg":           avgW.Float64,
-		"total_entries": count,
-		"change_7d":     change7,
-		"change_30d":    change30,
+		"latest":        stats.Latest,
+		"starting":      stats.Starting,
+		"min":           stats.Min,
+		"max":           stats.Max,
+		"avg":           stats.Avg,
+		"total_entries": stats.TotalEntries,
+		"change_7d":     stats.Change7d,
+		"change_30d":    stats.Change30d,
 	})
 }
 
-// parseDayOrTime accepts either a full RFC3339 timestamp or a bare YYYY-MM-DD.
-// Returns the parsed time, whether the input was an exact timestamp (so callers
-// know not to widen the window), and parse success.
+// normalizeLoggedAt defaults a zero time to now and forces UTC: keeps the wire
+// format consistent across deployments and lets a client-supplied offset
+// timestamp round-trip cleanly (a non-UTC time.Time otherwise fails to scan back).
+func normalizeLoggedAt(t time.Time) time.Time {
+	if t.IsZero() {
+		t = time.Now()
+	}
+	return t.UTC()
+}
+
+// parseDayOrTime accepts a full RFC3339 timestamp or a bare YYYY-MM-DD. Returns
+// the parsed time, whether it was an exact timestamp (don't widen), and success.
 func parseDayOrTime(s string) (t time.Time, exact bool, ok bool) {
 	if v, err := time.Parse(time.RFC3339, s); err == nil {
 		return v, true, true
@@ -281,21 +174,4 @@ func parseDayOrTime(s string) (t time.Time, exact bool, ok bool) {
 		return v, false, true
 	}
 	return time.Time{}, false, false
-}
-
-// changeOver returns latest weight minus the earliest weight within the last
-// `days` days. Returns 0 when there are fewer than two entries in the window.
-func changeOver(uid int64, days int) float64 {
-	cutoff := time.Now().UTC().AddDate(0, 0, -days)
-	var latest, earliest sql.NullFloat64
-	db.DB.QueryRow(
-		`SELECT
-		  (SELECT weight FROM weight_logs WHERE user_id = ? AND logged_at >= ? ORDER BY logged_at DESC, id DESC LIMIT 1),
-		  (SELECT weight FROM weight_logs WHERE user_id = ? AND logged_at >= ? ORDER BY logged_at ASC, id ASC LIMIT 1)`,
-		uid, cutoff, uid, cutoff,
-	).Scan(&latest, &earliest)
-	if !latest.Valid || !earliest.Valid {
-		return 0
-	}
-	return latest.Float64 - earliest.Float64
 }

--- a/backend/controllers/weight_test.go
+++ b/backend/controllers/weight_test.go
@@ -27,7 +27,7 @@ func TestListWeightLogs_empty(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight", nil)
-	ListWeightLogs(c)
+	th.ListWeightLogs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -52,7 +52,7 @@ func TestListWeightLogs_orderedDescAndScopedByUser(t *testing.T) {
 	insertWeightLog(t, otherUID, 999.0, now)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight", nil)
-	ListWeightLogs(c)
+	th.ListWeightLogs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -82,7 +82,7 @@ func TestListWeightLogs_sameDayNewestFirst(t *testing.T) {
 	insertWeightLog(t, uid, 186.0, day) // newer, identical timestamp
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight", nil)
-	ListWeightLogs(c)
+	th.ListWeightLogs(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -105,7 +105,7 @@ func TestGetWeightStats_latestPrefersNewestSameDay(t *testing.T) {
 	insertWeightLog(t, uid, 186.0, day)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight/stats", nil)
-	GetWeightStats(c)
+	th.GetWeightStats(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
@@ -127,7 +127,7 @@ func TestListWeightLogs_dateRange(t *testing.T) {
 	from := now.AddDate(0, 0, -7).Format("2006-01-02")
 	to := now.Format("2006-01-02")
 	c, w := newContext(uid, http.MethodGet, fmt.Sprintf("/api/v1/weight?from=%s&to=%s", from, to), nil)
-	ListWeightLogs(c)
+	th.ListWeightLogs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -154,7 +154,7 @@ func TestListWeightLogs_dateRangeWestTimezone(t *testing.T) {
 	insertWeightLog(t, uid, 175.0, loggedAt)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight?from=2026-04-25&to=2026-04-25", nil)
-	ListWeightLogs(c)
+	th.ListWeightLogs(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -176,7 +176,7 @@ func TestListWeightLogs_dateRangeExactRFC3339(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet,
 		"/api/v1/weight?from=2026-04-25T12:00:00Z&to=2026-04-25T15:00:00Z", nil)
-	ListWeightLogs(c)
+	th.ListWeightLogs(c)
 
 	resp := decodeResponse(t, w)
 	data := resp["data"].([]any)
@@ -195,7 +195,7 @@ func TestLogWeight_success(t *testing.T) {
 
 	body := map[string]any{"weight": 185.5, "notes": "morning"}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/weight", body)
-	LogWeight(c)
+	th.LogWeight(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -219,14 +219,14 @@ func TestLogWeight_sameDayUpdatesInPlace(t *testing.T) {
 	day := "2026-06-29T12:00:00Z"
 	c1, w1 := newContext(uid, http.MethodPost, "/api/v1/weight",
 		map[string]any{"weight": 181.0, "notes": "am", "logged_at": day})
-	LogWeight(c1)
+	th.LogWeight(c1)
 	if w1.Code != http.StatusCreated {
 		t.Fatalf("first log: expected 201, got %d: %s", w1.Code, w1.Body.String())
 	}
 
 	c2, w2 := newContext(uid, http.MethodPost, "/api/v1/weight",
 		map[string]any{"weight": 186.0, "notes": "pm", "logged_at": day})
-	LogWeight(c2)
+	th.LogWeight(c2)
 	if w2.Code != http.StatusCreated {
 		t.Fatalf("second log: expected 201, got %d: %s", w2.Code, w2.Body.String())
 	}
@@ -259,7 +259,7 @@ func TestLogWeight_differentDaysCoexist(t *testing.T) {
 	for _, d := range []string{"2026-06-27T12:00:00Z", "2026-06-28T12:00:00Z"} {
 		c, w := newContext(uid, http.MethodPost, "/api/v1/weight",
 			map[string]any{"weight": 180.0, "logged_at": d})
-		LogWeight(c)
+		th.LogWeight(c)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("log %s: expected 201, got %d", d, w.Code)
 		}
@@ -279,7 +279,7 @@ func TestLogWeight_normalizesOffsetToUTC(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodPost, "/api/v1/weight",
 		map[string]any{"weight": 190.0, "logged_at": "2026-07-16T20:00:00-05:00"})
-	LogWeight(c)
+	th.LogWeight(c)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("offset ts: expected 201, got %d: %s", w.Code, w.Body.String())
 	}
@@ -296,7 +296,7 @@ func TestLogWeight_rejectsNonPositive(t *testing.T) {
 
 	body := map[string]any{"weight": 0}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/weight", body)
-	LogWeight(c)
+	th.LogWeight(c)
 
 	if w.Code == http.StatusCreated {
 		t.Fatal("expected validation error for weight=0, got 201")
@@ -309,7 +309,7 @@ func TestLogWeight_rejectsImplausiblyLarge(t *testing.T) {
 
 	body := map[string]any{"weight": 9999}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/weight", body)
-	LogWeight(c)
+	th.LogWeight(c)
 
 	if w.Code == http.StatusCreated {
 		t.Fatal("expected validation error for weight=9999, got 201")
@@ -324,7 +324,7 @@ func TestUpdateWeightLog_success(t *testing.T) {
 	body := map[string]any{"weight": 178.0, "notes": "after run"}
 	c, w := newContext(uid, http.MethodPatch, "/api/v1/weight/"+fmt.Sprint(id), body)
 	setParam(c, "id", fmt.Sprint(id))
-	UpdateWeightLog(c)
+	th.UpdateWeightLog(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -351,7 +351,7 @@ func TestUpdateWeightLog_dedupsOnTargetDay(t *testing.T) {
 	body := map[string]any{"weight": 186.0, "logged_at": "2026-07-20T12:00:00Z"}
 	c, w := newContext(uid, http.MethodPatch, "/api/v1/weight/"+fmt.Sprint(b), body)
 	setParam(c, "id", fmt.Sprint(b))
-	UpdateWeightLog(c)
+	th.UpdateWeightLog(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -380,7 +380,7 @@ func TestUpdateWeightLog_ownershipEnforced(t *testing.T) {
 	body := map[string]any{"weight": 100.0}
 	c, w := newContext(uid, http.MethodPatch, "/api/v1/weight/"+fmt.Sprint(id), body)
 	setParam(c, "id", fmt.Sprint(id))
-	UpdateWeightLog(c)
+	th.UpdateWeightLog(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user update, got %d", w.Code)
@@ -401,7 +401,7 @@ func TestDeleteWeightLog_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/weight/"+fmt.Sprint(id), nil)
 	setParam(c, "id", fmt.Sprint(id))
-	DeleteWeightLog(c)
+	th.DeleteWeightLog(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user delete, got %d", w.Code)
@@ -423,7 +423,7 @@ func TestGetWeightStats_richFields(t *testing.T) {
 	insertWeightLog(t, uid, 175.0, now.AddDate(0, 0, -1))
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight/stats", nil)
-	GetWeightStats(c)
+	th.GetWeightStats(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -461,7 +461,7 @@ func TestGetWeightStats_noData(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/weight/stats", nil)
-	GetWeightStats(c)
+	th.GetWeightStats(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)

--- a/backend/controllers/workouts.go
+++ b/backend/controllers/workouts.go
@@ -3,55 +3,27 @@ package controllers
 import (
 	"database/sql"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/middleware"
 	"github.com/Cawlumm/lyftr-backend/models"
+	"github.com/Cawlumm/lyftr-backend/stores"
 	"github.com/Cawlumm/lyftr-backend/utils"
 	"github.com/gin-gonic/gin"
 )
 
 func (h *Handler) ListWorkouts(c *gin.Context) {
 	uid := middleware.UserID(c)
-	limit := 20
-	offset := 0
+	f := stores.WorkoutFilter{Limit: 20, Query: c.Query("q")}
 	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 100 {
-		limit = l
+		f.Limit = l
 	}
 	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o >= 0 {
-		offset = o
+		f.Offset = o
 	}
-	q := c.Query("q")
-
-	var rows *sql.Rows
-	var err error
-	if q != "" {
-		rows, err = db.DB.Query(
-			`SELECT id, user_id, name, notes, duration, started_at, created_at
-			 FROM workouts WHERE user_id = ? AND LOWER(name) LIKE ? ORDER BY started_at DESC LIMIT ? OFFSET ?`,
-			uid, "%"+strings.ToLower(q)+"%", limit, offset,
-		)
-	} else {
-		rows, err = db.DB.Query(
-			`SELECT id, user_id, name, notes, duration, started_at, created_at
-			 FROM workouts WHERE user_id = ? ORDER BY started_at DESC LIMIT ? OFFSET ?`,
-			uid, limit, offset,
-		)
-	}
-	if err != nil {
-		utils.InternalError(c)
+	workouts, err := h.s.Workout.List(uid, f)
+	if utils.DBError(c, err) {
 		return
-	}
-	defer rows.Close()
-
-	workouts := []models.Workout{}
-	for rows.Next() {
-		var w models.Workout
-		rows.Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt)
-		w.Exercises = loadWorkoutExercises(w.ID)
-		workouts = append(workouts, w)
 	}
 	utils.OK(c, workouts)
 }
@@ -63,22 +35,14 @@ func (h *Handler) GetWorkout(c *gin.Context) {
 		utils.BadRequest(c, "invalid workout id")
 		return
 	}
-
-	var w models.Workout
-	err = db.DB.QueryRow(
-		`SELECT id, user_id, name, notes, duration, started_at, created_at
-		 FROM workouts WHERE id = ? AND user_id = ?`, wid, uid,
-	).Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt)
+	w, err := h.s.Workout.Get(uid, wid)
 	if err == sql.ErrNoRows {
 		utils.NotFound(c, "workout not found")
 		return
 	}
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
 		return
 	}
-
-	w.Exercises = loadWorkoutExercises(wid)
 	utils.OK(c, w)
 }
 
@@ -93,69 +57,13 @@ func (h *Handler) CreateWorkout(c *gin.Context) {
 		utils.ValidationError(c, err)
 		return
 	}
-
 	if req.StartedAt.IsZero() {
 		req.StartedAt = time.Now()
 	}
-
-	tx, err := db.DB.Begin()
-	if err != nil {
-		utils.InternalError(c)
+	w, err := h.s.Workout.Create(uid, req)
+	if utils.DBError(c, err) {
 		return
 	}
-	defer tx.Rollback()
-
-	res, err := tx.Exec(
-		`INSERT INTO workouts (user_id, name, notes, duration, started_at) VALUES (?, ?, ?, ?, ?)`,
-		uid, req.Name, req.Notes, req.Duration, req.StartedAt,
-	)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-	wid, err := res.LastInsertId()
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	for i, ex := range req.Exercises {
-		exRes, err := tx.Exec(
-			`INSERT INTO workout_exercises (workout_id, exercise_id, order_index, notes) VALUES (?, ?, ?, ?)`,
-			wid, ex.ExerciseID, i, ex.Notes,
-		)
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		weid, err := exRes.LastInsertId()
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		for j, s := range ex.Sets {
-			_, err := tx.Exec(
-				`INSERT INTO sets (workout_exercise_id, set_number, reps, weight, duration, distance, rpe, is_warmup)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-				weid, j+1, s.Reps, s.Weight, s.Duration, s.Distance, s.RPE, s.IsWarmup,
-			)
-			if err != nil {
-				utils.InternalError(c)
-				return
-			}
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	var w models.Workout
-	db.DB.QueryRow(
-		`SELECT id, user_id, name, notes, duration, started_at, created_at FROM workouts WHERE id = ?`, wid,
-	).Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt)
-	w.Exercises = loadWorkoutExercises(wid)
 	utils.Created(c, w)
 }
 
@@ -166,7 +74,6 @@ func (h *Handler) UpdateWorkout(c *gin.Context) {
 		utils.BadRequest(c, "invalid workout id")
 		return
 	}
-
 	var req models.CreateWorkoutRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, err.Error())
@@ -176,79 +83,14 @@ func (h *Handler) UpdateWorkout(c *gin.Context) {
 		utils.ValidationError(c, err)
 		return
 	}
-
-	var existing models.Workout
-	err = db.DB.QueryRow(
-		`SELECT id, user_id FROM workouts WHERE id = ? AND user_id = ?`, wid, uid,
-	).Scan(&existing.ID, &existing.UserID)
+	w, err := h.s.Workout.Update(uid, wid, req)
 	if err == sql.ErrNoRows {
 		utils.NotFound(c, "workout not found")
 		return
 	}
-	if err != nil {
-		utils.InternalError(c)
+	if utils.DBError(c, err) {
 		return
 	}
-
-	tx, err := db.DB.Begin()
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-	defer tx.Rollback()
-
-	_, err = tx.Exec(
-		`UPDATE workouts SET name = ?, notes = ?, duration = ?, started_at = ? WHERE id = ?`,
-		req.Name, req.Notes, req.Duration, req.StartedAt, wid,
-	)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	_, err = tx.Exec(`DELETE FROM workout_exercises WHERE workout_id = ?`, wid)
-	if err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	for i, ex := range req.Exercises {
-		exRes, err := tx.Exec(
-			`INSERT INTO workout_exercises (workout_id, exercise_id, order_index, notes) VALUES (?, ?, ?, ?)`,
-			wid, ex.ExerciseID, i, ex.Notes,
-		)
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		weid, err := exRes.LastInsertId()
-		if err != nil {
-			utils.InternalError(c)
-			return
-		}
-		for j, s := range ex.Sets {
-			_, err := tx.Exec(
-				`INSERT INTO sets (workout_exercise_id, set_number, reps, weight, duration, distance, rpe, is_warmup)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-				weid, j+1, s.Reps, s.Weight, s.Duration, s.Distance, s.RPE, s.IsWarmup,
-			)
-			if err != nil {
-				utils.InternalError(c)
-				return
-			}
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		utils.InternalError(c)
-		return
-	}
-
-	var w models.Workout
-	db.DB.QueryRow(
-		`SELECT id, user_id, name, notes, duration, started_at, created_at FROM workouts WHERE id = ?`, wid,
-	).Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt)
-	w.Exercises = loadWorkoutExercises(wid)
 	utils.OK(c, w)
 }
 
@@ -259,65 +101,13 @@ func (h *Handler) DeleteWorkout(c *gin.Context) {
 		utils.BadRequest(c, "invalid workout id")
 		return
 	}
-
-	res, err := db.DB.Exec(`DELETE FROM workouts WHERE id = ? AND user_id = ?`, wid, uid)
-	if err != nil {
-		utils.InternalError(c)
+	n, err := h.s.Workout.Delete(uid, wid)
+	if utils.DBError(c, err) {
 		return
 	}
-	n, _ := res.RowsAffected()
 	if n == 0 {
 		utils.NotFound(c, "workout not found")
 		return
 	}
 	utils.OK(c, gin.H{"deleted": true})
-}
-
-func loadWorkoutExercises(workoutID int64) []models.WorkoutExercise {
-	rows, err := db.DB.Query(
-		`SELECT we.id, we.workout_id, we.exercise_id, we.order_index, we.notes,
-		        e.name, e.muscle_group, e.category, e.equipment, e.image_url
-		 FROM workout_exercises we
-		 JOIN exercises e ON e.id = we.exercise_id
-		 WHERE we.workout_id = ? ORDER BY we.order_index`,
-		workoutID,
-	)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-
-	var exercises []models.WorkoutExercise
-	for rows.Next() {
-		var we models.WorkoutExercise
-		rows.Scan(
-			&we.ID, &we.WorkoutID, &we.ExerciseID, &we.OrderIndex, &we.Notes,
-			&we.Exercise.Name, &we.Exercise.MuscleGroup, &we.Exercise.Category,
-			&we.Exercise.Equipment, &we.Exercise.ImageURL,
-		)
-		we.Exercise.ID = we.ExerciseID
-		we.Sets = loadSets(we.ID)
-		exercises = append(exercises, we)
-	}
-	return exercises
-}
-
-func loadSets(workoutExerciseID int64) []models.Set {
-	rows, err := db.DB.Query(
-		`SELECT id, workout_exercise_id, set_number, reps, weight, duration, distance, rpe, is_warmup
-		 FROM sets WHERE workout_exercise_id = ? ORDER BY set_number`,
-		workoutExerciseID,
-	)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-
-	var sets []models.Set
-	for rows.Next() {
-		var s models.Set
-		rows.Scan(&s.ID, &s.WorkoutExerciseID, &s.SetNumber, &s.Reps, &s.Weight, &s.Duration, &s.Distance, &s.RPE, &s.IsWarmup)
-		sets = append(sets, s)
-	}
-	return sets
 }

--- a/backend/controllers/workouts.go
+++ b/backend/controllers/workouts.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ListWorkouts(c *gin.Context) {
+func (h *Handler) ListWorkouts(c *gin.Context) {
 	uid := middleware.UserID(c)
 	limit := 20
 	offset := 0
@@ -56,7 +56,7 @@ func ListWorkouts(c *gin.Context) {
 	utils.OK(c, workouts)
 }
 
-func GetWorkout(c *gin.Context) {
+func (h *Handler) GetWorkout(c *gin.Context) {
 	uid := middleware.UserID(c)
 	wid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -82,7 +82,7 @@ func GetWorkout(c *gin.Context) {
 	utils.OK(c, w)
 }
 
-func CreateWorkout(c *gin.Context) {
+func (h *Handler) CreateWorkout(c *gin.Context) {
 	uid := middleware.UserID(c)
 	var req models.CreateWorkoutRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -159,7 +159,7 @@ func CreateWorkout(c *gin.Context) {
 	utils.Created(c, w)
 }
 
-func UpdateWorkout(c *gin.Context) {
+func (h *Handler) UpdateWorkout(c *gin.Context) {
 	uid := middleware.UserID(c)
 	wid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -252,7 +252,7 @@ func UpdateWorkout(c *gin.Context) {
 	utils.OK(c, w)
 }
 
-func DeleteWorkout(c *gin.Context) {
+func (h *Handler) DeleteWorkout(c *gin.Context) {
 	uid := middleware.UserID(c)
 	wid, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {

--- a/backend/controllers/workouts.go
+++ b/backend/controllers/workouts.go
@@ -61,6 +61,10 @@ func (h *Handler) CreateWorkout(c *gin.Context) {
 		req.StartedAt = time.Now()
 	}
 	w, err := h.s.Workout.Create(uid, req)
+	if utils.IsForeignKeyViolation(err) {
+		utils.BadRequest(c, "one or more exercises do not exist")
+		return
+	}
 	if utils.DBError(c, err) {
 		return
 	}
@@ -86,6 +90,10 @@ func (h *Handler) UpdateWorkout(c *gin.Context) {
 	w, err := h.s.Workout.Update(uid, wid, req)
 	if err == sql.ErrNoRows {
 		utils.NotFound(c, "workout not found")
+		return
+	}
+	if utils.IsForeignKeyViolation(err) {
+		utils.BadRequest(c, "one or more exercises do not exist")
 		return
 	}
 	if utils.DBError(c, err) {

--- a/backend/controllers/workouts_test.go
+++ b/backend/controllers/workouts_test.go
@@ -13,7 +13,7 @@ func TestListWorkouts_empty(t *testing.T) {
 	uid := createTestUser(t)
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/workouts", nil)
-	ListWorkouts(c)
+	th.ListWorkouts(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -50,7 +50,7 @@ func TestCreateWorkout_success(t *testing.T) {
 	}
 
 	c, w := newContext(uid, http.MethodPost, "/api/v1/workouts", body)
-	CreateWorkout(c)
+	th.CreateWorkout(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -75,7 +75,7 @@ func TestCreateWorkout_missingName(t *testing.T) {
 		"exercises": []map[string]any{},
 	}
 	c, w := newContext(uid, http.MethodPost, "/api/v1/workouts", body)
-	CreateWorkout(c)
+	th.CreateWorkout(c)
 
 	if w.Code == http.StatusCreated {
 		t.Fatal("expected error for empty name, got 201")
@@ -101,7 +101,7 @@ func TestCreateWorkout_preservesStartedAt(t *testing.T) {
 	}
 
 	c, w := newContext(uid, http.MethodPost, "/api/v1/workouts", body)
-	CreateWorkout(c)
+	th.CreateWorkout(c)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
@@ -130,7 +130,7 @@ func TestGetWorkout_ownershipEnforced(t *testing.T) {
 	// Try to GET as uid (different user)
 	c, w := newContext(uid, http.MethodGet, "/api/v1/workouts/"+fmt.Sprint(wid), nil)
 	setParam(c, "id", fmt.Sprint(wid))
-	GetWorkout(c)
+	th.GetWorkout(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user access, got %d", w.Code)
@@ -151,7 +151,7 @@ func TestDeleteWorkout_ownershipEnforced(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodDelete, "/api/v1/workouts/"+fmt.Sprint(wid), nil)
 	setParam(c, "id", fmt.Sprint(wid))
-	DeleteWorkout(c)
+	th.DeleteWorkout(c)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for cross-user delete, got %d", w.Code)
@@ -191,7 +191,7 @@ func TestUpdateWorkout_preservesStartedAt(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodPut, "/api/v1/workouts/"+fmt.Sprint(wid), body)
 	setParam(c, "id", fmt.Sprint(wid))
-	UpdateWorkout(c)
+	th.UpdateWorkout(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -218,7 +218,7 @@ func TestListWorkouts_limitCap(t *testing.T) {
 	// Request with limit=200 (above cap of 100)
 	c, w := newContext(uid, http.MethodGet, "/api/v1/workouts?limit=200", nil)
 	c.Request.URL.RawQuery = "limit=200"
-	ListWorkouts(c)
+	th.ListWorkouts(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -243,7 +243,7 @@ func TestListWorkouts_filtersBySearchQuery(t *testing.T) {
 
 	c, w := newContext(uid, http.MethodGet, "/api/v1/workouts?q=push", nil)
 	c.Request.URL.RawQuery = "q=push" // case-insensitive LIKE on name, scoped by user
-	ListWorkouts(c)
+	th.ListWorkouts(c)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())

--- a/backend/db/sqlite.go
+++ b/backend/db/sqlite.go
@@ -21,7 +21,15 @@ func Connect() {
 	}
 
 	var err error
-	DB, err = sql.Open("sqlite", dbPath+"?_journal_mode=DELETE&_foreign_keys=on&_busy_timeout=5000")
+	// modernc.org/sqlite uses _pragma=NAME(VALUE) DSN syntax. The old mattn-style
+	// params (_journal_mode=…&_busy_timeout=…) were silently ignored, leaving
+	// busy_timeout at 0 — so any contended lock failed instantly (a write racing
+	// other requests would 500). Fix:
+	//   busy_timeout(5000): wait up to 5s for a lock instead of erroring.
+	//   journal_mode(WAL): readers don't block the writer; fewer locks.
+	//   synchronous(NORMAL): the safe, faster durability setting under WAL.
+	//   foreign_keys(on): keep cascade deletes working (DeleteAccount relies on it).
+	DB, err = sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(on)")
 	if err != nil {
 		log.Fatalf("failed to open database: %v", err)
 	}

--- a/backend/db/sqlite.go
+++ b/backend/db/sqlite.go
@@ -34,8 +34,14 @@ func Connect() {
 		log.Fatalf("failed to open database: %v", err)
 	}
 
-	DB.SetMaxOpenConns(10)
-	DB.SetMaxIdleConns(5)
+	// SQLite is a single writer — it does not do concurrent writes. Rather than
+	// fight that with a larger pool (which only turns contention into lock errors
+	// to retry), serialize all DB access through ONE connection. With the
+	// nested-cursor fix (no request needs a second connection mid-query), one
+	// connection is sufficient and leaves no in-process lock contention to fail on.
+	// The busy_timeout/WAL pragmas above remain only as cheap cross-process defense.
+	DB.SetMaxOpenConns(1)
+	DB.SetMaxIdleConns(1)
 
 	if err = DB.Ping(); err != nil {
 		log.Fatalf("failed to ping database: %v", err)

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,9 +7,11 @@ import (
 	"os"
 
 	"github.com/Cawlumm/lyftr-backend/config"
+	"github.com/Cawlumm/lyftr-backend/controllers"
 	"github.com/Cawlumm/lyftr-backend/db"
 	"github.com/Cawlumm/lyftr-backend/routes"
 	"github.com/Cawlumm/lyftr-backend/seed"
+	"github.com/Cawlumm/lyftr-backend/stores"
 	"github.com/gin-gonic/gin"
 )
 
@@ -32,7 +34,9 @@ func main() {
 	}
 
 	r := gin.Default()
-	routes.Setup(r)
+	s := stores.New(db.DB)
+	h := controllers.NewHandler(s)
+	routes.Setup(r, h)
 
 	addr := ":" + config.C.Port
 	log.Printf("lyftr API listening on %s (env=%s)", addr, config.C.Env)

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -24,7 +24,7 @@ type Exercise struct {
 	Name             string   `json:"name" db:"name"`
 	MuscleGroup      string   `json:"muscle_group" db:"muscle_group"`
 	SecondaryMuscles []string `json:"secondary_muscles" db:"-"` // decoded from JSON column
-	Category         string   `json:"category" db:"category"` // "strength", "cardio", "flexibility"
+	Category         string   `json:"category" db:"category"`   // "strength", "cardio", "flexibility"
 	Equipment        string   `json:"equipment" db:"equipment"`
 	Description      string   `json:"description" db:"description"`
 	ImageURL         string   `json:"image_url,omitempty" db:"image_url"`
@@ -57,7 +57,7 @@ type Set struct {
 	WorkoutExerciseID int64   `json:"workout_exercise_id" db:"workout_exercise_id"`
 	SetNumber         int     `json:"set_number" db:"set_number"`
 	Reps              int     `json:"reps,omitempty" db:"reps"`
-	Weight            float64 `json:"weight,omitempty" db:"weight"` // raw value in user's preferred unit (lbs or kg)
+	Weight            float64 `json:"weight,omitempty" db:"weight"`     // raw value in user's preferred unit (lbs or kg)
 	Duration          int     `json:"duration,omitempty" db:"duration"` // seconds, for timed sets
 	Distance          float64 `json:"distance,omitempty" db:"distance"` // meters
 	RPE               float64 `json:"rpe,omitempty" db:"rpe"`
@@ -150,17 +150,17 @@ type RefreshRequest struct {
 }
 
 type CreateWorkoutRequest struct {
-	Name      string                    `json:"name" validate:"required"`
-	Notes     string                    `json:"notes"`
-	Duration  int                       `json:"duration"`
-	StartedAt time.Time                 `json:"started_at"`
+	Name      string                     `json:"name" validate:"required"`
+	Notes     string                     `json:"notes"`
+	Duration  int                        `json:"duration"`
+	StartedAt time.Time                  `json:"started_at"`
 	Exercises []CreateWorkoutExerciseReq `json:"exercises"`
 }
 
 type CreateWorkoutExerciseReq struct {
-	ExerciseID int64        `json:"exercise_id" validate:"required"`
-	OrderIndex int          `json:"order_index"`
-	Notes      string       `json:"notes"`
+	ExerciseID int64          `json:"exercise_id" validate:"required"`
+	OrderIndex int            `json:"order_index"`
+	Notes      string         `json:"notes"`
 	Sets       []CreateSetReq `json:"sets"`
 }
 
@@ -243,14 +243,14 @@ type ProgramSet struct {
 }
 
 type CreateProgramRequest struct {
-	Name      string                    `json:"name" validate:"required"`
-	Notes     string                    `json:"notes"`
+	Name      string                     `json:"name" validate:"required"`
+	Notes     string                     `json:"notes"`
 	Exercises []CreateProgramExerciseReq `json:"exercises"`
 }
 
 type CreateProgramExerciseReq struct {
-	ExerciseID int64                `json:"exercise_id" validate:"required"`
-	Notes      string               `json:"notes"`
+	ExerciseID int64                 `json:"exercise_id" validate:"required"`
+	Notes      string                `json:"notes"`
 	Sets       []CreateProgramSetReq `json:"sets"`
 }
 

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Setup(r *gin.Engine) {
+func Setup(r *gin.Engine, h *controllers.Handler) {
 	r.Use(cors.New(corsConfig()))
 
 	r.GET("/health", func(c *gin.Context) {
@@ -21,14 +21,14 @@ func Setup(r *gin.Engine) {
 	api := r.Group("/api/v1")
 
 	// Public: "test connection" probe for the in-app server selector.
-	api.GET("/info", controllers.ServerInfo)
+	api.GET("/info", h.ServerInfo)
 
 	// Auth (public)
 	auth := api.Group("/auth")
 	{
-		auth.POST("/register", controllers.Register)
-		auth.POST("/login", controllers.Login)
-		auth.POST("/refresh", controllers.RefreshToken)
+		auth.POST("/register", h.Register)
+		auth.POST("/login", h.Login)
+		auth.POST("/refresh", h.RefreshToken)
 	}
 
 	// Protected routes
@@ -36,62 +36,62 @@ func Setup(r *gin.Engine) {
 	protected.Use(middleware.Auth())
 	{
 		// User
-		protected.GET("me", controllers.GetMe)
-		protected.GET("settings", controllers.GetSettings)
-		protected.PUT("settings", controllers.UpdateSettings)
-		protected.DELETE("me", controllers.DeleteAccount)
+		protected.GET("me", h.GetMe)
+		protected.GET("settings", h.GetSettings)
+		protected.PUT("settings", h.UpdateSettings)
+		protected.DELETE("me", h.DeleteAccount)
 
 		// Workouts
-		protected.GET("workouts", controllers.ListWorkouts)
-		protected.POST("workouts", controllers.CreateWorkout)
-		protected.GET("workouts/:id", controllers.GetWorkout)
-		protected.PUT("workouts/:id", controllers.UpdateWorkout)
-		protected.DELETE("workouts/:id", controllers.DeleteWorkout)
+		protected.GET("workouts", h.ListWorkouts)
+		protected.POST("workouts", h.CreateWorkout)
+		protected.GET("workouts/:id", h.GetWorkout)
+		protected.PUT("workouts/:id", h.UpdateWorkout)
+		protected.DELETE("workouts/:id", h.DeleteWorkout)
 
 		// Weight
-		protected.GET("weight", controllers.ListWeightLogs)
-		protected.POST("weight", controllers.LogWeight)
-		protected.GET("weight/stats", controllers.GetWeightStats)
-		protected.GET("weight/:id", controllers.GetWeightLog)
-		protected.PATCH("weight/:id", controllers.UpdateWeightLog)
-		protected.DELETE("weight/:id", controllers.DeleteWeightLog)
+		protected.GET("weight", h.ListWeightLogs)
+		protected.POST("weight", h.LogWeight)
+		protected.GET("weight/stats", h.GetWeightStats)
+		protected.GET("weight/:id", h.GetWeightLog)
+		protected.PATCH("weight/:id", h.UpdateWeightLog)
+		protected.DELETE("weight/:id", h.DeleteWeightLog)
 
 		// Food — named sub-paths must be registered before food/:id
-		protected.GET("food", controllers.ListFoodLogs)
-		protected.POST("food", controllers.LogFood)
-		protected.GET("food/stats", controllers.GetDailyStats)
-		protected.GET("food/history", controllers.GetFoodHistory)
-		protected.GET("food/search", controllers.SearchFood)
-		protected.GET("food/barcode/:code", controllers.LookupBarcode)
-		protected.GET("food/saved", controllers.ListSavedFoods)
-		protected.POST("food/saved", controllers.CreateSavedFood)
-		protected.DELETE("food/saved/:id", controllers.DeleteSavedFood)
-		protected.GET("food/:id", controllers.GetFoodLog)
-		protected.PATCH("food/:id", controllers.UpdateFoodLog)
-		protected.DELETE("food/:id", controllers.DeleteFoodLog)
+		protected.GET("food", h.ListFoodLogs)
+		protected.POST("food", h.LogFood)
+		protected.GET("food/stats", h.GetDailyStats)
+		protected.GET("food/history", h.GetFoodHistory)
+		protected.GET("food/search", h.SearchFood)
+		protected.GET("food/barcode/:code", h.LookupBarcode)
+		protected.GET("food/saved", h.ListSavedFoods)
+		protected.POST("food/saved", h.CreateSavedFood)
+		protected.DELETE("food/saved/:id", h.DeleteSavedFood)
+		protected.GET("food/:id", h.GetFoodLog)
+		protected.PATCH("food/:id", h.UpdateFoodLog)
+		protected.DELETE("food/:id", h.DeleteFoodLog)
 
 		// Exercises (read-only for users)
-		protected.GET("exercises", controllers.ListExercises)
-		protected.GET("exercises/:id", controllers.GetExercise)
-		protected.GET("exercises/:id/prs", controllers.GetExercisePRs)
-		protected.GET("exercises/:id/history", controllers.GetExerciseHistory)
+		protected.GET("exercises", h.ListExercises)
+		protected.GET("exercises/:id", h.GetExercise)
+		protected.GET("exercises/:id/prs", h.GetExercisePRs)
+		protected.GET("exercises/:id/history", h.GetExerciseHistory)
 
 		// Active session
-		protected.GET("active-session", controllers.GetActiveSession)
-		protected.PUT("active-session", controllers.UpsertActiveSession)
-		protected.DELETE("active-session", controllers.DeleteActiveSession)
+		protected.GET("active-session", h.GetActiveSession)
+		protected.PUT("active-session", h.UpsertActiveSession)
+		protected.DELETE("active-session", h.DeleteActiveSession)
 
 		// Programs
-		protected.GET("programs", controllers.ListPrograms)
-		protected.POST("programs", controllers.CreateProgram)
-		protected.GET("programs/:id", controllers.GetProgram)
-		protected.PUT("programs/:id", controllers.UpdateProgram)
-		protected.DELETE("programs/:id", controllers.DeleteProgram)
+		protected.GET("programs", h.ListPrograms)
+		protected.POST("programs", h.CreateProgram)
+		protected.GET("programs/:id", h.GetProgram)
+		protected.PUT("programs/:id", h.UpdateProgram)
+		protected.DELETE("programs/:id", h.DeleteProgram)
 
 		// Admin
-		protected.POST("admin/sync-exercises", controllers.SyncExercises)
-		protected.GET("admin/seed-status", controllers.ExerciseSeedStatus)
-		protected.POST("admin/reset-exercises", controllers.ResetExercises)
+		protected.POST("admin/sync-exercises", h.SyncExercises)
+		protected.GET("admin/seed-status", h.ExerciseSeedStatus)
+		protected.POST("admin/reset-exercises", h.ResetExercises)
 	}
 }
 

--- a/backend/seed/exercises.go
+++ b/backend/seed/exercises.go
@@ -35,7 +35,7 @@ type freeExerciseItem struct {
 
 // SeedStatus returns current exercise count and whether a seed is running.
 type SeedStatus struct {
-	Count     int  `json:"count"`
+	Count      int  `json:"count"`
 	InProgress bool `json:"in_progress"`
 }
 

--- a/backend/seed/exercises.go
+++ b/backend/seed/exercises.go
@@ -77,7 +77,12 @@ func WipeAndReseed(db *sql.DB) error {
 	if !seeding.CompareAndSwap(false, true) {
 		return fmt.Errorf("seed already in progress")
 	}
-	if _, err := db.Exec(`DELETE FROM exercises`); err != nil {
+	// Prune only unreferenced exercises: with foreign_keys enforced, deleting an
+	// exercise that a saved workout/program references is (correctly) rejected.
+	// Referenced rows are refreshed in place by the ON CONFLICT(name) upsert below.
+	if _, err := db.Exec(`DELETE FROM exercises
+		WHERE id NOT IN (SELECT exercise_id FROM workout_exercises)
+		  AND id NOT IN (SELECT exercise_id FROM program_exercises)`); err != nil {
 		seeding.Store(false)
 		return fmt.Errorf("wipe failed: %w", err)
 	}

--- a/backend/seed/exercises.go
+++ b/backend/seed/exercises.go
@@ -72,21 +72,36 @@ func SyncExercises(db *sql.DB) error {
 
 // WipeAndReseed deletes all exercises then re-fetches from source.
 func WipeAndReseed(db *sql.DB) error {
-	if seeding.Load() {
+	// Claim the flag atomically BEFORE wiping: a Load-then-act check races —
+	// two concurrent calls could both pass it, double-wipe, and seed twice.
+	if !seeding.CompareAndSwap(false, true) {
 		return fmt.Errorf("seed already in progress")
 	}
 	if _, err := db.Exec(`DELETE FROM exercises`); err != nil {
+		seeding.Store(false)
 		return fmt.Errorf("wipe failed: %w", err)
 	}
 	log.Println("seed: exercises wiped, starting re-seed...")
-	go fetchAndStoreAsync(db)
+	go func() {
+		defer seeding.Store(false)
+		if err := fetchAndStoreLocked(db); err != nil {
+			log.Printf("seed: exercise sync failed: %v", err)
+		}
+	}()
 	return nil
 }
 
+// fetchAndStore claims the seeding flag for the duration of the sync.
 func fetchAndStore(db *sql.DB) error {
-	seeding.Store(true)
+	if !seeding.CompareAndSwap(false, true) {
+		return fmt.Errorf("seed already in progress")
+	}
 	defer seeding.Store(false)
+	return fetchAndStoreLocked(db)
+}
 
+// fetchAndStoreLocked does the sync; the caller must hold the seeding flag.
+func fetchAndStoreLocked(db *sql.DB) error {
 	items, err := fetchAll()
 	if err != nil {
 		return err

--- a/backend/stores/active_session.go
+++ b/backend/stores/active_session.go
@@ -1,8 +1,34 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
+	"time"
+)
 
 // ActiveSessionStore owns all SQL for the active_session entity.
 type ActiveSessionStore struct{ db *sql.DB }
 
 func NewActiveSessionStore(db *sql.DB) *ActiveSessionStore { return &ActiveSessionStore{db: db} }
+
+// Get returns the user's saved session blob. Returns sql.ErrNoRows if none.
+func (s *ActiveSessionStore) Get(uid int64) (data string, updatedAt time.Time, err error) {
+	err = s.db.QueryRow(
+		`SELECT data, updated_at FROM active_sessions WHERE user_id = ?`, uid,
+	).Scan(&data, &updatedAt)
+	return
+}
+
+func (s *ActiveSessionStore) Upsert(uid int64, data string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO active_sessions (user_id, data, updated_at)
+		 VALUES (?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(user_id) DO UPDATE SET data = excluded.data, updated_at = CURRENT_TIMESTAMP`,
+		uid, data,
+	)
+	return err
+}
+
+func (s *ActiveSessionStore) Delete(uid int64) error {
+	_, err := s.db.Exec(`DELETE FROM active_sessions WHERE user_id = ?`, uid)
+	return err
+}

--- a/backend/stores/active_session.go
+++ b/backend/stores/active_session.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// ActiveSessionStore owns all SQL for the active_session entity.
+type ActiveSessionStore struct{ db *sql.DB }
+
+func NewActiveSessionStore(db *sql.DB) *ActiveSessionStore { return &ActiveSessionStore{db: db} }

--- a/backend/stores/exercise.go
+++ b/backend/stores/exercise.go
@@ -1,8 +1,91 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
+	"encoding/json"
 
-// ExerciseStore owns all SQL for the exercise entity.
+	"github.com/Cawlumm/lyftr-backend/models"
+	"github.com/Cawlumm/lyftr-backend/seed"
+)
+
+// ExerciseStore owns all SQL for the (global, read-only) exercises catalog, and
+// wraps the seed subsystem for the admin sync/reset endpoints.
 type ExerciseStore struct{ db *sql.DB }
 
 func NewExerciseStore(db *sql.DB) *ExerciseStore { return &ExerciseStore{db: db} }
+
+// ExerciseFilter holds the optional list filters (empty string = no filter).
+type ExerciseFilter struct {
+	Query, MuscleGroup, Category, Equipment string
+	Limit                                   int
+}
+
+const exerciseSelect = `SELECT id, name, muscle_group, secondary_muscles, category, equipment, description, image_url FROM exercises`
+
+type scanner interface{ Scan(dest ...any) error }
+
+func scanExercise(row scanner) models.Exercise {
+	var e models.Exercise
+	var secondaryRaw string
+	row.Scan(&e.ID, &e.Name, &e.MuscleGroup, &secondaryRaw, &e.Category, &e.Equipment, &e.Description, &e.ImageURL)
+	json.Unmarshal([]byte(secondaryRaw), &e.SecondaryMuscles)
+	if e.SecondaryMuscles == nil {
+		e.SecondaryMuscles = []string{}
+	}
+	return e
+}
+
+func (s *ExerciseStore) List(f ExerciseFilter) ([]models.Exercise, error) {
+	q := exerciseSelect + ` WHERE 1=1`
+	args := []any{}
+	if f.Query != "" {
+		q += " AND name LIKE ?"
+		args = append(args, "%"+f.Query+"%")
+	}
+	if f.MuscleGroup != "" {
+		q += " AND muscle_group = ?"
+		args = append(args, f.MuscleGroup)
+	}
+	if f.Category != "" {
+		q += " AND category = ?"
+		args = append(args, f.Category)
+	}
+	if f.Equipment != "" {
+		q += " AND equipment = ?"
+		args = append(args, f.Equipment)
+	}
+	q += " ORDER BY name LIMIT ?"
+	args = append(args, f.Limit)
+
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	exercises := []models.Exercise{}
+	for rows.Next() {
+		exercises = append(exercises, scanExercise(rows))
+	}
+	return exercises, rows.Err()
+}
+
+// Get returns one exercise, or sql.ErrNoRows if not found.
+func (s *ExerciseStore) Get(id int64) (models.Exercise, error) {
+	e := scanExercise(s.db.QueryRow(exerciseSelect+` WHERE id = ?`, id))
+	if e.ID == 0 {
+		return models.Exercise{}, sql.ErrNoRows
+	}
+	return e, nil
+}
+
+func (s *ExerciseStore) Count() (int, error) {
+	var n int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM exercises`).Scan(&n)
+	return n, err
+}
+
+// Sync / SeedStatus / Reset delegate to the seed subsystem (which owns the
+// ExerciseDB fetch + the concurrency guard) so the controller stays SQL-free.
+func (s *ExerciseStore) Sync() error                 { return seed.SyncExercises(s.db) }
+func (s *ExerciseStore) SeedStatus() seed.SeedStatus { return seed.GetSeedStatus(s.db) }
+func (s *ExerciseStore) Reset() error                { return seed.WipeAndReseed(s.db) }

--- a/backend/stores/exercise.go
+++ b/backend/stores/exercise.go
@@ -24,15 +24,16 @@ const exerciseSelect = `SELECT id, name, muscle_group, secondary_muscles, catego
 
 type scanner interface{ Scan(dest ...any) error }
 
-func scanExercise(row scanner) models.Exercise {
-	var e models.Exercise
+func scanExercise(row scanner, e *models.Exercise) error {
 	var secondaryRaw string
-	row.Scan(&e.ID, &e.Name, &e.MuscleGroup, &secondaryRaw, &e.Category, &e.Equipment, &e.Description, &e.ImageURL)
+	if err := row.Scan(&e.ID, &e.Name, &e.MuscleGroup, &secondaryRaw, &e.Category, &e.Equipment, &e.Description, &e.ImageURL); err != nil {
+		return err
+	}
 	json.Unmarshal([]byte(secondaryRaw), &e.SecondaryMuscles)
 	if e.SecondaryMuscles == nil {
 		e.SecondaryMuscles = []string{}
 	}
-	return e
+	return nil
 }
 
 func (s *ExerciseStore) List(f ExerciseFilter) ([]models.Exercise, error) {
@@ -64,16 +65,20 @@ func (s *ExerciseStore) List(f ExerciseFilter) ([]models.Exercise, error) {
 	defer rows.Close()
 	exercises := []models.Exercise{}
 	for rows.Next() {
-		exercises = append(exercises, scanExercise(rows))
+		var e models.Exercise
+		if err := scanExercise(rows, &e); err != nil {
+			return nil, err
+		}
+		exercises = append(exercises, e)
 	}
 	return exercises, rows.Err()
 }
 
 // Get returns one exercise, or sql.ErrNoRows if not found.
 func (s *ExerciseStore) Get(id int64) (models.Exercise, error) {
-	e := scanExercise(s.db.QueryRow(exerciseSelect+` WHERE id = ?`, id))
-	if e.ID == 0 {
-		return models.Exercise{}, sql.ErrNoRows
+	var e models.Exercise
+	if err := scanExercise(s.db.QueryRow(exerciseSelect+` WHERE id = ?`, id), &e); err != nil {
+		return models.Exercise{}, err
 	}
 	return e, nil
 }

--- a/backend/stores/exercise.go
+++ b/backend/stores/exercise.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// ExerciseStore owns all SQL for the exercise entity.
+type ExerciseStore struct{ db *sql.DB }
+
+func NewExerciseStore(db *sql.DB) *ExerciseStore { return &ExerciseStore{db: db} }

--- a/backend/stores/food.go
+++ b/backend/stores/food.go
@@ -1,8 +1,180 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
 
-// FoodStore owns all SQL for the food entity.
+	"github.com/Cawlumm/lyftr-backend/models"
+)
+
+// FoodStore owns all SQL for food_logs and saved_foods.
 type FoodStore struct{ db *sql.DB }
 
 func NewFoodStore(db *sql.DB) *FoodStore { return &FoodStore{db: db} }
+
+const foodLogSelect = `SELECT id, user_id, name, meal, calories, protein, carbs, fat, fiber, servings, serving_size, barcode, image_url, logged_at, created_at FROM food_logs`
+
+func scanFoodLog(row interface{ Scan(...any) error }, f *models.FoodLog) error {
+	return row.Scan(
+		&f.ID, &f.UserID, &f.Name, &f.Meal,
+		&f.Calories, &f.Protein, &f.Carbs, &f.Fat, &f.Fiber,
+		&f.Servings, &f.ServingSize, &f.Barcode, &f.ImageURL,
+		&f.LoggedAt, &f.CreatedAt,
+	)
+}
+
+func (s *FoodStore) ListByDay(uid int64, date string) ([]models.FoodLog, error) {
+	rows, err := s.db.Query(
+		foodLogSelect+` WHERE user_id = ? AND substr(logged_at, 1, 10) = ? ORDER BY logged_at ASC`,
+		uid, date,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	logs := []models.FoodLog{}
+	for rows.Next() {
+		var f models.FoodLog
+		if err := scanFoodLog(rows, &f); err != nil {
+			return nil, err
+		}
+		logs = append(logs, f)
+	}
+	return logs, rows.Err()
+}
+
+// Get returns one user-owned food log, or sql.ErrNoRows.
+func (s *FoodStore) Get(uid, id int64) (models.FoodLog, error) {
+	var f models.FoodLog
+	err := scanFoodLog(s.db.QueryRow(foodLogSelect+` WHERE id = ? AND user_id = ?`, id, uid), &f)
+	return f, err
+}
+
+func (s *FoodStore) Create(uid int64, req models.LogFoodRequest) (models.FoodLog, error) {
+	res, err := s.db.Exec(
+		`INSERT INTO food_logs (user_id, name, meal, calories, protein, carbs, fat, fiber, servings, serving_size, barcode, image_url, logged_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		uid, req.Name, req.Meal, req.Calories, req.Protein, req.Carbs, req.Fat, req.Fiber,
+		req.Servings, req.ServingSize, req.Barcode, req.ImageURL, req.LoggedAt,
+	)
+	if err != nil {
+		return models.FoodLog{}, err
+	}
+	id, _ := res.LastInsertId()
+	return s.Get(uid, id)
+}
+
+func (s *FoodStore) Update(uid, id int64, req models.LogFoodRequest) (models.FoodLog, error) {
+	res, err := s.db.Exec(
+		`UPDATE food_logs SET name=?, meal=?, calories=?, protein=?, carbs=?, fat=?, fiber=?,
+		 servings=?, serving_size=?, barcode=?, image_url=?, logged_at=?
+		 WHERE id=? AND user_id=?`,
+		req.Name, req.Meal, req.Calories, req.Protein, req.Carbs, req.Fat, req.Fiber,
+		req.Servings, req.ServingSize, req.Barcode, req.ImageURL, req.LoggedAt,
+		id, uid,
+	)
+	if err != nil {
+		return models.FoodLog{}, err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return models.FoodLog{}, sql.ErrNoRows
+	}
+	return s.Get(uid, id)
+}
+
+func (s *FoodStore) Delete(uid, id int64) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM food_logs WHERE id = ? AND user_id = ?`, id, uid)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// DailyMacros returns the day's summed macros (WorkoutCount/Date are filled by
+// the caller, which composes a WorkoutStore count — cross-entity stays in the
+// controller, not in a store).
+func (s *FoodStore) DailyMacros(uid int64, date string) (models.DailyStats, error) {
+	var stats models.DailyStats
+	err := s.db.QueryRow(
+		`SELECT COALESCE(SUM(calories),0), COALESCE(SUM(protein),0),
+		        COALESCE(SUM(carbs),0), COALESCE(SUM(fat),0), COALESCE(SUM(fiber),0)
+		 FROM food_logs WHERE user_id = ? AND substr(logged_at, 1, 10) = ?`,
+		uid, date,
+	).Scan(&stats.TotalCalories, &stats.TotalProtein, &stats.TotalCarbs, &stats.TotalFat, &stats.TotalFiber)
+	return stats, err
+}
+
+func (s *FoodStore) History(uid int64, days int) ([]models.FoodHistoryPoint, error) {
+	rows, err := s.db.Query(
+		`SELECT substr(logged_at, 1, 10) as d,
+		        COALESCE(SUM(calories),0), COALESCE(SUM(protein),0),
+		        COALESCE(SUM(carbs),0), COALESCE(SUM(fat),0)
+		 FROM food_logs
+		 WHERE user_id = ? AND logged_at >= date('now', ?)
+		 GROUP BY d ORDER BY d ASC`,
+		uid, fmt.Sprintf("-%d days", days),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	points := []models.FoodHistoryPoint{}
+	for rows.Next() {
+		var p models.FoodHistoryPoint
+		if err := rows.Scan(&p.Date, &p.Calories, &p.Protein, &p.Carbs, &p.Fat); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, rows.Err()
+}
+
+const savedFoodSelect = `SELECT id, user_id, name, brand, calories, protein, carbs, fat, fiber, serving_size, barcode, created_at FROM saved_foods`
+
+func scanSavedFood(row interface{ Scan(...any) error }, f *models.SavedFood) error {
+	return row.Scan(&f.ID, &f.UserID, &f.Name, &f.Brand, &f.Calories, &f.Protein, &f.Carbs, &f.Fat,
+		&f.Fiber, &f.ServingSize, &f.Barcode, &f.CreatedAt)
+}
+
+func (s *FoodStore) ListSaved(uid int64) ([]models.SavedFood, error) {
+	rows, err := s.db.Query(savedFoodSelect+` WHERE user_id = ? ORDER BY name ASC`, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	foods := []models.SavedFood{}
+	for rows.Next() {
+		var f models.SavedFood
+		if err := scanSavedFood(rows, &f); err != nil {
+			return nil, err
+		}
+		foods = append(foods, f)
+	}
+	return foods, rows.Err()
+}
+
+func (s *FoodStore) CreateSaved(uid int64, req models.SaveFoodRequest) (models.SavedFood, error) {
+	res, err := s.db.Exec(
+		`INSERT INTO saved_foods (user_id, name, brand, calories, protein, carbs, fat, fiber, serving_size, barcode)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		uid, req.Name, req.Brand, req.Calories, req.Protein, req.Carbs, req.Fat, req.Fiber,
+		req.ServingSize, req.Barcode,
+	)
+	if err != nil {
+		return models.SavedFood{}, err
+	}
+	id, _ := res.LastInsertId()
+	var f models.SavedFood
+	err = scanSavedFood(s.db.QueryRow(savedFoodSelect+` WHERE id = ?`, id), &f)
+	return f, err
+}
+
+func (s *FoodStore) DeleteSaved(uid, id int64) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM saved_foods WHERE id = ? AND user_id = ?`, id, uid)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/backend/stores/food.go
+++ b/backend/stores/food.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// FoodStore owns all SQL for the food entity.
+type FoodStore struct{ db *sql.DB }
+
+func NewFoodStore(db *sql.DB) *FoodStore { return &FoodStore{db: db} }

--- a/backend/stores/program.go
+++ b/backend/stores/program.go
@@ -96,24 +96,21 @@ func (s *ProgramStore) get(id int64) (models.Program, error) {
 }
 
 func (s *ProgramStore) Create(uid int64, req models.CreateProgramRequest) (models.Program, error) {
-	tx, err := s.db.Begin()
+	pid, err := inTx(s.db, func(tx *sql.Tx) (int64, error) {
+		res, err := tx.Exec(`INSERT INTO programs (user_id, name, notes) VALUES (?, ?, ?)`, uid, req.Name, req.Notes)
+		if err != nil {
+			return 0, err
+		}
+		pid, err := res.LastInsertId()
+		if err != nil {
+			return 0, err
+		}
+		if err := insertProgramExercises(tx, pid, req.Exercises); err != nil {
+			return 0, err
+		}
+		return pid, nil
+	})
 	if err != nil {
-		return models.Program{}, err
-	}
-	defer tx.Rollback()
-
-	res, err := tx.Exec(`INSERT INTO programs (user_id, name, notes) VALUES (?, ?, ?)`, uid, req.Name, req.Notes)
-	if err != nil {
-		return models.Program{}, err
-	}
-	pid, err := res.LastInsertId()
-	if err != nil {
-		return models.Program{}, err
-	}
-	if err := insertProgramExercises(tx, pid, req.Exercises); err != nil {
-		return models.Program{}, err
-	}
-	if err := tx.Commit(); err != nil {
 		return models.Program{}, err
 	}
 	return s.get(pid)
@@ -122,27 +119,19 @@ func (s *ProgramStore) Create(uid int64, req models.CreateProgramRequest) (model
 // Update replaces a user-owned program and its children in one tx. sql.ErrNoRows
 // if the program isn't theirs (nothing is mutated).
 func (s *ProgramStore) Update(uid, id int64, req models.CreateProgramRequest) (models.Program, error) {
-	var ownedID int64
-	if err := s.db.QueryRow(`SELECT id FROM programs WHERE id = ? AND user_id = ?`, id, uid).Scan(&ownedID); err != nil {
-		return models.Program{}, err
-	}
-
-	tx, err := s.db.Begin()
-	if err != nil {
-		return models.Program{}, err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.Exec(`UPDATE programs SET name = ?, notes = ? WHERE id = ?`, req.Name, req.Notes, id); err != nil {
-		return models.Program{}, err
-	}
-	if _, err := tx.Exec(`DELETE FROM program_exercises WHERE program_id = ?`, id); err != nil {
-		return models.Program{}, err
-	}
-	if err := insertProgramExercises(tx, id, req.Exercises); err != nil {
-		return models.Program{}, err
-	}
-	if err := tx.Commit(); err != nil {
+	if err := inTxDo(s.db, func(tx *sql.Tx) error {
+		var ownedID int64
+		if err := tx.QueryRow(`SELECT id FROM programs WHERE id = ? AND user_id = ?`, id, uid).Scan(&ownedID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`UPDATE programs SET name = ?, notes = ? WHERE id = ?`, req.Name, req.Notes, id); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`DELETE FROM program_exercises WHERE program_id = ?`, id); err != nil {
+			return err
+		}
+		return insertProgramExercises(tx, id, req.Exercises)
+	}); err != nil {
 		return models.Program{}, err
 	}
 	return s.get(id)

--- a/backend/stores/program.go
+++ b/backend/stores/program.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// ProgramStore owns all SQL for the program entity.
+type ProgramStore struct{ db *sql.DB }
+
+func NewProgramStore(db *sql.DB) *ProgramStore { return &ProgramStore{db: db} }

--- a/backend/stores/program.go
+++ b/backend/stores/program.go
@@ -1,8 +1,252 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
+	"strings"
 
-// ProgramStore owns all SQL for the program entity.
+	"github.com/Cawlumm/lyftr-backend/models"
+)
+
+// ProgramStore owns all SQL for programs, program_exercises and program_sets.
 type ProgramStore struct{ db *sql.DB }
 
 func NewProgramStore(db *sql.DB) *ProgramStore { return &ProgramStore{db: db} }
+
+// ProgramFilter holds list paging + optional name search.
+type ProgramFilter struct {
+	Limit, Offset int
+	Query         string
+}
+
+const programCols = `id, user_id, name, notes, created_at`
+
+func scanProgram(row interface{ Scan(...any) error }, p *models.Program) error {
+	return row.Scan(&p.ID, &p.UserID, &p.Name, &p.Notes, &p.CreatedAt)
+}
+
+func (s *ProgramStore) List(uid int64, f ProgramFilter) ([]models.Program, error) {
+	var rows *sql.Rows
+	var err error
+	if f.Query != "" {
+		rows, err = s.db.Query(
+			`SELECT `+programCols+` FROM programs WHERE user_id = ? AND LOWER(name) LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+			uid, "%"+strings.ToLower(f.Query)+"%", f.Limit, f.Offset,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT `+programCols+` FROM programs WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+			uid, f.Limit, f.Offset,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	programs := []models.Program{}
+	for rows.Next() {
+		var p models.Program
+		if err := scanProgram(rows, &p); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		programs = append(programs, p)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close() // close the parent cursor BEFORE loading children (#36)
+
+	for i := range programs {
+		ex, err := s.loadExercises(programs[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		programs[i].Exercises = ex
+	}
+	return programs, nil
+}
+
+// Get returns a user-owned program with its exercises/sets, or sql.ErrNoRows.
+func (s *ProgramStore) Get(uid, id int64) (models.Program, error) {
+	var p models.Program
+	if err := scanProgram(
+		s.db.QueryRow(`SELECT `+programCols+` FROM programs WHERE id = ? AND user_id = ?`, id, uid), &p,
+	); err != nil {
+		return models.Program{}, err
+	}
+	ex, err := s.loadExercises(id)
+	if err != nil {
+		return models.Program{}, err
+	}
+	p.Exercises = ex
+	return p, nil
+}
+
+func (s *ProgramStore) get(id int64) (models.Program, error) {
+	var p models.Program
+	if err := scanProgram(s.db.QueryRow(`SELECT `+programCols+` FROM programs WHERE id = ?`, id), &p); err != nil {
+		return models.Program{}, err
+	}
+	ex, err := s.loadExercises(id)
+	if err != nil {
+		return models.Program{}, err
+	}
+	p.Exercises = ex
+	return p, nil
+}
+
+func (s *ProgramStore) Create(uid int64, req models.CreateProgramRequest) (models.Program, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return models.Program{}, err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(`INSERT INTO programs (user_id, name, notes) VALUES (?, ?, ?)`, uid, req.Name, req.Notes)
+	if err != nil {
+		return models.Program{}, err
+	}
+	pid, err := res.LastInsertId()
+	if err != nil {
+		return models.Program{}, err
+	}
+	if err := insertProgramExercises(tx, pid, req.Exercises); err != nil {
+		return models.Program{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return models.Program{}, err
+	}
+	return s.get(pid)
+}
+
+// Update replaces a user-owned program and its children in one tx. sql.ErrNoRows
+// if the program isn't theirs (nothing is mutated).
+func (s *ProgramStore) Update(uid, id int64, req models.CreateProgramRequest) (models.Program, error) {
+	var ownedID int64
+	if err := s.db.QueryRow(`SELECT id FROM programs WHERE id = ? AND user_id = ?`, id, uid).Scan(&ownedID); err != nil {
+		return models.Program{}, err
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return models.Program{}, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`UPDATE programs SET name = ?, notes = ? WHERE id = ?`, req.Name, req.Notes, id); err != nil {
+		return models.Program{}, err
+	}
+	if _, err := tx.Exec(`DELETE FROM program_exercises WHERE program_id = ?`, id); err != nil {
+		return models.Program{}, err
+	}
+	if err := insertProgramExercises(tx, id, req.Exercises); err != nil {
+		return models.Program{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return models.Program{}, err
+	}
+	return s.get(id)
+}
+
+func (s *ProgramStore) Delete(uid, id int64) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM programs WHERE id = ? AND user_id = ?`, id, uid)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+func insertProgramExercises(tx *sql.Tx, pid int64, exercises []models.CreateProgramExerciseReq) error {
+	for i, ex := range exercises {
+		exRes, err := tx.Exec(
+			`INSERT INTO program_exercises (program_id, exercise_id, order_index, notes) VALUES (?, ?, ?, ?)`,
+			pid, ex.ExerciseID, i, ex.Notes,
+		)
+		if err != nil {
+			return err
+		}
+		peid, err := exRes.LastInsertId()
+		if err != nil {
+			return err
+		}
+		for j, st := range ex.Sets {
+			sn := st.SetNumber
+			if sn == 0 {
+				sn = j + 1
+			}
+			if _, err := tx.Exec(
+				`INSERT INTO program_sets (program_exercise_id, set_number, target_reps, target_weight) VALUES (?, ?, ?, ?)`,
+				peid, sn, st.TargetReps, st.TargetWeight,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// loadExercises scans + closes the parent cursor BEFORE loading each exercise's
+// sets (#36), and surfaces scan errors.
+func (s *ProgramStore) loadExercises(programID int64) ([]models.ProgramExercise, error) {
+	rows, err := s.db.Query(
+		`SELECT pe.id, pe.program_id, pe.exercise_id, pe.order_index, pe.notes,
+		        e.name, e.muscle_group, e.category, e.equipment, e.image_url
+		 FROM program_exercises pe
+		 JOIN exercises e ON e.id = pe.exercise_id
+		 WHERE pe.program_id = ? ORDER BY pe.order_index`,
+		programID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var exercises []models.ProgramExercise
+	for rows.Next() {
+		var pe models.ProgramExercise
+		if err := rows.Scan(
+			&pe.ID, &pe.ProgramID, &pe.ExerciseID, &pe.OrderIndex, &pe.Notes,
+			&pe.Exercise.Name, &pe.Exercise.MuscleGroup, &pe.Exercise.Category,
+			&pe.Exercise.Equipment, &pe.Exercise.ImageURL,
+		); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		pe.Exercise.ID = pe.ExerciseID
+		exercises = append(exercises, pe)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+
+	for i := range exercises {
+		sets, err := s.loadSets(exercises[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		exercises[i].Sets = sets
+	}
+	return exercises, nil
+}
+
+func (s *ProgramStore) loadSets(programExerciseID int64) ([]models.ProgramSet, error) {
+	rows, err := s.db.Query(
+		`SELECT id, program_exercise_id, set_number, target_reps, target_weight
+		 FROM program_sets WHERE program_exercise_id = ? ORDER BY set_number`,
+		programExerciseID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var sets []models.ProgramSet
+	for rows.Next() {
+		var st models.ProgramSet
+		if err := rows.Scan(&st.ID, &st.ProgramExerciseID, &st.SetNumber, &st.TargetReps, &st.TargetWeight); err != nil {
+			return nil, err
+		}
+		sets = append(sets, st)
+	}
+	return sets, rows.Err()
+}

--- a/backend/stores/stores.go
+++ b/backend/stores/stores.go
@@ -29,3 +29,32 @@ func New(db *sql.DB) *Stores {
 		Program:       NewProgramStore(db),
 	}
 }
+
+// inTx runs fn inside a transaction, committing on success and rolling back on
+// error. Use it for any store operation that issues two or more statements that
+// must commit as a unit (read-modify-write, or multiple writes). Single-statement
+// operations are already atomic and must NOT use it.
+func inTx[T any](db *sql.DB, fn func(*sql.Tx) (T, error)) (T, error) {
+	var zero T
+	tx, err := db.Begin()
+	if err != nil {
+		return zero, err
+	}
+	defer tx.Rollback() // no-op once Commit succeeds
+	v, err := fn(tx)
+	if err != nil {
+		return zero, err
+	}
+	if err := tx.Commit(); err != nil {
+		return zero, err
+	}
+	return v, nil
+}
+
+// inTxDo is inTx for operations that don't return a value.
+func inTxDo(db *sql.DB, fn func(*sql.Tx) error) error {
+	_, err := inTx(db, func(tx *sql.Tx) (struct{}, error) {
+		return struct{}{}, fn(tx)
+	})
+	return err
+}

--- a/backend/stores/stores.go
+++ b/backend/stores/stores.go
@@ -1,0 +1,31 @@
+// Package stores holds the repository layer: each entity has a store that owns
+// ALL of its SQL. Controllers depend on these via *Stores (constructor-injected)
+// and never touch the database directly. Stores are transport-agnostic — they
+// return models + raw errors and import neither gin nor the utils HTTP helpers.
+package stores
+
+import "database/sql"
+
+// Stores aggregates every per-entity store, constructed once from the DB handle
+// and injected into the HTTP handlers.
+type Stores struct {
+	ActiveSession *ActiveSessionStore
+	Weight        *WeightStore
+	Food          *FoodStore
+	User          *UserStore
+	Exercise      *ExerciseStore
+	Workout       *WorkoutStore
+	Program       *ProgramStore
+}
+
+func New(db *sql.DB) *Stores {
+	return &Stores{
+		ActiveSession: NewActiveSessionStore(db),
+		Weight:        NewWeightStore(db),
+		Food:          NewFoodStore(db),
+		User:          NewUserStore(db),
+		Exercise:      NewExerciseStore(db),
+		Workout:       NewWorkoutStore(db),
+		Program:       NewProgramStore(db),
+	}
+}

--- a/backend/stores/user.go
+++ b/backend/stores/user.go
@@ -61,24 +61,17 @@ func (s *UserStore) UpsertSettings(uid int64, req models.UpdateSettingsRequest) 
 // fixes the previous non-transactional gap). A duplicate email surfaces as a
 // UNIQUE violation for the controller to map to 409.
 func (s *UserStore) Create(email, hash string) (int64, error) {
-	tx, err := s.db.Begin()
-	if err != nil {
-		return 0, err
-	}
-	defer tx.Rollback()
-
-	res, err := tx.Exec(`INSERT INTO users (email, password_hash) VALUES (?, ?)`, email, hash)
-	if err != nil {
-		return 0, err
-	}
-	uid, _ := res.LastInsertId()
-	if _, err := tx.Exec(`INSERT INTO user_settings (user_id) VALUES (?)`, uid); err != nil {
-		return 0, err
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, err
-	}
-	return uid, nil
+	return inTx(s.db, func(tx *sql.Tx) (int64, error) {
+		res, err := tx.Exec(`INSERT INTO users (email, password_hash) VALUES (?, ?)`, email, hash)
+		if err != nil {
+			return 0, err
+		}
+		uid, _ := res.LastInsertId()
+		if _, err := tx.Exec(`INSERT INTO user_settings (user_id) VALUES (?)`, uid); err != nil {
+			return 0, err
+		}
+		return uid, nil
+	})
 }
 
 // Delete removes the user; child rows go via ON DELETE CASCADE (foreign_keys=on).

--- a/backend/stores/user.go
+++ b/backend/stores/user.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// UserStore owns all SQL for the user entity.
+type UserStore struct{ db *sql.DB }
+
+func NewUserStore(db *sql.DB) *UserStore { return &UserStore{db: db} }

--- a/backend/stores/user.go
+++ b/backend/stores/user.go
@@ -1,8 +1,88 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
 
-// UserStore owns all SQL for the user entity.
+	"github.com/Cawlumm/lyftr-backend/models"
+)
+
+// UserStore owns all SQL for users and user_settings.
 type UserStore struct{ db *sql.DB }
 
 func NewUserStore(db *sql.DB) *UserStore { return &UserStore{db: db} }
+
+func (s *UserStore) GetMe(uid int64) (models.User, error) {
+	var u models.User
+	err := s.db.QueryRow(`SELECT id, email, created_at, updated_at FROM users WHERE id = ?`, uid).
+		Scan(&u.ID, &u.Email, &u.CreatedAt, &u.UpdatedAt)
+	return u, err
+}
+
+// GetByEmail loads a user incl. password_hash for login. sql.ErrNoRows if absent.
+func (s *UserStore) GetByEmail(email string) (models.User, error) {
+	var u models.User
+	err := s.db.QueryRow(
+		`SELECT id, email, password_hash, created_at, updated_at FROM users WHERE email = ?`, email,
+	).Scan(&u.ID, &u.Email, &u.Password, &u.CreatedAt, &u.UpdatedAt)
+	return u, err
+}
+
+const userSettingsSelect = `SELECT user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target FROM user_settings`
+
+// GetSettings returns the user's settings row, or sql.ErrNoRows if none (the
+// controller owns the default fallback).
+func (s *UserStore) GetSettings(uid int64) (models.UserSettings, error) {
+	var st models.UserSettings
+	err := s.db.QueryRow(userSettingsSelect+` WHERE user_id = ?`, uid).
+		Scan(&st.UserID, &st.WeightUnit, &st.CalorieTarget, &st.ProteinTarget, &st.CarbTarget, &st.FatTarget)
+	return st, err
+}
+
+// UpsertSettings writes the settings and returns the stored row (no controller-
+// to-controller call to render the response).
+func (s *UserStore) UpsertSettings(uid int64, req models.UpdateSettingsRequest) (models.UserSettings, error) {
+	if _, err := s.db.Exec(
+		`INSERT INTO user_settings (user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   weight_unit    = excluded.weight_unit,
+		   calorie_target = excluded.calorie_target,
+		   protein_target = excluded.protein_target,
+		   carb_target    = excluded.carb_target,
+		   fat_target     = excluded.fat_target`,
+		uid, req.WeightUnit, req.CalorieTarget, req.ProteinTarget, req.CarbTarget, req.FatTarget,
+	); err != nil {
+		return models.UserSettings{}, err
+	}
+	return s.GetSettings(uid)
+}
+
+// Create inserts a user and their default settings atomically (one transaction —
+// fixes the previous non-transactional gap). A duplicate email surfaces as a
+// UNIQUE violation for the controller to map to 409.
+func (s *UserStore) Create(email, hash string) (int64, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(`INSERT INTO users (email, password_hash) VALUES (?, ?)`, email, hash)
+	if err != nil {
+		return 0, err
+	}
+	uid, _ := res.LastInsertId()
+	if _, err := tx.Exec(`INSERT INTO user_settings (user_id) VALUES (?)`, uid); err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return uid, nil
+}
+
+// Delete removes the user; child rows go via ON DELETE CASCADE (foreign_keys=on).
+func (s *UserStore) Delete(uid int64) error {
+	_, err := s.db.Exec(`DELETE FROM users WHERE id = ?`, uid)
+	return err
+}

--- a/backend/stores/weight.go
+++ b/backend/stores/weight.go
@@ -86,41 +86,38 @@ func dayBounds(t time.Time) (time.Time, time.Time) {
 // entry if present, else insert. req.LoggedAt must already be normalized to UTC.
 func (s *WeightStore) UpsertForDay(uid int64, req models.LogWeightRequest) (models.WeightLog, error) {
 	dayStart, dayEnd := dayBounds(req.LoggedAt)
-	// One transaction so the existence check + insert/update is atomic: otherwise
-	// the connection is released between the SELECT and the write, and two same-day
-	// logs can both miss the row and both insert (duplicate day).
-	tx, err := s.db.Begin()
+	// Atomic check-then-write: without the transaction the connection is released
+	// between the SELECT and the write, so two same-day logs could both miss the
+	// row and both insert (duplicate day).
+	id, err := inTx(s.db, func(tx *sql.Tx) (int64, error) {
+		var id int64
+		err := tx.QueryRow(
+			`SELECT id FROM weight_logs WHERE user_id = ? AND logged_at >= ? AND logged_at < ? ORDER BY id DESC LIMIT 1`,
+			uid, dayStart, dayEnd,
+		).Scan(&id)
+		switch err {
+		case nil:
+			if _, e := tx.Exec(
+				`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ?`,
+				req.Weight, req.Notes, req.LoggedAt, id,
+			); e != nil {
+				return 0, e
+			}
+		case sql.ErrNoRows:
+			res, e := tx.Exec(
+				`INSERT INTO weight_logs (user_id, weight, notes, logged_at) VALUES (?, ?, ?, ?)`,
+				uid, req.Weight, req.Notes, req.LoggedAt,
+			)
+			if e != nil {
+				return 0, e
+			}
+			id, _ = res.LastInsertId()
+		default:
+			return 0, err
+		}
+		return id, nil
+	})
 	if err != nil {
-		return models.WeightLog{}, err
-	}
-	defer tx.Rollback()
-
-	var id int64
-	err = tx.QueryRow(
-		`SELECT id FROM weight_logs WHERE user_id = ? AND logged_at >= ? AND logged_at < ? ORDER BY id DESC LIMIT 1`,
-		uid, dayStart, dayEnd,
-	).Scan(&id)
-	switch err {
-	case nil:
-		if _, e := tx.Exec(
-			`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ?`,
-			req.Weight, req.Notes, req.LoggedAt, id,
-		); e != nil {
-			return models.WeightLog{}, e
-		}
-	case sql.ErrNoRows:
-		res, e := tx.Exec(
-			`INSERT INTO weight_logs (user_id, weight, notes, logged_at) VALUES (?, ?, ?, ?)`,
-			uid, req.Weight, req.Notes, req.LoggedAt,
-		)
-		if e != nil {
-			return models.WeightLog{}, e
-		}
-		id, _ = res.LastInsertId()
-	default:
-		return models.WeightLog{}, err
-	}
-	if err := tx.Commit(); err != nil {
 		return models.WeightLog{}, err
 	}
 	return s.get(id)
@@ -129,21 +126,25 @@ func (s *WeightStore) UpsertForDay(uid int64, req models.LogWeightRequest) (mode
 // Update edits an entry the user owns (sql.ErrNoRows if not theirs), then drops
 // any other same-day entry so the day keeps a single entry. req.LoggedAt UTC.
 func (s *WeightStore) Update(uid, id int64, req models.LogWeightRequest) (models.WeightLog, error) {
-	res, err := s.db.Exec(
-		`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ? AND user_id = ?`,
-		req.Weight, req.Notes, req.LoggedAt, id, uid,
-	)
-	if err != nil {
-		return models.WeightLog{}, err
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return models.WeightLog{}, sql.ErrNoRows
-	}
-	dayStart, dayEnd := dayBounds(req.LoggedAt)
-	if _, err := s.db.Exec(
-		`DELETE FROM weight_logs WHERE user_id = ? AND id != ? AND logged_at >= ? AND logged_at < ?`,
-		uid, id, dayStart, dayEnd,
-	); err != nil {
+	// Atomic: the row update + the same-day dedup delete must commit together.
+	if err := inTxDo(s.db, func(tx *sql.Tx) error {
+		res, err := tx.Exec(
+			`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ? AND user_id = ?`,
+			req.Weight, req.Notes, req.LoggedAt, id, uid,
+		)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return sql.ErrNoRows
+		}
+		dayStart, dayEnd := dayBounds(req.LoggedAt)
+		_, err = tx.Exec(
+			`DELETE FROM weight_logs WHERE user_id = ? AND id != ? AND logged_at >= ? AND logged_at < ?`,
+			uid, id, dayStart, dayEnd,
+		)
+		return err
+	}); err != nil {
 		return models.WeightLog{}, err
 	}
 	return s.get(id)

--- a/backend/stores/weight.go
+++ b/backend/stores/weight.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// WeightStore owns all SQL for the weight entity.
+type WeightStore struct{ db *sql.DB }
+
+func NewWeightStore(db *sql.DB) *WeightStore { return &WeightStore{db: db} }

--- a/backend/stores/weight.go
+++ b/backend/stores/weight.go
@@ -1,8 +1,187 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
+	"time"
 
-// WeightStore owns all SQL for the weight entity.
+	"github.com/Cawlumm/lyftr-backend/models"
+)
+
+// WeightStore owns all SQL for the weight_logs entity.
 type WeightStore struct{ db *sql.DB }
 
 func NewWeightStore(db *sql.DB) *WeightStore { return &WeightStore{db: db} }
+
+// WeightFilter holds resolved (already TZ-adjusted) query bounds. The controller
+// owns the calendar-day → UTC-window widening and passes the resolved bounds.
+type WeightFilter struct {
+	Limit, Offset int
+	From, To      *time.Time // nil = unbounded
+}
+
+// WeightStats is the computed summary for GetWeightStats.
+type WeightStats struct {
+	Latest, Starting, Min, Max, Avg float64
+	TotalEntries                    int
+	Change7d, Change30d             float64
+}
+
+const weightCols = `id, user_id, weight, notes, logged_at, created_at`
+
+func (s *WeightStore) List(uid int64, f WeightFilter) ([]models.WeightLog, error) {
+	q := `SELECT ` + weightCols + ` FROM weight_logs WHERE user_id = ?`
+	args := []any{uid}
+	if f.From != nil {
+		q += ` AND logged_at >= ?`
+		args = append(args, *f.From)
+	}
+	if f.To != nil {
+		q += ` AND logged_at < ?`
+		args = append(args, *f.To)
+	}
+	q += ` ORDER BY logged_at DESC, id DESC LIMIT ? OFFSET ?`
+	args = append(args, f.Limit, f.Offset)
+
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	logs := []models.WeightLog{}
+	for rows.Next() {
+		var w models.WeightLog
+		if err := rows.Scan(&w.ID, &w.UserID, &w.Weight, &w.Notes, &w.LoggedAt, &w.CreatedAt); err != nil {
+			return nil, err
+		}
+		logs = append(logs, w)
+	}
+	return logs, rows.Err()
+}
+
+// get reads a single row by id (no user scope — used after a user-scoped write).
+func (s *WeightStore) get(id int64) (models.WeightLog, error) {
+	var w models.WeightLog
+	err := s.db.QueryRow(`SELECT `+weightCols+` FROM weight_logs WHERE id = ?`, id).
+		Scan(&w.ID, &w.UserID, &w.Weight, &w.Notes, &w.LoggedAt, &w.CreatedAt)
+	return w, err
+}
+
+// Get returns one user-owned entry, or sql.ErrNoRows.
+func (s *WeightStore) Get(uid, id int64) (models.WeightLog, error) {
+	var w models.WeightLog
+	err := s.db.QueryRow(`SELECT `+weightCols+` FROM weight_logs WHERE id = ? AND user_id = ?`, id, uid).
+		Scan(&w.ID, &w.UserID, &w.Weight, &w.Notes, &w.LoggedAt, &w.CreatedAt)
+	return w, err
+}
+
+// dayBounds returns [00:00, next 00:00) for the given instant's calendar day.
+// Range match (not SQLite date()) because timestamps store in Go's time.String
+// format which date() can't parse.
+func dayBounds(t time.Time) (time.Time, time.Time) {
+	start := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	return start, start.AddDate(0, 0, 1)
+}
+
+// UpsertForDay enforces one entry per calendar day: update the day's existing
+// entry if present, else insert. req.LoggedAt must already be normalized to UTC.
+func (s *WeightStore) UpsertForDay(uid int64, req models.LogWeightRequest) (models.WeightLog, error) {
+	dayStart, dayEnd := dayBounds(req.LoggedAt)
+	var id int64
+	err := s.db.QueryRow(
+		`SELECT id FROM weight_logs WHERE user_id = ? AND logged_at >= ? AND logged_at < ? ORDER BY id DESC LIMIT 1`,
+		uid, dayStart, dayEnd,
+	).Scan(&id)
+	switch err {
+	case nil:
+		if _, e := s.db.Exec(
+			`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ?`,
+			req.Weight, req.Notes, req.LoggedAt, id,
+		); e != nil {
+			return models.WeightLog{}, e
+		}
+	case sql.ErrNoRows:
+		res, e := s.db.Exec(
+			`INSERT INTO weight_logs (user_id, weight, notes, logged_at) VALUES (?, ?, ?, ?)`,
+			uid, req.Weight, req.Notes, req.LoggedAt,
+		)
+		if e != nil {
+			return models.WeightLog{}, e
+		}
+		id, _ = res.LastInsertId()
+	default:
+		return models.WeightLog{}, err
+	}
+	return s.get(id)
+}
+
+// Update edits an entry the user owns (sql.ErrNoRows if not theirs), then drops
+// any other same-day entry so the day keeps a single entry. req.LoggedAt UTC.
+func (s *WeightStore) Update(uid, id int64, req models.LogWeightRequest) (models.WeightLog, error) {
+	res, err := s.db.Exec(
+		`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ? AND user_id = ?`,
+		req.Weight, req.Notes, req.LoggedAt, id, uid,
+	)
+	if err != nil {
+		return models.WeightLog{}, err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return models.WeightLog{}, sql.ErrNoRows
+	}
+	dayStart, dayEnd := dayBounds(req.LoggedAt)
+	if _, err := s.db.Exec(
+		`DELETE FROM weight_logs WHERE user_id = ? AND id != ? AND logged_at >= ? AND logged_at < ?`,
+		uid, id, dayStart, dayEnd,
+	); err != nil {
+		return models.WeightLog{}, err
+	}
+	return s.get(id)
+}
+
+func (s *WeightStore) Delete(uid, id int64) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM weight_logs WHERE id = ? AND user_id = ?`, id, uid)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+func (s *WeightStore) Stats(uid int64) (WeightStats, error) {
+	var latest, oldest, minW, maxW, avgW sql.NullFloat64
+	var count int
+	err := s.db.QueryRow(
+		`SELECT
+		  (SELECT weight FROM weight_logs WHERE user_id = ? ORDER BY logged_at DESC, id DESC LIMIT 1),
+		  (SELECT weight FROM weight_logs WHERE user_id = ? ORDER BY logged_at ASC, id ASC LIMIT 1),
+		  MIN(weight), MAX(weight), AVG(weight), COUNT(*)
+		 FROM weight_logs WHERE user_id = ?`,
+		uid, uid, uid,
+	).Scan(&latest, &oldest, &minW, &maxW, &avgW, &count)
+	if err != nil {
+		return WeightStats{}, err
+	}
+	return WeightStats{
+		Latest: latest.Float64, Starting: oldest.Float64,
+		Min: minW.Float64, Max: maxW.Float64, Avg: avgW.Float64,
+		TotalEntries: count,
+		Change7d:     s.changeOver(uid, 7),
+		Change30d:    s.changeOver(uid, 30),
+	}, nil
+}
+
+// changeOver returns latest minus earliest weight within the last `days` days,
+// or 0 with fewer than two entries in the window.
+func (s *WeightStore) changeOver(uid int64, days int) float64 {
+	cutoff := time.Now().UTC().AddDate(0, 0, -days)
+	var latest, earliest sql.NullFloat64
+	s.db.QueryRow(
+		`SELECT
+		  (SELECT weight FROM weight_logs WHERE user_id = ? AND logged_at >= ? ORDER BY logged_at DESC, id DESC LIMIT 1),
+		  (SELECT weight FROM weight_logs WHERE user_id = ? AND logged_at >= ? ORDER BY logged_at ASC, id ASC LIMIT 1)`,
+		uid, cutoff, uid, cutoff,
+	).Scan(&latest, &earliest)
+	if !latest.Valid || !earliest.Valid {
+		return 0
+	}
+	return latest.Float64 - earliest.Float64
+}

--- a/backend/stores/weight.go
+++ b/backend/stores/weight.go
@@ -86,21 +86,30 @@ func dayBounds(t time.Time) (time.Time, time.Time) {
 // entry if present, else insert. req.LoggedAt must already be normalized to UTC.
 func (s *WeightStore) UpsertForDay(uid int64, req models.LogWeightRequest) (models.WeightLog, error) {
 	dayStart, dayEnd := dayBounds(req.LoggedAt)
+	// One transaction so the existence check + insert/update is atomic: otherwise
+	// the connection is released between the SELECT and the write, and two same-day
+	// logs can both miss the row and both insert (duplicate day).
+	tx, err := s.db.Begin()
+	if err != nil {
+		return models.WeightLog{}, err
+	}
+	defer tx.Rollback()
+
 	var id int64
-	err := s.db.QueryRow(
+	err = tx.QueryRow(
 		`SELECT id FROM weight_logs WHERE user_id = ? AND logged_at >= ? AND logged_at < ? ORDER BY id DESC LIMIT 1`,
 		uid, dayStart, dayEnd,
 	).Scan(&id)
 	switch err {
 	case nil:
-		if _, e := s.db.Exec(
+		if _, e := tx.Exec(
 			`UPDATE weight_logs SET weight = ?, notes = ?, logged_at = ? WHERE id = ?`,
 			req.Weight, req.Notes, req.LoggedAt, id,
 		); e != nil {
 			return models.WeightLog{}, e
 		}
 	case sql.ErrNoRows:
-		res, e := s.db.Exec(
+		res, e := tx.Exec(
 			`INSERT INTO weight_logs (user_id, weight, notes, logged_at) VALUES (?, ?, ?, ?)`,
 			uid, req.Weight, req.Notes, req.LoggedAt,
 		)
@@ -109,6 +118,9 @@ func (s *WeightStore) UpsertForDay(uid int64, req models.LogWeightRequest) (mode
 		}
 		id, _ = res.LastInsertId()
 	default:
+		return models.WeightLog{}, err
+	}
+	if err := tx.Commit(); err != nil {
 		return models.WeightLog{}, err
 	}
 	return s.get(id)
@@ -160,28 +172,35 @@ func (s *WeightStore) Stats(uid int64) (WeightStats, error) {
 	if err != nil {
 		return WeightStats{}, err
 	}
-	return WeightStats{
+	stats := WeightStats{
 		Latest: latest.Float64, Starting: oldest.Float64,
 		Min: minW.Float64, Max: maxW.Float64, Avg: avgW.Float64,
 		TotalEntries: count,
-		Change7d:     s.changeOver(uid, 7),
-		Change30d:    s.changeOver(uid, 30),
-	}, nil
+	}
+	if stats.Change7d, err = s.changeOver(uid, 7); err != nil {
+		return WeightStats{}, err
+	}
+	if stats.Change30d, err = s.changeOver(uid, 30); err != nil {
+		return WeightStats{}, err
+	}
+	return stats, nil
 }
 
 // changeOver returns latest minus earliest weight within the last `days` days,
 // or 0 with fewer than two entries in the window.
-func (s *WeightStore) changeOver(uid int64, days int) float64 {
+func (s *WeightStore) changeOver(uid int64, days int) (float64, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -days)
 	var latest, earliest sql.NullFloat64
-	s.db.QueryRow(
+	if err := s.db.QueryRow(
 		`SELECT
 		  (SELECT weight FROM weight_logs WHERE user_id = ? AND logged_at >= ? ORDER BY logged_at DESC, id DESC LIMIT 1),
 		  (SELECT weight FROM weight_logs WHERE user_id = ? AND logged_at >= ? ORDER BY logged_at ASC, id ASC LIMIT 1)`,
 		uid, cutoff, uid, cutoff,
-	).Scan(&latest, &earliest)
-	if !latest.Valid || !earliest.Valid {
-		return 0
+	).Scan(&latest, &earliest); err != nil {
+		return 0, err
 	}
-	return latest.Float64 - earliest.Float64
+	if !latest.Valid || !earliest.Valid {
+		return 0, nil
+	}
+	return latest.Float64 - earliest.Float64, nil
 }

--- a/backend/stores/workout.go
+++ b/backend/stores/workout.go
@@ -17,3 +17,62 @@ func (s *WorkoutStore) CountOn(uid int64, date string) (int, error) {
 	).Scan(&n)
 	return n, err
 }
+
+// ExercisePR is the best single set for an exercise (heaviest, then most reps).
+type ExercisePR struct {
+	Weight    float64
+	Reps      int
+	Date      string
+	WorkoutID int64
+}
+
+// ExerciseHistoryPoint is a per-workout rollup for an exercise's progress chart.
+type ExerciseHistoryPoint struct {
+	Date        string  `json:"date"`
+	MaxWeight   float64 `json:"max_weight"`
+	TotalVolume float64 `json:"total_volume"`
+	SetsCount   int     `json:"sets_count"`
+}
+
+// PRForExercise returns the user's PR set for an exercise, or sql.ErrNoRows if
+// they have no qualifying (non-warmup, weighted) set. Reads workout tables — this
+// is workout-derived analytics keyed by exercise, so it lives on WorkoutStore.
+func (s *WorkoutStore) PRForExercise(uid, exerciseID int64) (ExercisePR, error) {
+	var pr ExercisePR
+	err := s.db.QueryRow(`
+		SELECT s.weight, s.reps, w.started_at, w.id
+		FROM sets s
+		JOIN workout_exercises we ON we.id = s.workout_exercise_id
+		JOIN workouts w ON w.id = we.workout_id
+		WHERE w.user_id = ? AND we.exercise_id = ? AND s.is_warmup = 0 AND s.weight > 0
+		ORDER BY s.weight DESC, s.reps DESC
+		LIMIT 1
+	`, uid, exerciseID).Scan(&pr.Weight, &pr.Reps, &pr.Date, &pr.WorkoutID)
+	return pr, err
+}
+
+func (s *WorkoutStore) HistoryForExercise(uid, exerciseID int64, limit int) ([]ExerciseHistoryPoint, error) {
+	rows, err := s.db.Query(`
+		SELECT w.started_at, MAX(s.weight), SUM(s.reps * s.weight), COUNT(s.id)
+		FROM sets s
+		JOIN workout_exercises we ON we.id = s.workout_exercise_id
+		JOIN workouts w ON w.id = we.workout_id
+		WHERE w.user_id = ? AND we.exercise_id = ? AND s.is_warmup = 0
+		GROUP BY w.id
+		ORDER BY w.started_at DESC
+		LIMIT ?
+	`, uid, exerciseID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	history := []ExerciseHistoryPoint{}
+	for rows.Next() {
+		var p ExerciseHistoryPoint
+		if err := rows.Scan(&p.Date, &p.MaxWeight, &p.TotalVolume, &p.SetsCount); err != nil {
+			return nil, err
+		}
+		history = append(history, p)
+	}
+	return history, rows.Err()
+}

--- a/backend/stores/workout.go
+++ b/backend/stores/workout.go
@@ -98,27 +98,24 @@ func (s *WorkoutStore) get(id int64) (models.Workout, error) {
 }
 
 func (s *WorkoutStore) Create(uid int64, req models.CreateWorkoutRequest) (models.Workout, error) {
-	tx, err := s.db.Begin()
+	wid, err := inTx(s.db, func(tx *sql.Tx) (int64, error) {
+		res, err := tx.Exec(
+			`INSERT INTO workouts (user_id, name, notes, duration, started_at) VALUES (?, ?, ?, ?, ?)`,
+			uid, req.Name, req.Notes, req.Duration, req.StartedAt,
+		)
+		if err != nil {
+			return 0, err
+		}
+		wid, err := res.LastInsertId()
+		if err != nil {
+			return 0, err
+		}
+		if err := insertWorkoutExercises(tx, wid, req.Exercises); err != nil {
+			return 0, err
+		}
+		return wid, nil
+	})
 	if err != nil {
-		return models.Workout{}, err
-	}
-	defer tx.Rollback()
-
-	res, err := tx.Exec(
-		`INSERT INTO workouts (user_id, name, notes, duration, started_at) VALUES (?, ?, ?, ?, ?)`,
-		uid, req.Name, req.Notes, req.Duration, req.StartedAt,
-	)
-	if err != nil {
-		return models.Workout{}, err
-	}
-	wid, err := res.LastInsertId()
-	if err != nil {
-		return models.Workout{}, err
-	}
-	if err := insertWorkoutExercises(tx, wid, req.Exercises); err != nil {
-		return models.Workout{}, err
-	}
-	if err := tx.Commit(); err != nil {
 		return models.Workout{}, err
 	}
 	return s.get(wid)
@@ -127,31 +124,24 @@ func (s *WorkoutStore) Create(uid int64, req models.CreateWorkoutRequest) (model
 // Update replaces a user-owned workout and its children in one tx. sql.ErrNoRows
 // if the workout isn't theirs (nothing is mutated).
 func (s *WorkoutStore) Update(uid, id int64, req models.CreateWorkoutRequest) (models.Workout, error) {
-	var ownedID int64
-	if err := s.db.QueryRow(`SELECT id FROM workouts WHERE id = ? AND user_id = ?`, id, uid).Scan(&ownedID); err != nil {
-		return models.Workout{}, err // ErrNoRows = not theirs
-	}
-
-	tx, err := s.db.Begin()
-	if err != nil {
-		return models.Workout{}, err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.Exec(
-		`UPDATE workouts SET name = ?, notes = ?, duration = ?, started_at = ? WHERE id = ?`,
-		req.Name, req.Notes, req.Duration, req.StartedAt, id,
-	); err != nil {
-		return models.Workout{}, err
-	}
-	// Children replaced wholesale; sets cascade-delete with their workout_exercise.
-	if _, err := tx.Exec(`DELETE FROM workout_exercises WHERE workout_id = ?`, id); err != nil {
-		return models.Workout{}, err
-	}
-	if err := insertWorkoutExercises(tx, id, req.Exercises); err != nil {
-		return models.Workout{}, err
-	}
-	if err := tx.Commit(); err != nil {
+	// Ownership check + replace-children, all in one transaction (no TOCTOU).
+	if err := inTxDo(s.db, func(tx *sql.Tx) error {
+		var ownedID int64
+		if err := tx.QueryRow(`SELECT id FROM workouts WHERE id = ? AND user_id = ?`, id, uid).Scan(&ownedID); err != nil {
+			return err // ErrNoRows = not theirs
+		}
+		if _, err := tx.Exec(
+			`UPDATE workouts SET name = ?, notes = ?, duration = ?, started_at = ? WHERE id = ?`,
+			req.Name, req.Notes, req.Duration, req.StartedAt, id,
+		); err != nil {
+			return err
+		}
+		// Children replaced wholesale; sets cascade-delete with their workout_exercise.
+		if _, err := tx.Exec(`DELETE FROM workout_exercises WHERE workout_id = ?`, id); err != nil {
+			return err
+		}
+		return insertWorkoutExercises(tx, id, req.Exercises)
+	}); err != nil {
 		return models.Workout{}, err
 	}
 	return s.get(id)

--- a/backend/stores/workout.go
+++ b/backend/stores/workout.go
@@ -6,3 +6,14 @@ import "database/sql"
 type WorkoutStore struct{ db *sql.DB }
 
 func NewWorkoutStore(db *sql.DB) *WorkoutStore { return &WorkoutStore{db: db} }
+
+// CountOn returns how many workouts the user started on the given calendar day
+// (YYYY-MM-DD). Used by the food daily-stats view (cross-entity composition).
+func (s *WorkoutStore) CountOn(uid int64, date string) (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM workouts WHERE user_id = ? AND substr(started_at, 1, 10) = ?`,
+		uid, date,
+	).Scan(&n)
+	return n, err
+}

--- a/backend/stores/workout.go
+++ b/backend/stores/workout.go
@@ -1,11 +1,263 @@
 package stores
 
-import "database/sql"
+import (
+	"database/sql"
+	"strings"
 
-// WorkoutStore owns all SQL for the workout entity.
+	"github.com/Cawlumm/lyftr-backend/models"
+)
+
+// WorkoutStore owns all SQL for workouts, workout_exercises and sets, plus the
+// workout-derived exercise analytics (PRs/history/daily count).
 type WorkoutStore struct{ db *sql.DB }
 
 func NewWorkoutStore(db *sql.DB) *WorkoutStore { return &WorkoutStore{db: db} }
+
+// WorkoutFilter holds list paging + optional name search.
+type WorkoutFilter struct {
+	Limit, Offset int
+	Query         string
+}
+
+const workoutCols = `id, user_id, name, notes, duration, started_at, created_at`
+
+func scanWorkout(row interface{ Scan(...any) error }, w *models.Workout) error {
+	return row.Scan(&w.ID, &w.UserID, &w.Name, &w.Notes, &w.Duration, &w.StartedAt, &w.CreatedAt)
+}
+
+func (s *WorkoutStore) List(uid int64, f WorkoutFilter) ([]models.Workout, error) {
+	var rows *sql.Rows
+	var err error
+	if f.Query != "" {
+		rows, err = s.db.Query(
+			`SELECT `+workoutCols+` FROM workouts WHERE user_id = ? AND LOWER(name) LIKE ? ORDER BY started_at DESC LIMIT ? OFFSET ?`,
+			uid, "%"+strings.ToLower(f.Query)+"%", f.Limit, f.Offset,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT `+workoutCols+` FROM workouts WHERE user_id = ? ORDER BY started_at DESC LIMIT ? OFFSET ?`,
+			uid, f.Limit, f.Offset,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	workouts := []models.Workout{}
+	for rows.Next() {
+		var w models.Workout
+		if err := scanWorkout(rows, &w); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		workouts = append(workouts, w)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close() // close the parent cursor BEFORE loading children (#36: avoid holding 2 pool connections per request)
+
+	for i := range workouts {
+		ex, err := s.loadExercises(workouts[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		workouts[i].Exercises = ex
+	}
+	return workouts, nil
+}
+
+// Get returns a user-owned workout with its exercises/sets, or sql.ErrNoRows.
+func (s *WorkoutStore) Get(uid, id int64) (models.Workout, error) {
+	var w models.Workout
+	if err := scanWorkout(
+		s.db.QueryRow(`SELECT `+workoutCols+` FROM workouts WHERE id = ? AND user_id = ?`, id, uid), &w,
+	); err != nil {
+		return models.Workout{}, err
+	}
+	ex, err := s.loadExercises(id)
+	if err != nil {
+		return models.Workout{}, err
+	}
+	w.Exercises = ex
+	return w, nil
+}
+
+// get re-reads by id (no user scope) — used after a user-scoped write.
+func (s *WorkoutStore) get(id int64) (models.Workout, error) {
+	var w models.Workout
+	if err := scanWorkout(s.db.QueryRow(`SELECT `+workoutCols+` FROM workouts WHERE id = ?`, id), &w); err != nil {
+		return models.Workout{}, err
+	}
+	ex, err := s.loadExercises(id)
+	if err != nil {
+		return models.Workout{}, err
+	}
+	w.Exercises = ex
+	return w, nil
+}
+
+func (s *WorkoutStore) Create(uid int64, req models.CreateWorkoutRequest) (models.Workout, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return models.Workout{}, err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(
+		`INSERT INTO workouts (user_id, name, notes, duration, started_at) VALUES (?, ?, ?, ?, ?)`,
+		uid, req.Name, req.Notes, req.Duration, req.StartedAt,
+	)
+	if err != nil {
+		return models.Workout{}, err
+	}
+	wid, err := res.LastInsertId()
+	if err != nil {
+		return models.Workout{}, err
+	}
+	if err := insertWorkoutExercises(tx, wid, req.Exercises); err != nil {
+		return models.Workout{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return models.Workout{}, err
+	}
+	return s.get(wid)
+}
+
+// Update replaces a user-owned workout and its children in one tx. sql.ErrNoRows
+// if the workout isn't theirs (nothing is mutated).
+func (s *WorkoutStore) Update(uid, id int64, req models.CreateWorkoutRequest) (models.Workout, error) {
+	var ownedID int64
+	if err := s.db.QueryRow(`SELECT id FROM workouts WHERE id = ? AND user_id = ?`, id, uid).Scan(&ownedID); err != nil {
+		return models.Workout{}, err // ErrNoRows = not theirs
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return models.Workout{}, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(
+		`UPDATE workouts SET name = ?, notes = ?, duration = ?, started_at = ? WHERE id = ?`,
+		req.Name, req.Notes, req.Duration, req.StartedAt, id,
+	); err != nil {
+		return models.Workout{}, err
+	}
+	// Children replaced wholesale; sets cascade-delete with their workout_exercise.
+	if _, err := tx.Exec(`DELETE FROM workout_exercises WHERE workout_id = ?`, id); err != nil {
+		return models.Workout{}, err
+	}
+	if err := insertWorkoutExercises(tx, id, req.Exercises); err != nil {
+		return models.Workout{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return models.Workout{}, err
+	}
+	return s.get(id)
+}
+
+func (s *WorkoutStore) Delete(uid, id int64) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM workouts WHERE id = ? AND user_id = ?`, id, uid)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// insertWorkoutExercises writes the exercises + their sets for a workout within tx.
+func insertWorkoutExercises(tx *sql.Tx, wid int64, exercises []models.CreateWorkoutExerciseReq) error {
+	for i, ex := range exercises {
+		exRes, err := tx.Exec(
+			`INSERT INTO workout_exercises (workout_id, exercise_id, order_index, notes) VALUES (?, ?, ?, ?)`,
+			wid, ex.ExerciseID, i, ex.Notes,
+		)
+		if err != nil {
+			return err
+		}
+		weid, err := exRes.LastInsertId()
+		if err != nil {
+			return err
+		}
+		for j, st := range ex.Sets {
+			if _, err := tx.Exec(
+				`INSERT INTO sets (workout_exercise_id, set_number, reps, weight, duration, distance, rpe, is_warmup)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				weid, j+1, st.Reps, st.Weight, st.Duration, st.Distance, st.RPE, st.IsWarmup,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// loadExercises loads a workout's exercises (JOIN exercises for display) then
+// their sets. Scans + closes the parent cursor fully BEFORE the per-exercise set
+// queries (#36) so a request never holds two pool connections at once.
+func (s *WorkoutStore) loadExercises(workoutID int64) ([]models.WorkoutExercise, error) {
+	rows, err := s.db.Query(
+		`SELECT we.id, we.workout_id, we.exercise_id, we.order_index, we.notes,
+		        e.name, e.muscle_group, e.category, e.equipment, e.image_url
+		 FROM workout_exercises we
+		 JOIN exercises e ON e.id = we.exercise_id
+		 WHERE we.workout_id = ? ORDER BY we.order_index`,
+		workoutID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var exercises []models.WorkoutExercise
+	for rows.Next() {
+		var we models.WorkoutExercise
+		if err := rows.Scan(
+			&we.ID, &we.WorkoutID, &we.ExerciseID, &we.OrderIndex, &we.Notes,
+			&we.Exercise.Name, &we.Exercise.MuscleGroup, &we.Exercise.Category,
+			&we.Exercise.Equipment, &we.Exercise.ImageURL,
+		); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		we.Exercise.ID = we.ExerciseID
+		exercises = append(exercises, we)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+
+	for i := range exercises {
+		sets, err := s.loadSets(exercises[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		exercises[i].Sets = sets
+	}
+	return exercises, nil
+}
+
+func (s *WorkoutStore) loadSets(workoutExerciseID int64) ([]models.Set, error) {
+	rows, err := s.db.Query(
+		`SELECT id, workout_exercise_id, set_number, reps, weight, duration, distance, rpe, is_warmup
+		 FROM sets WHERE workout_exercise_id = ? ORDER BY set_number`,
+		workoutExerciseID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var sets []models.Set
+	for rows.Next() {
+		var st models.Set
+		if err := rows.Scan(&st.ID, &st.WorkoutExerciseID, &st.SetNumber, &st.Reps, &st.Weight, &st.Duration, &st.Distance, &st.RPE, &st.IsWarmup); err != nil {
+			return nil, err
+		}
+		sets = append(sets, st)
+	}
+	return sets, rows.Err()
+}
 
 // CountOn returns how many workouts the user started on the given calendar day
 // (YYYY-MM-DD). Used by the food daily-stats view (cross-entity composition).

--- a/backend/stores/workout.go
+++ b/backend/stores/workout.go
@@ -1,0 +1,8 @@
+package stores
+
+import "database/sql"
+
+// WorkoutStore owns all SQL for the workout entity.
+type WorkoutStore struct{ db *sql.DB }
+
+func NewWorkoutStore(db *sql.DB) *WorkoutStore { return &WorkoutStore{db: db} }

--- a/backend/utils/dberr.go
+++ b/backend/utils/dberr.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+
+	"github.com/gin-gonic/gin"
+	sqlite "modernc.org/sqlite"
+	sqlitelib "modernc.org/sqlite/lib"
+)
+
+// sqliteCode returns the SQLite result code for err, or 0 if err is not a
+// modernc SQLite error.
+func sqliteCode(err error) int {
+	var se *sqlite.Error
+	if errors.As(err, &se) {
+		return se.Code()
+	}
+	return 0
+}
+
+// IsLocked reports whether err is a transient SQLite lock (SQLITE_BUSY /
+// SQLITE_LOCKED), the kind of failure that is worth retrying rather than
+// surfacing as a domain error.
+func IsLocked(err error) bool {
+	switch sqliteCode(err) {
+	case sqlitelib.SQLITE_BUSY, sqlitelib.SQLITE_LOCKED:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsUniqueViolation reports whether err is a UNIQUE/PRIMARY KEY constraint
+// violation, so callers can distinguish a genuine duplicate from any other
+// write failure.
+func IsUniqueViolation(err error) bool {
+	switch sqliteCode(err) {
+	case sqlitelib.SQLITE_CONSTRAINT_UNIQUE, sqlitelib.SQLITE_CONSTRAINT_PRIMARYKEY:
+		return true
+	default:
+		return false
+	}
+}
+
+// DBError maps a database error to an HTTP response and reports whether it wrote
+// one. It deliberately ignores nil and sql.ErrNoRows: "no rows" means something
+// different per endpoint (401, 404, an empty 200), so each caller handles that
+// itself before delegating the rest here:
+//
+//	err := db.DB.QueryRow(...).Scan(...)
+//	if err == sql.ErrNoRows { utils.NotFound(c, "..."); return }
+//	if utils.DBError(c, err) { return }
+//
+// A locked database becomes a 503 the client can retry; anything else is a
+// logged 500. Both lock and unexpected errors are logged so a "database is
+// locked" incident is visible in the server logs instead of masquerading as a
+// bad login or a duplicate email.
+func DBError(c *gin.Context, err error) bool {
+	if err == nil || errors.Is(err, sql.ErrNoRows) {
+		return false
+	}
+	if IsLocked(err) {
+		log.Printf("db locked on %s %s: %v", c.Request.Method, c.Request.URL.Path, err)
+		ServiceUnavailable(c, "the database is busy, please try again in a moment")
+		return true
+	}
+	log.Printf("db error on %s %s: %v", c.Request.Method, c.Request.URL.Path, err)
+	InternalError(c)
+	return true
+}

--- a/backend/utils/dberr.go
+++ b/backend/utils/dberr.go
@@ -44,6 +44,13 @@ func IsUniqueViolation(err error) bool {
 	}
 }
 
+// IsForeignKeyViolation reports whether err is a FOREIGN KEY constraint failure,
+// i.e. a write referencing a row that doesn't exist — a client error, not an
+// internal one.
+func IsForeignKeyViolation(err error) bool {
+	return sqliteCode(err) == sqlitelib.SQLITE_CONSTRAINT_FOREIGNKEY
+}
+
 // DBError maps a database error to an HTTP response and reports whether it wrote
 // one. It deliberately ignores nil and sql.ErrNoRows: "no rows" means something
 // different per endpoint (401, 404, an empty 200), so each caller handles that

--- a/backend/utils/dberr_test.go
+++ b/backend/utils/dberr_test.go
@@ -1,0 +1,121 @@
+package utils
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	_ "modernc.org/sqlite"
+)
+
+func testCtx() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	return c, w
+}
+
+// uniqueErr returns a real modernc UNIQUE-constraint error.
+func uniqueErr(t *testing.T) error {
+	t.Helper()
+	d, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if _, err := d.Exec(`CREATE TABLE t (x TEXT UNIQUE)`); err != nil {
+		t.Fatal(err)
+	}
+	d.Exec(`INSERT INTO t VALUES ('a')`)
+	_, err = d.Exec(`INSERT INTO t VALUES ('a')`)
+	if err == nil {
+		t.Fatal("expected unique violation")
+	}
+	return err
+}
+
+// busyErr returns a real modernc SQLITE_BUSY error by writing from a second
+// connection while a write lock is held on the first.
+func busyErr(t *testing.T) error {
+	t.Helper()
+	path := t.TempDir() + "/busy.db"
+	a, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(0)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	if _, err := a.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := a.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`INSERT INTO t (id) VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	b, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(0)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	_, err = b.Exec(`INSERT INTO t (id) VALUES (2)`)
+	if err == nil {
+		t.Fatal("expected busy error")
+	}
+	return err
+}
+
+func TestClassifiers(t *testing.T) {
+	uniq := uniqueErr(t)
+	busy := busyErr(t)
+
+	if !IsUniqueViolation(uniq) {
+		t.Errorf("IsUniqueViolation(unique) = false, want true")
+	}
+	if IsLocked(uniq) {
+		t.Errorf("IsLocked(unique) = true, want false")
+	}
+	if !IsLocked(busy) {
+		t.Errorf("IsLocked(busy) = false, want true")
+	}
+	if IsUniqueViolation(busy) {
+		t.Errorf("IsUniqueViolation(busy) = true, want false")
+	}
+	if IsLocked(errors.New("plain")) || IsUniqueViolation(errors.New("plain")) {
+		t.Errorf("plain error should classify as neither")
+	}
+}
+
+func TestDBError(t *testing.T) {
+	busy := busyErr(t)
+
+	cases := []struct {
+		name     string
+		err      error
+		handled  bool
+		wantCode int
+	}{
+		{"nil", nil, false, http.StatusOK},                    // 200 = recorder default, nothing written
+		{"no rows", sql.ErrNoRows, false, http.StatusOK},      // caller's responsibility
+		{"locked", busy, true, http.StatusServiceUnavailable}, // retryable 503
+		{"generic", errors.New("boom"), true, http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, w := testCtx()
+			if got := DBError(c, tc.err); got != tc.handled {
+				t.Fatalf("DBError handled = %v, want %v", got, tc.handled)
+			}
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", w.Code, tc.wantCode)
+			}
+		})
+	}
+}

--- a/backend/utils/response.go
+++ b/backend/utils/response.go
@@ -33,3 +33,14 @@ func InternalError(c *gin.Context) {
 func ValidationError(c *gin.Context, err error) {
 	c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 }
+
+func Conflict(c *gin.Context, msg string) {
+	c.JSON(http.StatusConflict, gin.H{"error": msg})
+}
+
+// ServiceUnavailable signals a transient failure the client may retry, such as
+// a busy/locked database.
+func ServiceUnavailable(c *gin.Context, msg string) {
+	c.Header("Retry-After", "2")
+	c.JSON(http.StatusServiceUnavailable, gin.H{"error": msg})
+}


### PR DESCRIPTION
## What & why

Controllers were building and running SQL inline (114 `db.DB.` calls across 8 controllers). This moves **all** of it into a per-entity **store layer** (repository pattern): only stores touch the database; controllers do HTTP only (bind → validate → call store → map result/error). Since we were already in this code, this **absorbs three in-flight fixes** into one MR instead of merging them piecemeal.

**Supersedes #32, #36, #38. Closes #29.** (Also fixes the underlying #25 production 500 and #30 pool deadlock.)

## Architecture (full constructor injection)

- New `backend/stores` package — one store per entity (`Weight`/`Food`/`User`/`Exercise`/`Workout`/`Program`/`ActiveSession`), aggregated by `stores.Stores` + `New(db)`. Stores own all SQL + transactions, return models + raw errors, and import neither `gin` nor `utils`.
- Controllers are methods on `controllers.Handler{ s *stores.Stores }`; `routes.Setup(r, h)` injects it; `main` wires `stores.New(db.DB) → NewHandler`.
- `utils.DBError(c, err)` is the standard controller tail (lock → 503 retryable, else → 500); unique violations → 409.

## Absorbed fixes

- **#32 (prod 500):** the mattn-style DSN params were silently ignored by `modernc.org/sqlite`, leaving `busy_timeout` at 0 → contended writes 500'd instantly. DSN now uses `_pragma=…` (busy_timeout + WAL + synchronous + **foreign_keys(on)** — #32 had accidentally dropped FK). Adds `utils/dberr.go` + `Conflict`/`ServiceUnavailable`.
- **#36 (pool deadlock):** list loaders now scan + close the parent cursor **before** loading children, so a request never needs two pool connections; scan errors are surfaced, not swallowed.
- **#38 (reseed race):** atomic `CompareAndSwap` seed guard.

## Working *with* SQLite, not against it

SQLite is a single writer. Rather than fight that with a larger pool (which just turns contention into lock errors to retry), `MaxOpenConns(1)` serializes all DB access through one connection — safe now that #36 means no request needs a second connection mid-query, so there's no in-process lock contention to fail on. WAL/busy_timeout remain only as cheap cross-process defense.

## Verification

- `go build ./... && go test ./...` green at **every commit** (11 commits, each compiles + passes).
- Folds in the #32 lock tests (503-on-lock, 409-on-duplicate) and #36 concurrency tests (pool=2, 6 goroutines, deadlock guard) — adapted to DI.
- New `TestDeleteAccountCascadesChildren` guards the FK-cascade behavior — and **exposed a latent test bug**: the harness DSN also used the ignored `_foreign_keys=on`, so the suite had been running with FK enforcement *off*. Fixed to `_pragma=foreign_keys(on)` so tests match production.
- **Playwright e2e: 87 passed, 1 skipped** against the rebuilt backend (chromium + mobile), all test accounts swept clean.
- `grep db.DB. backend/controllers/*.go` → **zero** live references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
