### PR TITLE
chore(mobile): set version to 0.1.0-beta.5 for the release tag

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Lyftr",
     "slug": "lyftr",
     "scheme": "lyftr",
-    "version": "0.3.0",
+    "version": "0.1.0-beta.5",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,


### PR DESCRIPTION
Version bump ahead of pushing `v0.1.0-beta.5`. Per RELEASING.md, `expo.version` should match the tag before it goes out — CI stamps the same value from the tag at build time, so this is about the repo not disagreeing with what ships, not about what the APK depends on.

This lowers the displayed version from `0.3.0`, since mobile was numbered independently before the tag namespace was unified in #77. Cosmetic: Android gates upgrades on `versionCode`, which lives on EAS and keeps climbing (next build takes 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxKyZy6vR6xKu7Sp2MrEwn
