### PR TITLE
docs(mobile): Android APK download + separate release trains

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -144,6 +144,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: lyftr-${{ github.ref_name }}.apk
+          make_latest: false # separate release train; keep mobile out of the repo-wide Latest
+          prerelease: true # Android betas ship as prereleases (like the web betas)
           generate_release_notes: true
           body: |
             ### Android (side-load)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <p align="center">
-  <a href="https://github.com/Cawlumm/lyftr/releases/latest"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?include_prereleases&label=release&color=6366f1" alt="Latest release" /></a>
+  <a href="https://github.com/Cawlumm/lyftr/releases?q=v0"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?filter=v*&label=release&color=6366f1" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <img src="https://img.shields.io/badge/status-beta-orange" alt="Beta" />
   <a href="https://selfh.st/weekly/2026-04-24/"><img src="https://img.shields.io/badge/Featured%20in-selfh.st%20%C2%B7%20Apr%202026-6366f1" alt="Featured in selfh.st" /></a>
+  <a href="https://github.com/Cawlumm/lyftr/releases?q=mobile-v"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?filter=mobile-v*&label=Android&logo=android&logoColor=white&color=3ddc84" alt="Android APK" /></a>
   <img src="https://img.shields.io/badge/iOS-planned-black?logo=apple&logoColor=white" alt="iOS Planned" />
   <a href="https://discord.gg/hfFWsrebQA"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Join Discord" /></a>
 </p>
@@ -16,6 +17,24 @@
 > **Beta** — actively being built. Expect rough edges and frequent updates. Issues and feedback are welcome. The software equivalent of going to the gym for the first time.
 
 > 🌐 **[Live demo → lyftr-demo.fly.dev](https://lyftr-demo.fly.dev)** — log in with `demo@lyftr.local` / `password123`. Shared instance, resets every hour.
+
+---
+
+## 📱 Get the app
+
+<a href="https://github.com/Cawlumm/lyftr/releases?q=mobile-v"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?filter=mobile-v*&label=Download%20Android%20APK&logo=android&logoColor=white&color=3ddc84" alt="Download Android APK" /></a>
+
+**Android** — download the latest signed APK from the [Releases](https://github.com/Cawlumm/lyftr/releases?q=mobile-v) page, or grab the current build directly:
+
+**[⬇️  Download the Android APK](https://github.com/Cawlumm/lyftr/releases/download/mobile-v0.1.0/lyftr-mobile-v0.1.0.apk)**  (`mobile-v0.1.0`, ~102 MB)
+
+1. Open the `.apk` on your Android phone.
+2. Allow **"install from unknown sources"** if prompted.
+3. Launch Lyftr and point it at your server.
+
+> Side-loaded builds don't auto-update — when a new `mobile-v*` release drops, download and install it over the old one.
+
+**iOS** — planned. Apple doesn't allow side-loading, so iOS will ship via **TestFlight** / the App Store once the Apple Developer account is set up.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <img src="docs/banner.png" alt="Lyftr — Self-hosted workout tracking" width="100%" />
 </p>
 
+> 📱 **The Lyftr Android app is live — [download the APK](https://github.com/Cawlumm/lyftr/releases/download/mobile-v0.1.0/lyftr-mobile-v0.1.0.apk)** and track your workouts on your phone. This is an early beta — more polish, auto-updating store builds, and an iOS version are on the way.
+
 > 🎉 **First beta release is live — [`v0.1.0-beta.1`](https://github.com/Cawlumm/lyftr/releases/tag/v0.1.0-beta.1).** Workouts, programs, gym mode, dashboard, weight, and the new nutrition tracker are all in. Pin this tag for a stable self-host target instead of tracking `main`.
 
 > **Beta** — actively being built. Expect rough edges and frequent updates. Issues and feedback are welcome. The software equivalent of going to the gym for the first time.


### PR DESCRIPTION
## What

Documents the Android beta rollout and fixes a monorepo release-train collision.

### README
- **New "📱 Get the app" section** — Android APK download link, size, and side-load steps.
- **Filtered the self-host release badge to `v*`** and added an **Android `mobile-v*` badge**, so the web and mobile version badges track their own tags instead of whichever tag was cut most recently.

### `eas-build.yml`
- Mobile releases now set **`make_latest: false`** + **`prerelease: true`**, so a `mobile-v*` tag no longer steals the repo-wide **"Latest"** that self-hosters use.

## Why
Publishing `mobile-v0.1.0` made the phone APK the repo's "Latest" release — so the self-host badge and `/releases/latest` link started pointing at the Android app instead of the web/server release. Separate release trains should keep separate "latest". (Already corrected `mobile-v0.1.0` to prerelease on the live release.)

## Rollout pattern
Android beta = APK on a GitHub Release, linked from README + Discord. iOS via TestFlight later (needs Apple Developer account).