### PR TITLE
feat(weight): step bodyweight +/- by 0.1 instead of 0.5 (#80)

### DIFF
--- a/mobile/app/(tabs)/weight/[id].tsx
+++ b/mobile/app/(tabs)/weight/[id].tsx
@@ -13,7 +13,7 @@ import {
   NumericKeyboardAccessory, NUMERIC_ACCESSORY_ID, Screen, StepperTile, deleteConfirmProps,
 } from '../../../src/components/ui'
 import { client, useSettingsStore } from '../../../src/lib/lyftr'
-import { clampStep } from '../../../src/utils/number'
+import { BODYWEIGHT_STEP, clampStep } from '../../../src/utils/number'
 import { useTheme } from '../../../src/theme/useTheme'
 
 export default function WeightDetail() {
@@ -204,7 +204,7 @@ export default function WeightDetail() {
                   icon={Scale}
                   label={`Weight (${wUnit})`}
                   name="weight"
-                  step={0.5}
+                  step={BODYWEIGHT_STEP}
                   onStep={(d) => setEditWeight(String(clampStep(parseFloat(editWeight) || 0, d, { min: 0, max: maxWeight(unit) })))}
                 >
                   <NumberField

--- a/mobile/app/(tabs)/weight/index.tsx
+++ b/mobile/app/(tabs)/weight/index.tsx
@@ -20,7 +20,7 @@ import { WeightEntryRow } from '../../../src/components/weight/WeightEntryRow'
 import { WeightSkeleton } from '../../../src/components/weight/WeightSkeleton'
 import { useServerInfiniteList } from '../../../src/hooks/useServerInfiniteList'
 import { client, useSettingsStore } from '../../../src/lib/lyftr'
-import { clampStep } from '../../../src/utils/number'
+import { BODYWEIGHT_STEP, clampStep } from '../../../src/utils/number'
 import { useTheme } from '../../../src/theme/useTheme'
 
 const PERIODS = ['7d', '30d', '90d', 'All'] as const
@@ -250,7 +250,7 @@ export default function Weight() {
                   icon={Scale}
                   label={`Weight (${wUnit})`}
                   name="weight"
-                  step={0.5}
+                  step={BODYWEIGHT_STEP}
                   onStep={(d) => setNewWeight(String(clampStep(parseFloat(newWeight) || 0, d, { min: 0, max: maxWeight(unit) })))}
                 >
                   <NumberField

--- a/mobile/src/components/dashboard/QuickWeighInSheet.tsx
+++ b/mobile/src/components/dashboard/QuickWeighInSheet.tsx
@@ -11,7 +11,7 @@ import {
   Sheet, StepperTile,
 } from '../ui'
 import { client, useSettingsStore } from '../../lib/lyftr'
-import { clampStep } from '../../utils/number'
+import { BODYWEIGHT_STEP, clampStep } from '../../utils/number'
 import { useTheme } from '../../theme/useTheme'
 
 interface Props {
@@ -134,7 +134,7 @@ export function QuickWeighInSheet({ open, lastValue, lastLog, onClose, onSuccess
             icon={Scale}
             label={`Weight (${wUnit})`}
             name="weight"
-            step={0.5}
+            step={BODYWEIGHT_STEP}
             onStep={(d) => setValue(String(clampStep(parseFloat(value) || 0, d, { min: 0, max: maxWeight(unit) })))}
           >
             <NumberField

--- a/mobile/src/components/workouts/GymModeWorkout.tsx
+++ b/mobile/src/components/workouts/GymModeWorkout.tsx
@@ -19,7 +19,7 @@ import { RestTimerBanner } from './RestTimerBanner'
 import { client, useSettingsStore, useWorkoutSession } from '../../lib/lyftr'
 import { useWorkoutOutcome } from '../../lib/workoutOutcome'
 import { useTheme } from '../../theme/useTheme'
-import { clampStep, clampValue } from '../../utils/number'
+import { PLATE_STEP, REP_STEP, clampStep, clampValue } from '../../utils/number'
 import { nextIncompleteSet } from '../../utils/workoutSets'
 import { muscleColor, EQUIPMENT_LABEL } from '../../utils/exerciseUtils'
 
@@ -520,12 +520,12 @@ export function GymModeWorkout() {
           {/* reps + weight steppers */}
           <View className="w-full flex-row gap-3">
             <View className="flex-1">
-              <StepperTile icon={Repeat} label="Reps" name="reps" step={1} disabled={set.completed} onStep={(d) => updateSet(activeIdx, clampedSetIdx, 'actual_reps', clampStep(set.actual_reps || 0, d, { min: 0 }))}>
+              <StepperTile icon={Repeat} label="Reps" name="reps" step={REP_STEP} disabled={set.completed} onStep={(d) => updateSet(activeIdx, clampedSetIdx, 'actual_reps', clampStep(set.actual_reps || 0, d, { min: 0 }))}>
                 <NumberField key={`reps-${activeIdx}-${clampedSetIdx}`} inputMode="numeric" value={set.actual_reps ? String(set.actual_reps) : ''} onChange={(v) => updateSet(activeIdx, clampedSetIdx, 'actual_reps', Math.round(clampValue(v)))} placeholder={set.target_reps > 0 ? String(set.target_reps) : '0'} disabled={set.completed} accessibilityLabel="Reps" inputAccessoryViewID={NUMERIC_ACCESSORY_ID} />
               </StepperTile>
             </View>
             <View className="flex-1">
-              <StepperTile icon={Dumbbell} label={`Weight (${wUnit})`} name="weight" step={2.5} disabled={set.completed} onStep={(d) => updateSet(activeIdx, clampedSetIdx, 'actual_weight', displayToLbs(clampStep(displayWeight(set.actual_weight, wUnit), d, { min: 0 }), settings.weight_unit))}>
+              <StepperTile icon={Dumbbell} label={`Weight (${wUnit})`} name="weight" step={PLATE_STEP} disabled={set.completed} onStep={(d) => updateSet(activeIdx, clampedSetIdx, 'actual_weight', displayToLbs(clampStep(displayWeight(set.actual_weight, wUnit), d, { min: 0 }), settings.weight_unit))}>
                 <NumberField key={`wt-${activeIdx}-${clampedSetIdx}`} inputMode="decimal" value={set.actual_weight ? String(displayWeight(set.actual_weight, wUnit)) : ''} onChange={(v) => updateSet(activeIdx, clampedSetIdx, 'actual_weight', displayToLbs(clampValue(v), settings.weight_unit))} placeholder={set.target_weight > 0 ? String(displayWeight(set.target_weight, wUnit)) : '0'} disabled={set.completed} accessibilityLabel="Weight" inputAccessoryViewID={NUMERIC_ACCESSORY_ID} />
               </StepperTile>
             </View>

--- a/mobile/src/utils/number.ts
+++ b/mobile/src/utils/number.ts
@@ -1,5 +1,9 @@
 // Port of web/src/utils/number.ts — keep in sync.
 
+// Bodyweight +/- increment. Day-to-day bodyweight moves less than the old 0.5 step
+// could express (#80); the field itself accepts 0.1 typed regardless.
+export const BODYWEIGHT_STEP = 0.1
+
 // Step a numeric value by `delta`, round to the app's 0.1 precision, and clamp to
 // [min, max]. Single source for the +/- stepper math shared by WeightInput and the
 // gym StepperTile (default min 0 also serves as the "no negatives" guard).

--- a/mobile/src/utils/number.ts
+++ b/mobile/src/utils/number.ts
@@ -1,12 +1,35 @@
 // Port of web/src/utils/number.ts — keep in sync.
 
-// Bodyweight +/- increment. Day-to-day bodyweight moves less than the old 0.5 step
-// could express (#80); the field itself accepts 0.1 typed regardless.
+// Increments for the +/- stepper buttons, in *display* units — the caller has
+// already converted lbs↔kg, so 2.5 means "2.5 of whatever the user is reading".
+// They only drive the buttons: every field still accepts any typed value at 0.1
+// precision (#39), so a step is a convenience, never a limit.
+//
+// Three constants rather than one, because each answers a different question about
+// the thing being measured:
+
+// How much a body moves between weigh-ins — tenths. The old 0.5 was too coarse to
+// express a normal day's change (#80). Used by every bodyweight input: it's
+// WeightInput's default step (web) and passed explicitly on the three mobile
+// weight screens.
 export const BODYWEIGHT_STEP = 0.1
+
+// How much a barbell can actually be loaded by — the smallest pair of plates on
+// the rack, and the same number in either unit (2.5 lb / 2.5 kg). Used by gym
+// mode's weight tile on both platforms. Deliberately NOT the bodyweight step:
+// nudging a squat by a tenth of a pound is not a thing you can do.
+export const PLATE_STEP = 2.5
+
+// Reps are whole. Used by gym mode's reps tile on both platforms.
+export const REP_STEP = 1
 
 // Step a numeric value by `delta`, round to the app's 0.1 precision, and clamp to
 // [min, max]. Single source for the +/- stepper math shared by WeightInput and the
 // gym StepperTile (default min 0 also serves as the "no negatives" guard).
+//
+// The toFixed(1) is what keeps repeated steps exact (183.6 + 0.1 is 183.7, not
+// 183.70000000000002) — and it's also the floor on how fine a step can be: 0.1 is
+// the smallest one this can express, which is why BODYWEIGHT_STEP stops there.
 export function clampStep(base: number, delta: number, opts: { min?: number; max?: number } = {}): number {
   const { min = 0, max = Infinity } = opts
   const b = Number.isFinite(base) ? base : 0

--- a/web/src/components/WeightInput.test.tsx
+++ b/web/src/components/WeightInput.test.tsx
@@ -16,11 +16,13 @@ describe('WeightInput', () => {
     expect(screen.getByLabelText(/increase/i)).toBeTruthy()
   })
 
-  it('+ adjusts by step and emits a string', () => {
+  // 2.5, not 0.1: an explicit step equal to STEP_DEFAULT would pass whether or not
+  // the prop is honoured at all. Doubles as the gym-mode plate increment.
+  it('+ adjusts by an explicit step and emits a string', () => {
     const onChange = vi.fn()
-    render(<WeightInput value="100" onChange={onChange} unit="lbs" step={0.1} />)
+    render(<WeightInput value="100" onChange={onChange} unit="lbs" step={2.5} />)
     fireEvent.click(screen.getByLabelText(/increase/i))
-    expect(onChange).toHaveBeenCalledWith('100.1')
+    expect(onChange).toHaveBeenCalledWith('102.5')
   })
 
   it('clamps at 0 — never goes negative', () => {

--- a/web/src/components/WeightInput.test.tsx
+++ b/web/src/components/WeightInput.test.tsx
@@ -42,11 +42,20 @@ describe('WeightInput', () => {
     expect(screen.getByText('kg')).toBeTruthy()
   })
 
-  it('default + button steps by 0.5 (locks STEP_DEFAULT — bodyweight ergonomics)', () => {
+  it('default + button steps by 0.1 (locks STEP_DEFAULT — bodyweight moves in tenths)', () => {
     const onChange = vi.fn()
     render(<WeightInput value="100" onChange={onChange} unit="lbs" />) // no step prop
     fireEvent.click(screen.getByLabelText(/increase/i))
-    expect(onChange).toHaveBeenCalledWith('100.5')
+    expect(onChange).toHaveBeenCalledWith('100.1')
+  })
+
+  it('repeated default steps stay exact — no float dust', () => {
+    const onChange = vi.fn()
+    render(<WeightInput value="183.6" onChange={onChange} unit="lbs" />)
+    fireEvent.click(screen.getByLabelText(/increase/i))
+    expect(onChange).toHaveBeenCalledWith('183.7')
+    fireEvent.click(screen.getByLabelText(/decrease/i))
+    expect(onChange).toHaveBeenLastCalledWith('183.6')
   })
 
   it('the field always accepts 0.1 precision regardless of the button step', () => {

--- a/web/src/components/WeightInput.tsx
+++ b/web/src/components/WeightInput.tsx
@@ -29,6 +29,14 @@ interface Props {
 // Nothing overrides `step` today: the sets tables pass stepper={false}, and gym mode
 // builds its own tiles from StepperTile + NumberField (see PLATE_STEP). The prop
 // stays for a caller that wants a coarser jump.
+//
+// That gym mode uses a different component for the same job is the inconsistency
+// tracked in #91: web is the only place a stepper flanks the field instead of
+// sitting in a tile footer, and mobile's bodyweight screens already use the tile.
+// Converging the four web bodyweight inputs onto StepperTile deletes the stepper
+// half of this component outright — both buttons, `stepper`, `step`, STEP_DEFAULT —
+// since the remaining callers all pass stepper={false}. Deliberately a follow-up,
+// not part of #80: it is a visual change to four screens, not a constant.
 const INPUT_STEP = 0.1
 const STEP_DEFAULT = BODYWEIGHT_STEP
 

--- a/web/src/components/WeightInput.tsx
+++ b/web/src/components/WeightInput.tsx
@@ -1,6 +1,6 @@
 import { Minus, Plus } from 'lucide-react'
 import { useNumericText } from '../hooks/useNumericText'
-import { clampStep } from '../utils/number'
+import { BODYWEIGHT_STEP, clampStep } from '../utils/number'
 
 interface Props {
   value: string
@@ -21,10 +21,11 @@ interface Props {
 }
 
 // The field always accepts 0.1 precision (the #39 feature); the +/- buttons step
-// by `step` — a larger, ergonomic increment — so gym mode can jump by 2.5 while you
-// can still type an exact 0.1 value. Bodyweight keeps the original 0.5 button feel.
+// by `step`, so gym mode can jump by a plate-sized 2.5 while you can still type an
+// exact 0.1 value. Bodyweight takes the default — the smallest step the field can
+// hold, since a day's change is often under half a pound (#80).
 const INPUT_STEP = 0.1
-const STEP_DEFAULT = 0.5
+const STEP_DEFAULT = BODYWEIGHT_STEP
 
 // Single component for every weight input in the app. Conversion-agnostic: the
 // caller owns lbs↔display unit (pass display-unit strings in/out). `stepper`

--- a/web/src/components/WeightInput.tsx
+++ b/web/src/components/WeightInput.tsx
@@ -20,10 +20,15 @@ interface Props {
   max?: number
 }
 
-// The field always accepts 0.1 precision (the #39 feature); the +/- buttons step
-// by `step`, so gym mode can jump by a plate-sized 2.5 while you can still type an
-// exact 0.1 value. Bodyweight takes the default — the smallest step the field can
-// hold, since a day's change is often under half a pound (#80).
+// Two different granularities that happen to be the same number right now, and must
+// not be collapsed into one: INPUT_STEP is what the field accepts typed (the #39
+// feature — always tenths, whatever the buttons do), STEP_DEFAULT is how far one
+// +/- tap moves. They coincide because bodyweight, the only caller that shows the
+// buttons, wants the finest step the field can hold (#80).
+//
+// Nothing overrides `step` today: the sets tables pass stepper={false}, and gym mode
+// builds its own tiles from StepperTile + NumberField (see PLATE_STEP). The prop
+// stays for a caller that wants a coarser jump.
 const INPUT_STEP = 0.1
 const STEP_DEFAULT = BODYWEIGHT_STEP
 

--- a/web/src/pages/GymModeWorkout.tsx
+++ b/web/src/pages/GymModeWorkout.tsx
@@ -17,7 +17,7 @@ import { workoutAPI } from '../services/api'
 import StepperTile from '../components/ui/StepperTile'
 import NumberField from '../components/ui/NumberField'
 import DiscardConfirm from '../components/DiscardConfirm'
-import { clampStep, clampValue } from '../utils/number'
+import { PLATE_STEP, REP_STEP, clampStep, clampValue } from '../utils/number'
 import { nextIncompleteSet } from '../utils/workoutSets'
 import { displayWeight, displayToLbs } from '../stores/settings'
 
@@ -611,7 +611,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
         <div className="w-full grid grid-cols-2 gap-3">
           {/* Reps — key by set so a half-typed value can't bleed to the next set */}
           <StepperTile
-            icon={Repeat} label="Reps" name="reps" step={1} disabled={set.completed}
+            icon={Repeat} label="Reps" name="reps" step={REP_STEP} disabled={set.completed}
             onStep={d => updateSet(activeIdx, clampedSetIdx, 'actual_reps', clampStep(set.actual_reps || 0, d, { min: 0 }))}
           >
             <NumberField
@@ -627,7 +627,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
 
           {/* Weight */}
           <StepperTile
-            icon={Dumbbell} label={`Weight (${wUnit})`} name="weight" step={2.5} disabled={set.completed}
+            icon={Dumbbell} label={`Weight (${wUnit})`} name="weight" step={PLATE_STEP} disabled={set.completed}
             onStep={d => updateSet(activeIdx, clampedSetIdx, 'actual_weight', displayToLbs(clampStep(displayWeight(set.actual_weight, wUnit), d, { min: 0 }), wUnit))}
           >
             <NumberField

--- a/web/src/utils/number.ts
+++ b/web/src/utils/number.ts
@@ -1,3 +1,7 @@
+// Bodyweight +/- increment. Day-to-day bodyweight moves less than the old 0.5 step
+// could express (#80); the field itself accepts 0.1 typed regardless.
+export const BODYWEIGHT_STEP = 0.1
+
 // Step a numeric value by `delta`, round to the app's 0.1 precision, and clamp to
 // [min, max]. Single source for the +/- stepper math shared by WeightInput and the
 // gym StepperTile (default min 0 also serves as the "no negatives" guard).

--- a/web/src/utils/number.ts
+++ b/web/src/utils/number.ts
@@ -1,10 +1,33 @@
-// Bodyweight +/- increment. Day-to-day bodyweight moves less than the old 0.5 step
-// could express (#80); the field itself accepts 0.1 typed regardless.
+// Increments for the +/- stepper buttons, in *display* units — the caller has
+// already converted lbs↔kg, so 2.5 means "2.5 of whatever the user is reading".
+// They only drive the buttons: every field still accepts any typed value at 0.1
+// precision (#39), so a step is a convenience, never a limit.
+//
+// Three constants rather than one, because each answers a different question about
+// the thing being measured:
+
+// How much a body moves between weigh-ins — tenths. The old 0.5 was too coarse to
+// express a normal day's change (#80). Used by every bodyweight input: it's
+// WeightInput's default step (web) and passed explicitly on the three mobile
+// weight screens.
 export const BODYWEIGHT_STEP = 0.1
+
+// How much a barbell can actually be loaded by — the smallest pair of plates on
+// the rack, and the same number in either unit (2.5 lb / 2.5 kg). Used by gym
+// mode's weight tile on both platforms. Deliberately NOT the bodyweight step:
+// nudging a squat by a tenth of a pound is not a thing you can do.
+export const PLATE_STEP = 2.5
+
+// Reps are whole. Used by gym mode's reps tile on both platforms.
+export const REP_STEP = 1
 
 // Step a numeric value by `delta`, round to the app's 0.1 precision, and clamp to
 // [min, max]. Single source for the +/- stepper math shared by WeightInput and the
 // gym StepperTile (default min 0 also serves as the "no negatives" guard).
+//
+// The toFixed(1) is what keeps repeated steps exact (183.6 + 0.1 is 183.7, not
+// 183.70000000000002) — and it's also the floor on how fine a step can be: 0.1 is
+// the smallest one this can express, which is why BODYWEIGHT_STEP stops there.
 export function clampStep(base: number, delta: number, opts: { min?: number; max?: number } = {}): number {
   const { min = 0, max = Infinity } = opts
   const b = Number.isFinite(base) ? base : 0


### PR DESCRIPTION
Closes #80.

Day-to-day bodyweight often moves less than half a pound, so the +/- buttons on the weight logger could not express a normal change. They now step by **0.1** — the same precision the field itself has accepted since #39.

Applies to every bodyweight input on both platforms: the Weight tab log card, the weight-detail edit screen, and the dashboard quick weigh-in. Lifting weight in gym mode keeps its plate-sized 2.5 step, and reps keep 1.

### Notes

- Both Weight pages already prefill the field with the latest logged weight (`weight/index.tsx`, `Weight.tsx`), so the common interaction is nudging an existing value rather than counting up from zero. Typing still handles large corrections and exact values.
- `clampStep` already rounds with `.toFixed(1)`, so repeated steps stay exact — no `183.70000000000002`.
- The step is named once per platform as `BODYWEIGHT_STEP` in `utils/number.ts` (the two files are already declared keep-in-sync forks), replacing a `0.5` literal in four places.
- On web every bodyweight input uses the component default, and every lifting input either passes `stepper={false}` or an explicit `step={2.5}` — so changing the default touches exactly the intended four call sites.

### Tests

- `WeightInput.test.tsx`: retargeted the test that locked the old default, plus a new 183.6 → 183.7 → 183.6 case guarding against float dust
- web unit 133 passed · mobile jest 47 passed · both type-checks clean
- `go test ./controllers/` ok
- Playwright: 88 passed, 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxKyZy6vR6xKu7Sp2MrEwn
