### PR TITLE
chore(mobile): read the app version from the tag instead of committing it

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -172,7 +172,8 @@ jobs:
       # only place a release version exists: nothing to bump, nothing to drift.
       #
       # A dry run has no tag (the ref is a branch, which can contain slashes and isn't a
-      # version at all). It leaves LYFTR_VERSION unset and takes app.json's dev placeholder.
+      # version at all), so it invents a run-specific one — see below for why that beats
+      # reusing app.json's placeholder.
       - name: Resolve the release version
         id: ver
         env:
@@ -188,7 +189,13 @@ jobs:
               *) echo "::error::Tag '$GITHUB_REF_NAME' isn't a version — expected vMAJOR.MINOR.PATCH[-suffix]"; exit 1 ;;
             esac
           else
-            V="$(node -p "require('./mobile/app.json').expo.version")"
+            # Deliberately NOT app.json's version. That value is also app.config.js's
+            # fallback, so a dry run using it would compare the fallback against itself
+            # and pass whether or not LYFTR_VERSION ever reached the build — a check that
+            # cannot fail. A run-specific value can only appear in the APK if the variable
+            # actually flowed through EAS's config evaluation, which is the thing worth
+            # proving before a tag depends on it.
+            V="0.0.0-dryrun.$GITHUB_RUN_NUMBER"
           fi
           echo "version=$V" >> "$GITHUB_OUTPUT"
           echo "name=lyftr-v$V.apk" >> "$GITHUB_OUTPUT"
@@ -205,7 +212,7 @@ jobs:
         working-directory: mobile
         env:
           APK_NAME: ${{ steps.ver.outputs.name }}
-          LYFTR_VERSION: ${{ github.event_name == 'push' && steps.ver.outputs.version || '' }}
+          LYFTR_VERSION: ${{ steps.ver.outputs.version }} # set on both paths — see the resolve step
         run: |
           eas build \
             --platform android \

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -168,11 +168,11 @@ jobs:
 
       # The tag is the version, for every platform — #77 unified the namespace, and this
       # is what comparable self-hosted projects do (Immich tags v3.1.0 and its mobile app
-      # reports 3.1.0). Stamping it here means the APK's versionName can never drift from
-      # the release it's attached to, whatever app.json happens to say.
+      # reports 3.1.0). mobile/app.config.js reads it from LYFTR_VERSION, so the tag is the
+      # only place a release version exists: nothing to bump, nothing to drift.
       #
       # A dry run has no tag (the ref is a branch, which can contain slashes and isn't a
-      # version at all), so it falls back to app.json and the stamp is a no-op.
+      # version at all). It leaves LYFTR_VERSION unset and takes app.json's dev placeholder.
       - name: Resolve the release version
         id: ver
         env:
@@ -180,9 +180,9 @@ jobs:
         run: |
           if [ "$EVENT" = "push" ]; then
             V="${GITHUB_REF_NAME#v}"
-            # The `v*` trigger matches anything — `vnext` would stamp expo.version="next",
-            # sail past the versionName check (which compares against this same string, so
-            # it can't disagree), and publish lyftr-vnext.apk. Only a real version ships.
+            # The `v*` trigger matches anything — `vnext` would build an app versioned
+            # "next", sail past the versionName check (which compares against this same
+            # string, so it can't disagree), and publish lyftr-vnext.apk.
             case "$V" in
               [0-9]*.[0-9]*.[0-9]*) ;;
               *) echo "::error::Tag '$GITHUB_REF_NAME' isn't a version — expected vMAJOR.MINOR.PATCH[-suffix]"; exit 1 ;;
@@ -193,34 +193,19 @@ jobs:
           echo "version=$V" >> "$GITHUB_OUTPUT"
           echo "name=lyftr-v$V.apk" >> "$GITHUB_OUTPUT"
 
-      # Runner-only edit; never committed. app.json in the repo should be bumped to match
-      # the tag in the release commit anyway (see RELEASING.md) — this is the backstop that
-      # makes a forgotten bump impossible to ship.
-      #
-      # VERSION comes in through env, not ${{ }} interpolation: it derives from a tag name,
-      # and tag text expanded straight into a `run:` script is arbitrary code in a job that
-      # holds contents:write and EXPO_TOKEN. Needs push access to exploit, but the safe form
-      # costs nothing.
-      - name: Stamp the version into app.json
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          node -e '
-            const fs = require("fs"), p = "mobile/app.json";
-            const j = JSON.parse(fs.readFileSync(p, "utf8"));
-            j.expo.version = process.env.VERSION;
-            fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
-          '
-          node -p "'app.json version is now ' + require('./mobile/app.json').expo.version"
-
       # `preview` profile: distribution:internal → a signed, installable APK (production
       # builds an AAB store bundle, which isn't directly side-loadable). --local keeps the
       # build on this runner; credentials are still fetched from EAS, so the signing key
       # is the same one previous releases used.
+      # Both values arrive through env rather than ${{ }} interpolation: they derive from a
+      # tag name, and tag text expanded straight into a `run:` script is arbitrary code in a
+      # job holding contents:write and EXPO_TOKEN. Exploiting it needs push access, but the
+      # safe form costs nothing. LYFTR_VERSION is what app.config.js reads.
       - name: Build the APK on this runner
         working-directory: mobile
         env:
-          APK_NAME: ${{ steps.ver.outputs.name }} # via env, same reasoning as the stamp step
+          APK_NAME: ${{ steps.ver.outputs.name }}
+          LYFTR_VERSION: ${{ github.event_name == 'push' && steps.ver.outputs.version || '' }}
         run: |
           eas build \
             --platform android \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,22 +30,24 @@ Pushing the tag triggers two workflows:
 
 ## Mobile version numbers
 
-The tag is the version, on every platform. Before tagging, bump `expo.version` in
-`mobile/app.json` to match the tag you're about to push (tag `v0.4.0` → version
-`0.4.0`). CI also stamps it from the tag at build time, so a forgotten bump can't
-ship a mismatched APK — but the repo shouldn't be lying either.
+The tag is the version, on every platform. **There is nothing to bump** — the release
+job passes the tag to the build as `LYFTR_VERSION`, and `mobile/app.config.js` reads
+it, so the tag is the only place a release version exists.
+
+`expo.version` in `mobile/app.json` is a dev placeholder (`0.0.0-dev`) used when
+`LYFTR_VERSION` isn't set — local `expo start`, dev builds, dry runs. Leave it alone;
+it is never what ships.
 
 `versionCode` is a separate monotonic counter tracked on EAS
 (`appVersionSource: remote`), bumped per build and never reset — the same split
 Immich uses (`3.1.0+3057`). Android upgrades are gated on this number, not on the
 version name. Don't hand-edit it to bump a release.
 
-The `versionCode` still in `app.json` was only a seed: EAS initializes the remote
-counter from the app config the first time it builds under `remote`, and this
-project had no remote version configured. It was set to `4`, the highest already
-published. **That initialization has already happened** — the counter now lives on
-EAS and stands at `5`, so the field is inert and the CLI says so on every build.
-Note that dry runs share the counter, so release numbers will have gaps.
+It's no longer in `app.json` at all. The field was briefly kept as a seed — EAS
+initializes the remote counter from the app config the first time it builds under
+`remote`, and this project had none — set to `4`, the highest already published. That
+initialization has happened, so the field was inert and is now gone. Note that dry
+runs share the counter, so release numbers will have gaps.
 
 To inspect or correct it:
 

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,16 @@
+// Dynamic Expo config. Everything static still lives in app.json; this file exists for
+// one job: the app's version is whatever release is being built, and nothing else.
+//
+// The tag is the version (#77 unified the namespace across backend/web/mobile), so a
+// version committed to app.json could only ever be a second copy of that fact — one
+// that drifts the first time someone forgets to bump it, and that CI would have to
+// overwrite on every build to be safe. Reading it from the environment removes the
+// copy instead of policing it.
+//
+// LYFTR_VERSION is set by .github/workflows/eas-build.yml from the tag being built.
+// Unset (local dev, a dry run, `npx expo start`) falls back to app.json's placeholder,
+// which is deliberately not a real release number.
+module.exports = ({ config }) => ({
+  ...config,
+  version: process.env.LYFTR_VERSION || config.version,
+})

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Lyftr",
     "slug": "lyftr",
     "scheme": "lyftr",
-    "version": "0.1.0-beta.5",
+    "version": "0.0.0-dev",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
@@ -31,8 +31,7 @@
       },
       "permissions": [
         "android.permission.CAMERA"
-      ],
-      "versionCode": 4
+      ]
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
The release version lived in two places — `mobile/app.json`, bumped by hand before each tag, and the tag itself. CI papered over the gap by rewriting `app.json` during the build, so the committed value was simultaneously required by process and ignored in practice. A ritual whose only failure mode is silent.

`mobile/app.config.js` now reads the version from `LYFTR_VERSION`, which the release job sets from the tag. The tag becomes the only place a release version exists: nothing to bump, nothing to drift, and the stamp step is deleted rather than made more careful.

```js
module.exports = ({ config }) => ({
  ...config,
  version: process.env.LYFTR_VERSION || config.version,
})
```

## Changes

- **`mobile/app.config.js`** — new; the only thing it overrides is `version`. Everything static stays in `app.json`.
- **`expo.version`** becomes an explicit dev placeholder, `0.0.0-dev`, used when `LYFTR_VERSION` is unset: local `expo start`, dev builds, dry runs. Never what ships.
- **`android.versionCode` dropped.** It was kept as a seed to initialize the remote counter on the first `appVersionSource: remote` build. That has happened — the counter stands at 5 on EAS — so the field was inert, and the CLI recommended removing it on every build.
- **Workflow** — the "Stamp the version into app.json" step is gone; the build step passes `LYFTR_VERSION` instead.
- **RELEASING.md** — the "bump `expo.version` before tagging" instruction is replaced with "there is nothing to bump."

## Verification

`expo config --json` resolves correctly both ways:

| env | resolved `version` |
|---|---|
| unset | `0.0.0-dev` |
| `LYFTR_VERSION=0.1.0-beta.5` | `0.1.0-beta.5` |
| `LYFTR_VERSION=9.9.9` | `9.9.9` |

`android.versionCode` resolves to `undefined`, i.e. left to EAS. `npm run type-check` passes.

**What this can't prove before merge:** a dry run leaves `LYFTR_VERSION` unset by design, so CI can only exercise the fallback. The tag path is verified locally via `expo config` above, but its first real proof is the next tagged release — where the existing gate already fails the build if the APK's `versionName` doesn't match the tag. So a regression here surfaces as a failed release, not a bad one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxKyZy6vR6xKu7Sp2MrEwn
