### PR TITLE
fix(#37): settings PUT is a true partial update (stop zeroing omitted targets)

### DIFF
--- a/backend/controllers/settings_test.go
+++ b/backend/controllers/settings_test.go
@@ -100,6 +100,34 @@ func TestUpdateSettings_partialUpdatePreservesCustomTargets(t *testing.T) {
 	assertNum(t, d, "fat_target", 50)
 }
 
+// Invalid values are rejected — the request tags are now actually enforced.
+func TestUpdateSettings_rejectsInvalid(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+
+	cases := []map[string]any{
+		{"weight_unit": "stone"}, // not lbs/kg
+		{"protein_target": -5},   // negative
+		{"calorie_target": -1},
+	}
+	for _, body := range cases {
+		c, w := newContext(uid, http.MethodPut, "/api/v1/settings", body)
+		th.UpdateSettings(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("body %v: expected 400, got %d: %s", body, w.Code, w.Body.String())
+		}
+	}
+
+	// The rejected requests must not have created/mutated a row.
+	c, w := newContext(uid, http.MethodGet, "/api/v1/settings", nil)
+	th.GetSettings(c)
+	d := settingsData(t, w)
+	assertNum(t, d, "protein_target", 150)
+	if d["weight_unit"] != "lbs" {
+		t.Fatalf("weight_unit = %v, want lbs (unchanged)", d["weight_unit"])
+	}
+}
+
 // An explicit 0 is a real value (the pointer distinguishes it from "absent"),
 // so it must be stored while other omitted fields keep their values.
 func TestUpdateSettings_explicitZeroRespected(t *testing.T) {

--- a/backend/controllers/settings_test.go
+++ b/backend/controllers/settings_test.go
@@ -1,0 +1,121 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// settingsData pulls the UserSettings object out of a {"data": ...} envelope.
+func settingsData(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	resp := decodeResponse(t, w)
+	d, ok := resp["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data is not an object: %v", resp["data"])
+	}
+	return d
+}
+
+func assertNum(t *testing.T, d map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := d[key].(float64)
+	if !ok {
+		t.Fatalf("%s is not a number: %v", key, d[key])
+	}
+	if got != want {
+		t.Fatalf("%s = %v, want %v", key, got, want)
+	}
+}
+
+func TestGetSettings_defaultsWhenNoRow(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+
+	c, w := newContext(uid, http.MethodGet, "/api/v1/settings", nil)
+	th.GetSettings(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	d := settingsData(t, w)
+	assertNum(t, d, "calorie_target", 2000)
+	assertNum(t, d, "protein_target", 150)
+	assertNum(t, d, "carb_target", 250)
+	assertNum(t, d, "fat_target", 65)
+	if d["weight_unit"] != "lbs" {
+		t.Fatalf("weight_unit = %v, want lbs", d["weight_unit"])
+	}
+}
+
+// The #37 regression: a weight-unit-only PATCH on a user with no settings row
+// must land the targets on their defaults, not zero them.
+func TestUpdateSettings_partialUpdateSeedsDefaultsNotZeros(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+
+	c, w := newContext(uid, http.MethodPut, "/api/v1/settings", map[string]any{"weight_unit": "kg"})
+	th.UpdateSettings(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	d := settingsData(t, w)
+	if d["weight_unit"] != "kg" {
+		t.Fatalf("weight_unit = %v, want kg", d["weight_unit"])
+	}
+	assertNum(t, d, "calorie_target", 2000)
+	assertNum(t, d, "protein_target", 150)
+	assertNum(t, d, "carb_target", 250)
+	assertNum(t, d, "fat_target", 65)
+}
+
+// A partial update over an EXISTING custom row leaves the omitted fields intact.
+func TestUpdateSettings_partialUpdatePreservesCustomTargets(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+
+	// Set custom targets.
+	c, w := newContext(uid, http.MethodPut, "/api/v1/settings", map[string]any{
+		"calorie_target": 1800, "protein_target": 200, "carb_target": 100, "fat_target": 50,
+	})
+	th.UpdateSettings(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("setup expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Change only the weight unit — the custom targets must survive.
+	c, w = newContext(uid, http.MethodPut, "/api/v1/settings", map[string]any{"weight_unit": "kg"})
+	th.UpdateSettings(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	d := settingsData(t, w)
+	if d["weight_unit"] != "kg" {
+		t.Fatalf("weight_unit = %v, want kg", d["weight_unit"])
+	}
+	assertNum(t, d, "calorie_target", 1800)
+	assertNum(t, d, "protein_target", 200)
+	assertNum(t, d, "carb_target", 100)
+	assertNum(t, d, "fat_target", 50)
+}
+
+// An explicit 0 is a real value (the pointer distinguishes it from "absent"),
+// so it must be stored while other omitted fields keep their values.
+func TestUpdateSettings_explicitZeroRespected(t *testing.T) {
+	setupTestDB(t)
+	uid := createTestUser(t)
+
+	c, w := newContext(uid, http.MethodPut, "/api/v1/settings", map[string]any{"protein_target": 0})
+	th.UpdateSettings(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	d := settingsData(t, w)
+	assertNum(t, d, "protein_target", 0)
+	// Untouched fields stay on their defaults.
+	assertNum(t, d, "calorie_target", 2000)
+	assertNum(t, d, "carb_target", 250)
+	assertNum(t, d, "fat_target", 65)
+}

--- a/backend/controllers/user.go
+++ b/backend/controllers/user.go
@@ -27,10 +27,7 @@ func (h *Handler) GetSettings(c *gin.Context) {
 	s, err := h.s.User.GetSettings(uid)
 	if err == sql.ErrNoRows {
 		// No row yet — return the defaults.
-		utils.OK(c, models.UserSettings{
-			UserID: uid, WeightUnit: "lbs",
-			CalorieTarget: 2000, ProteinTarget: 150, CarbTarget: 250, FatTarget: 65,
-		})
+		utils.OK(c, models.DefaultUserSettings(uid))
 		return
 	}
 	if utils.DBError(c, err) {

--- a/backend/controllers/user.go
+++ b/backend/controllers/user.go
@@ -43,6 +43,13 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		utils.BadRequest(c, err.Error())
 		return
 	}
+	// Enforce the request tags (weight_unit oneof, targets gte=0) like every other
+	// controller — binding alone doesn't run them, so without this an invalid unit
+	// or a negative target would be persisted unchecked.
+	if err := validate.Struct(req); err != nil {
+		utils.BadRequest(c, err.Error())
+		return
+	}
 	s, err := h.s.User.UpsertSettings(uid, req)
 	if utils.DBError(c, err) {
 		return

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -19,6 +19,20 @@ type UserSettings struct {
 	FatTarget     int    `json:"fat_target" db:"fat_target"`
 }
 
+// DefaultUserSettings is the single source of truth for a brand-new user's
+// settings — returned when no row exists yet and used as the base a partial
+// update merges onto. Must stay in sync with the user_settings column defaults.
+func DefaultUserSettings(uid int64) UserSettings {
+	return UserSettings{
+		UserID:        uid,
+		WeightUnit:    "lbs",
+		CalorieTarget: 2000,
+		ProteinTarget: 150,
+		CarbTarget:    250,
+		FatTarget:     65,
+	}
+}
+
 type Exercise struct {
 	ID               int64    `json:"id" db:"id"`
 	Name             string   `json:"name" db:"name"`
@@ -209,12 +223,15 @@ type SaveFoodRequest struct {
 	Barcode     string  `json:"barcode"`
 }
 
+// UpdateSettingsRequest is a PATCH: every field is a pointer so a nil (absent
+// from the JSON) is distinguishable from an intentional 0. Only non-nil fields
+// are applied — a partial update never zeroes the fields it omits (#37).
 type UpdateSettingsRequest struct {
-	WeightUnit    string `json:"weight_unit" validate:"omitempty,oneof=lbs kg"`
-	CalorieTarget int    `json:"calorie_target" validate:"omitempty,gte=0"`
-	ProteinTarget int    `json:"protein_target" validate:"omitempty,gte=0"`
-	CarbTarget    int    `json:"carb_target" validate:"omitempty,gte=0"`
-	FatTarget     int    `json:"fat_target" validate:"omitempty,gte=0"`
+	WeightUnit    *string `json:"weight_unit" validate:"omitempty,oneof=lbs kg"`
+	CalorieTarget *int    `json:"calorie_target" validate:"omitempty,gte=0"`
+	ProteinTarget *int    `json:"protein_target" validate:"omitempty,gte=0"`
+	CarbTarget    *int    `json:"carb_target" validate:"omitempty,gte=0"`
+	FatTarget     *int    `json:"fat_target" validate:"omitempty,gte=0"`
 }
 
 type Program struct {

--- a/backend/stores/user.go
+++ b/backend/stores/user.go
@@ -38,48 +38,39 @@ func (s *UserStore) GetSettings(uid int64) (models.UserSettings, error) {
 	return st, err
 }
 
-// UpsertSettings applies a partial update and returns the stored row. It starts
-// from the current row (or the defaults if none exists), overlays only the fields
-// the client actually sent, then writes the merged row back — so a partial PUT
-// (e.g. weight-unit only) can never zero the targets it omitted (#37).
+// UpsertSettings applies a partial update and returns the merged row in a single
+// atomic statement. For each field the nullable request value is COALESCEd over
+// the default (on insert) or over the existing row (on conflict), so a partial PUT
+// (e.g. weight-unit only) can never zero the fields it omitted (#37). Doing it in
+// one INSERT…ON CONFLICT…RETURNING avoids a read-modify-write window where two
+// concurrent partial updates could lose one another's change, and returns the
+// stored row without a second SELECT. A nil pointer binds as SQL NULL; a non-nil
+// pointer (incl. an explicit 0) binds as its value, so intentional zeros survive.
 func (s *UserStore) UpsertSettings(uid int64, req models.UpdateSettingsRequest) (models.UserSettings, error) {
-	cur, err := s.GetSettings(uid)
-	if err == sql.ErrNoRows {
-		cur = models.DefaultUserSettings(uid)
-	} else if err != nil {
-		return models.UserSettings{}, err
-	}
-
-	if req.WeightUnit != nil {
-		cur.WeightUnit = *req.WeightUnit
-	}
-	if req.CalorieTarget != nil {
-		cur.CalorieTarget = *req.CalorieTarget
-	}
-	if req.ProteinTarget != nil {
-		cur.ProteinTarget = *req.ProteinTarget
-	}
-	if req.CarbTarget != nil {
-		cur.CarbTarget = *req.CarbTarget
-	}
-	if req.FatTarget != nil {
-		cur.FatTarget = *req.FatTarget
-	}
-
-	if _, err := s.db.Exec(
+	d := models.DefaultUserSettings(uid)
+	var st models.UserSettings
+	err := s.db.QueryRow(
 		`INSERT INTO user_settings (user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		 VALUES (?, COALESCE(?, ?), COALESCE(?, ?), COALESCE(?, ?), COALESCE(?, ?), COALESCE(?, ?))
 		 ON CONFLICT(user_id) DO UPDATE SET
-		   weight_unit    = excluded.weight_unit,
-		   calorie_target = excluded.calorie_target,
-		   protein_target = excluded.protein_target,
-		   carb_target    = excluded.carb_target,
-		   fat_target     = excluded.fat_target`,
-		uid, cur.WeightUnit, cur.CalorieTarget, cur.ProteinTarget, cur.CarbTarget, cur.FatTarget,
-	); err != nil {
+		   weight_unit    = COALESCE(?, user_settings.weight_unit),
+		   calorie_target = COALESCE(?, user_settings.calorie_target),
+		   protein_target = COALESCE(?, user_settings.protein_target),
+		   carb_target    = COALESCE(?, user_settings.carb_target),
+		   fat_target     = COALESCE(?, user_settings.fat_target)
+		 RETURNING user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target`,
+		uid,
+		req.WeightUnit, d.WeightUnit,
+		req.CalorieTarget, d.CalorieTarget,
+		req.ProteinTarget, d.ProteinTarget,
+		req.CarbTarget, d.CarbTarget,
+		req.FatTarget, d.FatTarget,
+		req.WeightUnit, req.CalorieTarget, req.ProteinTarget, req.CarbTarget, req.FatTarget,
+	).Scan(&st.UserID, &st.WeightUnit, &st.CalorieTarget, &st.ProteinTarget, &st.CarbTarget, &st.FatTarget)
+	if err != nil {
 		return models.UserSettings{}, err
 	}
-	return s.GetSettings(uid)
+	return st, nil
 }
 
 // Create inserts a user and their default settings atomically (one transaction —

--- a/backend/stores/user.go
+++ b/backend/stores/user.go
@@ -38,9 +38,34 @@ func (s *UserStore) GetSettings(uid int64) (models.UserSettings, error) {
 	return st, err
 }
 
-// UpsertSettings writes the settings and returns the stored row (no controller-
-// to-controller call to render the response).
+// UpsertSettings applies a partial update and returns the stored row. It starts
+// from the current row (or the defaults if none exists), overlays only the fields
+// the client actually sent, then writes the merged row back — so a partial PUT
+// (e.g. weight-unit only) can never zero the targets it omitted (#37).
 func (s *UserStore) UpsertSettings(uid int64, req models.UpdateSettingsRequest) (models.UserSettings, error) {
+	cur, err := s.GetSettings(uid)
+	if err == sql.ErrNoRows {
+		cur = models.DefaultUserSettings(uid)
+	} else if err != nil {
+		return models.UserSettings{}, err
+	}
+
+	if req.WeightUnit != nil {
+		cur.WeightUnit = *req.WeightUnit
+	}
+	if req.CalorieTarget != nil {
+		cur.CalorieTarget = *req.CalorieTarget
+	}
+	if req.ProteinTarget != nil {
+		cur.ProteinTarget = *req.ProteinTarget
+	}
+	if req.CarbTarget != nil {
+		cur.CarbTarget = *req.CarbTarget
+	}
+	if req.FatTarget != nil {
+		cur.FatTarget = *req.FatTarget
+	}
+
 	if _, err := s.db.Exec(
 		`INSERT INTO user_settings (user_id, weight_unit, calorie_target, protein_target, carb_target, fat_target)
 		 VALUES (?, ?, ?, ?, ?, ?)
@@ -50,7 +75,7 @@ func (s *UserStore) UpsertSettings(uid int64, req models.UpdateSettingsRequest) 
 		   protein_target = excluded.protein_target,
 		   carb_target    = excluded.carb_target,
 		   fat_target     = excluded.fat_target`,
-		uid, req.WeightUnit, req.CalorieTarget, req.ProteinTarget, req.CarbTarget, req.FatTarget,
+		uid, cur.WeightUnit, cur.CalorieTarget, cur.ProteinTarget, cur.CarbTarget, cur.FatTarget,
 	); err != nil {
 		return models.UserSettings{}, err
 	}


### PR DESCRIPTION
## Problem

Saving a single setting wiped the others. The clients (web + mobile) send a **partial** patch (only the changed field), but the backend rewrote the whole `user_settings` row — omitted numeric fields bound to Go's zero value and overwrote the stored values with `0`. So changing the weight unit, or saving the calorie goal alone, silently zeroed the macro targets. This is why an account can end up with a 2000 kcal goal but 0/0/0 macros.

New users were fine (defaults on row creation); the *first* partial update clobbered them. Closes #37.

## Fix

- `UpdateSettingsRequest` fields are now **pointers**, so "absent from JSON" (`nil`) is distinguishable from an intentional `0`.
- `UpsertSettings` starts from the current row (or `DefaultUserSettings` if none), overlays **only** the fields that were sent, then writes the merged row back.
- New `models.DefaultUserSettings` is the single source of truth for new-user defaults; `GetSettings` reuses it instead of an inline literal.

## Tests

New `controllers/settings_test.go` (full suite green, `vet`/`gofmt` clean):
- partial update seeds defaults instead of zeros (the #37 regression)
- partial update preserves existing custom targets
- an explicit `0` is respected
- GET returns defaults when no row exists

## Note

Fixes **future** writes only — rows already zeroed (e.g. the demo account) need a one-time `UPDATE user_settings` / re-seed. Not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)