### PR TITLE
chore(site): rename Pages project → lyftr-app (cleaner pages.dev)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -54,7 +54,7 @@ jobs:
           # Cloudflare Pages serves at the domain root — no '/lyftr' base path. Canonical/OG
           # point at the stable production URL even from preview builds (avoids duplicate-content).
           SITE_BASE: /
-          SITE_URL: https://lyftr.pages.dev # → https://lyftr.dev once the custom domain is added
+          SITE_URL: https://lyftr-app.pages.dev # → https://lyftr.dev once the custom domain is added
 
       # The Pages project is provisioned by Terraform (infra/cloudflare/ + infra.yml) — run that
       # apply once before the first deploy. This workflow only pushes content to it.
@@ -67,4 +67,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # main → production; any other branch → a preview deployment with its own URL.
-          command: pages deploy site/dist --project-name=lyftr --branch=${{ github.ref_name }}
+          command: pages deploy site/dist --project-name=lyftr-app --branch=${{ github.ref_name }}

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -8,7 +8,7 @@ variable "cloudflare_account_id" {
 # itself. `main` is the production branch; every other branch becomes a preview deployment.
 resource "cloudflare_pages_project" "lyftr" {
   account_id        = var.cloudflare_account_id
-  name              = "lyftr"
+  name              = "lyftr-app"
   production_branch = "main"
 }
 


### PR DESCRIPTION
Global `lyftr.pages.dev` was taken (we got `lyftr-xbr`). Rename the Pages project to `lyftr-app` → **lyftr-app.pages.dev**.

- `infra/cloudflare/main.tf`: project `name` lyftr → lyftr-app (Terraform **replaces** the project)
- `.github/workflows/site.yml`: `--project-name` + `SITE_URL` → lyftr-app

Apply gated on the `production-infra` environment (your approval). Nothing valuable in the old project — it just redeploys.