### PR TITLE
fix(fly): hourly demo reset silently no-ops under WAL mode

### DIFF
--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -45,7 +45,8 @@ COPY fly/nginx.fly.conf /etc/nginx/conf.d/default.conf
 # sed strips Windows \r\n → \n so the #!/bin/sh shebang works on Linux
 COPY fly/entrypoint.sh /app/entrypoint.sh
 COPY fly/reset.sh      /app/reset.sh
-RUN sed -i 's/\r$//' /app/entrypoint.sh /app/reset.sh && chmod +x /app/entrypoint.sh /app/reset.sh
+COPY fly/snapshot.sh   /app/snapshot.sh
+RUN sed -i 's/\r$//' /app/entrypoint.sh /app/reset.sh /app/snapshot.sh && chmod +x /app/entrypoint.sh /app/reset.sh /app/snapshot.sh
 
 # /app/data is a Fly volume mount — this mkdir is a fallback for local testing
 RUN mkdir -p /app/data

--- a/fly/SETUP.md
+++ b/fly/SETUP.md
@@ -49,8 +49,14 @@ The first deploy will:
 Once exercises and demo data are fully seeded (~60s after first deploy):
 
 ```bash
-fly ssh console --app lyftr-demo -C "cp /app/data/lyftr.db /app/data/lyftr.seed.db"
+fly ssh console --app lyftr-demo -C "sh -c 'pkill lyftr-api 2>/dev/null; sleep 2; cp /app/data/lyftr.db /app/data/lyftr.seed.db; [ -f /app/data/lyftr.db-wal ] && cp /app/data/lyftr.db-wal /app/data/lyftr.seed.db-wal; [ -f /app/data/lyftr.db-shm ] && cp /app/data/lyftr.db-shm /app/data/lyftr.seed.db-shm; true'"
 ```
+
+The DB runs in WAL mode, so recent writes can still be sitting in `lyftr.db-wal`
+rather than folded into `lyftr.db` — stopping the backend first (it restarts on
+its own within seconds) and copying the `-wal`/`-shm` side files too, when
+present, keeps the snapshot from silently missing whatever hasn't been
+checkpointed yet.
 
 From this point the hourly cron (`reset.sh`) will restore this snapshot every hour,
 keeping the demo clean regardless of what visitors do.
@@ -70,14 +76,18 @@ Update `CORS_ORIGIN` in `fly.toml` and redeploy.
 # Check logs
 fly logs --app lyftr-demo
 
+# Check the reset job's own log (persists across restarts/redeploys)
+fly ssh console --app lyftr-demo -C "cat /app/data/reset.log"
+
 # Manual reset
 fly ssh console --app lyftr-demo -C "/app/reset.sh"
 
 # Redeploy after code changes
 fly deploy --app lyftr-demo
 
-# Update seed snapshot after improving demo data
-fly ssh console --app lyftr-demo -C "cp /app/data/lyftr.db /app/data/lyftr.seed.db"
+# Update seed snapshot after improving demo data (see step 5 for why the
+# -wal/-shm side files matter too)
+fly ssh console --app lyftr-demo -C "sh -c 'pkill lyftr-api 2>/dev/null; sleep 2; cp /app/data/lyftr.db /app/data/lyftr.seed.db; [ -f /app/data/lyftr.db-wal ] && cp /app/data/lyftr.db-wal /app/data/lyftr.seed.db-wal; [ -f /app/data/lyftr.db-shm ] && cp /app/data/lyftr.db-shm /app/data/lyftr.seed.db-shm; true'"
 ```
 
 ## Architecture

--- a/fly/SETUP.md
+++ b/fly/SETUP.md
@@ -49,14 +49,14 @@ The first deploy will:
 Once exercises and demo data are fully seeded (~60s after first deploy):
 
 ```bash
-fly ssh console --app lyftr-demo -C "sh -c 'pkill lyftr-api 2>/dev/null; sleep 2; cp /app/data/lyftr.db /app/data/lyftr.seed.db; [ -f /app/data/lyftr.db-wal ] && cp /app/data/lyftr.db-wal /app/data/lyftr.seed.db-wal; [ -f /app/data/lyftr.db-shm ] && cp /app/data/lyftr.db-shm /app/data/lyftr.seed.db-shm; true'"
+fly ssh console --app lyftr-demo -C "/app/snapshot.sh"
 ```
 
 The DB runs in WAL mode, so recent writes can still be sitting in `lyftr.db-wal`
-rather than folded into `lyftr.db` — stopping the backend first (it restarts on
-its own within seconds) and copying the `-wal`/`-shm` side files too, when
-present, keeps the snapshot from silently missing whatever hasn't been
-checkpointed yet.
+rather than folded into `lyftr.db` — `snapshot.sh` stops the backend first (it
+restarts on its own within seconds, same as `reset.sh`) and copies the
+`-wal`/`-shm` side files too, when present, so the snapshot doesn't silently
+miss whatever hasn't been checkpointed yet.
 
 From this point the hourly cron (`reset.sh`) will restore this snapshot every hour,
 keeping the demo clean regardless of what visitors do.
@@ -85,9 +85,8 @@ fly ssh console --app lyftr-demo -C "/app/reset.sh"
 # Redeploy after code changes
 fly deploy --app lyftr-demo
 
-# Update seed snapshot after improving demo data (see step 5 for why the
-# -wal/-shm side files matter too)
-fly ssh console --app lyftr-demo -C "sh -c 'pkill lyftr-api 2>/dev/null; sleep 2; cp /app/data/lyftr.db /app/data/lyftr.seed.db; [ -f /app/data/lyftr.db-wal ] && cp /app/data/lyftr.db-wal /app/data/lyftr.seed.db-wal; [ -f /app/data/lyftr.db-shm ] && cp /app/data/lyftr.db-shm /app/data/lyftr.seed.db-shm; true'"
+# Update seed snapshot after improving demo data
+fly ssh console --app lyftr-demo -C "/app/snapshot.sh"
 ```
 
 ## Architecture

--- a/fly/entrypoint.sh
+++ b/fly/entrypoint.sh
@@ -8,9 +8,11 @@
 set -e
 
 # Register hourly reset: copies seed snapshot → live DB, then kills backend
-# so the restart loop below picks it back up with fresh data.
+# so the restart loop below picks it back up with fresh data. Logged onto the
+# /app/data volume (not /var/log) so it survives restarts/redeploys and is
+# actually inspectable via `fly ssh console -C "cat /app/data/reset.log"`.
 mkdir -p /var/spool/cron/crontabs
-echo "0 * * * * /app/reset.sh >> /var/log/reset.log 2>&1" > /var/spool/cron/crontabs/root
+echo "0 * * * * /app/reset.sh >> /app/data/reset.log 2>&1" > /var/spool/cron/crontabs/root
 crond
 
 # Restart loop: reset.sh uses pkill to stop lyftr-api; this loop restarts it.

--- a/fly/reset.sh
+++ b/fly/reset.sh
@@ -2,11 +2,13 @@
 # reset.sh — hourly demo reset, invoked by crond inside the container
 #
 # Restores the live DB from a pre-seeded snapshot so the demo always shows
-# realistic data. Stops the backend first, then swaps the DB file, then lets
-# entrypoint.sh's restart loop bring it back with the fresh DB.
+# realistic data. Stops the backend first, stages the restore, then swaps it
+# in atomically, then lets entrypoint.sh's restart loop bring the backend
+# back with the fresh DB.
 #
-# The seed snapshot (lyftr.seed.db [+ -wal/-shm if present]) is created once
-# on first deploy — see fly/SETUP.md.
+# The seed snapshot (lyftr.seed.db [+ -wal/-shm if present]) is created via
+# fly/snapshot.sh — see fly/SETUP.md.
+set -e
 SEED="/app/data/lyftr.seed.db"
 LIVE="/app/data/lyftr.db"
 
@@ -25,13 +27,24 @@ for i in 1 2 3 4 5; do
 done
 
 echo "[reset] $(date): restoring demo DB..."
+# Stage the restore under temp names and verify every copy succeeds before
+# touching the live files — if cp fails partway (full volume, I/O error),
+# set -e aborts here and the current (stale but valid) live DB is left
+# exactly as it was, instead of being deleted with nothing to replace it.
+cp "$SEED" "$LIVE.new"
+rm -f "$LIVE-wal.new" "$LIVE-shm.new"
+if [ -f "$SEED-wal" ]; then cp "$SEED-wal" "$LIVE-wal.new"; fi
+if [ -f "$SEED-shm" ]; then cp "$SEED-shm" "$LIVE-shm.new"; fi
+
 # journal_mode=WAL means recent writes can still be sitting in lyftr.db-wal,
-# not yet folded into lyftr.db. Copying only the main file and leaving stale
-# WAL/SHM side files behind lets SQLite replay those old frames back on top
-# of the fresh copy the moment the backend reopens it — silently undoing the
-# reset. Clear them so the restarted backend opens a clean, single file.
-rm -f "$LIVE" "$LIVE-wal" "$LIVE-shm"
-cp "$SEED" "$LIVE"
-[ -f "$SEED-wal" ] && cp "$SEED-wal" "$LIVE-wal"
-[ -f "$SEED-shm" ] && cp "$SEED-shm" "$LIVE-shm"
+# not yet folded into lyftr.db. Leaving stale WAL/SHM side files behind lets
+# SQLite replay those old frames back on top of the fresh copy the moment
+# the backend reopens it — silently undoing the reset. Clear them only now
+# that the staged copy above is known-good, and swap everything in via an
+# atomic rename.
+mv -f "$LIVE.new" "$LIVE"
+rm -f "$LIVE-wal" "$LIVE-shm"
+if [ -f "$LIVE-wal.new" ]; then mv -f "$LIVE-wal.new" "$LIVE-wal"; fi
+if [ -f "$LIVE-shm.new" ]; then mv -f "$LIVE-shm.new" "$LIVE-shm"; fi
+
 echo "[reset] $(date): done — backend will restart automatically"

--- a/fly/reset.sh
+++ b/fly/reset.sh
@@ -2,12 +2,11 @@
 # reset.sh — hourly demo reset, invoked by crond inside the container
 #
 # Restores the live DB from a pre-seeded snapshot so the demo always shows
-# realistic data. After the copy, pkill stops the backend; entrypoint.sh's
-# restart loop brings it back with the fresh DB.
+# realistic data. Stops the backend first, then swaps the DB file, then lets
+# entrypoint.sh's restart loop bring it back with the fresh DB.
 #
-# The seed snapshot (lyftr.seed.db) is created once on first deploy:
-#   fly ssh console -a lyftr-demo
-#   cp /app/data/lyftr.db /app/data/lyftr.seed.db
+# The seed snapshot (lyftr.seed.db [+ -wal/-shm if present]) is created once
+# on first deploy — see fly/SETUP.md.
 SEED="/app/data/lyftr.seed.db"
 LIVE="/app/data/lyftr.db"
 
@@ -16,8 +15,23 @@ if [ ! -f "$SEED" ]; then
     exit 0
 fi
 
-echo "[reset] $(date): restoring demo DB..."
-cp "$SEED" "$LIVE"
-# Kill backend so entrypoint restart loop picks up the fresh DB immediately
+echo "[reset] $(date): stopping backend..."
 pkill lyftr-api 2>/dev/null || true
+# The backend has no SIGTERM handler, so it dies immediately and this rarely
+# loops more than once — but the copy below must not race a still-open WAL.
+for i in 1 2 3 4 5; do
+    pgrep lyftr-api >/dev/null 2>&1 || break
+    sleep 1
+done
+
+echo "[reset] $(date): restoring demo DB..."
+# journal_mode=WAL means recent writes can still be sitting in lyftr.db-wal,
+# not yet folded into lyftr.db. Copying only the main file and leaving stale
+# WAL/SHM side files behind lets SQLite replay those old frames back on top
+# of the fresh copy the moment the backend reopens it — silently undoing the
+# reset. Clear them so the restarted backend opens a clean, single file.
+rm -f "$LIVE" "$LIVE-wal" "$LIVE-shm"
+cp "$SEED" "$LIVE"
+[ -f "$SEED-wal" ] && cp "$SEED-wal" "$LIVE-wal"
+[ -f "$SEED-shm" ] && cp "$SEED-shm" "$LIVE-shm"
 echo "[reset] $(date): done — backend will restart automatically"

--- a/fly/snapshot.sh
+++ b/fly/snapshot.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# snapshot.sh — (re)create the seed snapshot from the current live DB.
+#
+# Run once after first deploy (see fly/SETUP.md) to establish the baseline
+# reset.sh restores every hour, and again any time you want to refresh what
+# that baseline contains. Safe to re-run.
+set -e
+SEED="/app/data/lyftr.seed.db"
+LIVE="/app/data/lyftr.db"
+
+echo "[snapshot] $(date): stopping backend..."
+pkill lyftr-api 2>/dev/null || true
+# The backend has no SIGTERM handler, so it dies immediately and this rarely
+# loops more than once — but the copy below must not race a still-open WAL.
+for i in 1 2 3 4 5; do
+    pgrep lyftr-api >/dev/null 2>&1 || break
+    sleep 1
+done
+
+echo "[snapshot] $(date): capturing seed from live DB..."
+# Stage under temp names and verify every copy succeeds before touching the
+# seed files reset.sh depends on — if cp fails partway, set -e aborts here
+# and the previous seed snapshot (if any) is left untouched.
+cp "$LIVE" "$SEED.new"
+rm -f "$SEED-wal.new" "$SEED-shm.new"
+if [ -f "$LIVE-wal" ]; then cp "$LIVE-wal" "$SEED-wal.new"; fi
+if [ -f "$LIVE-shm" ]; then cp "$LIVE-shm" "$SEED-shm.new"; fi
+
+# Clear any stale seed-side WAL/SHM from a previous snapshot before swapping
+# the new ones in — otherwise a re-run where the live WAL has since been
+# auto-checkpointed away would leave an old seed.db-wal mismatched against
+# the freshly copied seed.db, and reset.sh would replay those stale frames
+# back onto the live DB on the very next hourly run.
+mv -f "$SEED.new" "$SEED"
+rm -f "$SEED-wal" "$SEED-shm"
+if [ -f "$SEED-wal.new" ]; then mv -f "$SEED-wal.new" "$SEED-wal"; fi
+if [ -f "$SEED-shm.new" ]; then mv -f "$SEED-shm.new" "$SEED-shm"; fi
+
+echo "[snapshot] $(date): done — backend will restart automatically"


### PR DESCRIPTION
## Problem

The public demo's hourly `reset.sh` job runs, logs success, but visitor data
survives — the demo never actually resets.

## Root cause

`journal_mode=WAL` only became *actually* effective once the SQLite DSN
pragma syntax was corrected (cf21aa2) — before that, the pragma was silently
ignored. `fly/reset.sh` predates that fix and was only ever written to `cp`
the main `lyftr.db` file.

Under real WAL mode, recent commits can sit in `lyftr.db-wal`/`lyftr.db-shm`
long before SQLite auto-checkpoints them into the main file. `reset.sh`
copied the seed snapshot over `lyftr.db` but left the stale `-wal`/`-shm`
side files in place — the moment the backend reopens the db, SQLite replays
those old frames right back on top of the fresh copy, silently undoing the
reset.

## Fix

- `fly/reset.sh`: stop the backend, wait for it to actually exit, then clear
  `lyftr.db`/`-wal`/`-shm` before restoring from the seed snapshot (copying
  the seed's own `-wal`/`-shm` too, if present).
- `fly/SETUP.md`: the one-time snapshot-creation steps have the identical
  blind spot (an in-flight WAL means the *snapshot itself* can miss recent
  writes) — updated both snapshot commands to stop the backend and capture
  the `-wal`/`-shm` files alongside the main db.
- `fly/entrypoint.sh`: `reset.sh`'s log now goes to `/app/data/reset.log`
  (the persistent volume) instead of `/var/log` (ephemeral rootfs), so it
  survives restarts/redeploys and is actually inspectable.

## Test plan

- [x] Reproduced locally with the real backend binary + real SQLite/WAL:
      wrote a marker row via a second connection (stays in `-wal`, under
      the auto-checkpoint threshold), ran the *old* reset logic — marker
      survives. Confirmed bug.
- [x] Applied the fix, reran the same sequence — marker is gone after reset.
- [x] Verified `pkill`/`pgrep`/`crond` all exist in the real `nginx:alpine`
      base image (busybox).
- [x] Built the actual `fly/Dockerfile` image and ran it as a real
      container: seeded demo data, took the (fixed) snapshot, logged in via
      the real API and wrote a real weight-log marker, ran `/app/reset.sh`
      exactly as `crond` would, confirmed the marker is cleared and the
      crontab/`crond` registration itself is correct.