### PR TITLE
refactor(weight): move web bodyweight inputs to StepperTile, drop WeightInput's stepper (#91)

### DIFF
--- a/web/e2e/weight.spec.ts
+++ b/web/e2e/weight.spec.ts
@@ -85,9 +85,11 @@ test.describe('Weight', () => {
     await page.locator('input[type="date"]').fill(testDate)
     await page.locator('input[placeholder*="morning"]').fill(FORM_WEIGHT_NOTE)
 
-    // Fill weight
+    // A decimal on purpose: type=number defaults to step=1, so a field missing an
+    // explicit step rejects tenths and the browser blocks submit before any request
+    // is made. An integer here passes whether or not that's set (#91).
     const weightInput = page.locator('input[inputmode="decimal"]').first()
-    await weightInput.fill('170')
+    await weightInput.fill('170.4')
 
     // Wait for the actual save (POST /weight) instead of a fixed sleep.
     await Promise.all([

--- a/web/src/components/AddWorkoutModal.tsx
+++ b/web/src/components/AddWorkoutModal.tsx
@@ -381,7 +381,7 @@ export default function AddWorkoutModal({ isOpen, onClose, onSuccess }: Props) {
                           {/* Weight */}
                           <div className="flex-1 min-w-0">
                             <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                            <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
+                            <WeightInput size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                           </div>
 
                           {/* Remove set button */}

--- a/web/src/components/EditWeightModal.tsx
+++ b/web/src/components/EditWeightModal.tsx
@@ -3,7 +3,9 @@ import { createPortal } from 'react-dom'
 import { X, Scale, AlertCircle, Save } from 'lucide-react'
 import { weightAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayWeight, weightError, maxWeight, resolveWeightLbs } from '../stores/settings'
-import WeightInput from './WeightInput'
+import StepperTile from './ui/StepperTile'
+import NumberField from './ui/NumberField'
+import { BODYWEIGHT_STEP, clampStep } from '../utils/number'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { dayToIsoNoon, isoToDayInput, todayStr } from '../utils/dateUtils'
@@ -97,12 +99,15 @@ export default function EditWeightModal({ isOpen, onClose, onSuccess, log }: Pro
             </div>
           )}
 
-          <div>
-            <label className="label">Weight</label>
-            <div className="mt-1">
-              <WeightInput value={weight} onChange={setWeight} unit={wUnit} max={maxWeight(settings.weight_unit)} autoFocus />
-            </div>
-          </div>
+          <StepperTile
+            icon={Scale}
+            label={`Weight (${wUnit})`}
+            name="weight"
+            step={BODYWEIGHT_STEP}
+            onStep={d => setWeight(String(clampStep(parseFloat(weight) || 0, d, { max: maxWeight(settings.weight_unit) })))}
+          >
+            <NumberField value={weight} onChange={setWeight} autoFocus aria-label="Weight" />
+          </StepperTile>
 
           <div>
             <label className="label">Date</label>

--- a/web/src/components/EditWorkoutModal.tsx
+++ b/web/src/components/EditWorkoutModal.tsx
@@ -399,7 +399,7 @@ export default function EditWorkoutModal({ isOpen, onClose, onSuccess, workoutId
                           {/* Weight */}
                           <div className="flex-1 min-w-0">
                             <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                            <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
+                            <WeightInput size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                           </div>
 
                           {/* Remove set button */}

--- a/web/src/components/QuickWeighInSheet.tsx
+++ b/web/src/components/QuickWeighInSheet.tsx
@@ -6,7 +6,9 @@ import { useSettingsStore, weightShort, displayToLbs , weightError, maxWeight } 
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { todayStr, dayToIsoNoon, isoToDayInput } from '../utils/dateUtils'
-import WeightInput from './WeightInput'
+import StepperTile from './ui/StepperTile'
+import NumberField from './ui/NumberField'
+import { BODYWEIGHT_STEP, clampStep } from '../utils/number'
 import * as types from '../types'
 
 interface Props {
@@ -147,14 +149,15 @@ export default function QuickWeighInSheet({ isOpen, lastValue, lastLog, onClose,
             </div>
           )}
 
-          <WeightInput
-            value={value}
-            onChange={setValue}
-            unit={wUnit}
-            max={maxWeight(settings.weight_unit)}
-            autoFocus
-            size="lg"
-          />
+          <StepperTile
+            icon={Scale}
+            label={`Weight (${wUnit})`}
+            name="weight"
+            step={BODYWEIGHT_STEP}
+            onStep={d => setValue(String(clampStep(parseFloat(value) || 0, d, { max: maxWeight(settings.weight_unit) })))}
+          >
+            <NumberField value={value} onChange={setValue} autoFocus aria-label="Weight" />
+          </StepperTile>
 
           {!showExtras ? (
             <button

--- a/web/src/components/WeightInput.test.tsx
+++ b/web/src/components/WeightInput.test.tsx
@@ -2,74 +2,43 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import WeightInput from './WeightInput'
 
+// WeightInput is the bare sets-table field now; the +/- buttons it used to carry
+// live in StepperTile (see StepperTile.test.tsx for the button wiring and
+// number.test.ts for the stepping math).
 describe('WeightInput', () => {
-  it('stepper=false renders a bare field with no +/- buttons', () => {
-    render(<WeightInput value="100" onChange={() => {}} unit="lbs" stepper={false} />)
+  it('renders a bare field — no +/- buttons', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="lbs" />)
     expect(screen.queryByLabelText(/decrease/i)).toBeNull()
     expect(screen.queryByLabelText(/increase/i)).toBeNull()
     expect((screen.getByRole('spinbutton') as HTMLInputElement).value).toBe('100')
   })
 
-  it('renders +/- buttons by default (stepper mode)', () => {
-    render(<WeightInput value="100" onChange={() => {}} unit="lbs" />)
-    expect(screen.getByLabelText(/decrease/i)).toBeTruthy()
-    expect(screen.getByLabelText(/increase/i)).toBeTruthy()
-  })
-
-  // 2.5, not 0.1: an explicit step equal to STEP_DEFAULT would pass whether or not
-  // the prop is honoured at all. Doubles as the gym-mode plate increment.
-  it('+ adjusts by an explicit step and emits a string', () => {
-    const onChange = vi.fn()
-    render(<WeightInput value="100" onChange={onChange} unit="lbs" step={2.5} />)
-    fireEvent.click(screen.getByLabelText(/increase/i))
-    expect(onChange).toHaveBeenCalledWith('102.5')
-  })
-
-  it('clamps at 0 — never goes negative', () => {
-    const onChange = vi.fn()
-    render(<WeightInput value="0" onChange={onChange} unit="lbs" step={0.1} />)
-    fireEvent.click(screen.getByLabelText(/decrease/i))
-    expect(onChange).toHaveBeenCalledWith('0')
-  })
-
   it('passes the typed value straight through as a string (caller owns conversion)', () => {
     const onChange = vi.fn()
-    render(<WeightInput value="" onChange={onChange} unit="lbs" stepper={false} />)
+    render(<WeightInput value="" onChange={onChange} unit="lbs" />)
     fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '170.3' } })
     expect(onChange).toHaveBeenCalledWith('170.3')
   })
 
+  it('strips a typed minus — weights are never negative', () => {
+    const onChange = vi.fn()
+    render(<WeightInput value="" onChange={onChange} unit="lbs" />)
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '-45' } })
+    expect(onChange).toHaveBeenCalledWith('45')
+  })
+
   it('shows the unit suffix', () => {
-    render(<WeightInput value="100" onChange={() => {}} unit="kg" stepper={false} />)
+    render(<WeightInput value="100" onChange={() => {}} unit="kg" />)
     expect(screen.getByText('kg')).toBeTruthy()
   })
 
-  it('default + button steps by 0.1 (locks STEP_DEFAULT — bodyweight moves in tenths)', () => {
-    const onChange = vi.fn()
-    render(<WeightInput value="100" onChange={onChange} unit="lbs" />) // no step prop
-    fireEvent.click(screen.getByLabelText(/increase/i))
-    expect(onChange).toHaveBeenCalledWith('100.1')
-  })
-
-  it('repeated default steps stay exact — no float dust', () => {
-    const onChange = vi.fn()
-    render(<WeightInput value="183.6" onChange={onChange} unit="lbs" />)
-    fireEvent.click(screen.getByLabelText(/increase/i))
-    expect(onChange).toHaveBeenCalledWith('183.7')
-    fireEvent.click(screen.getByLabelText(/decrease/i))
-    expect(onChange).toHaveBeenLastCalledWith('183.6')
-  })
-
-  it('the field always accepts 0.1 precision regardless of the button step', () => {
-    render(<WeightInput value="100" onChange={() => {}} unit="lbs" step={2.5} />)
-    // Button step is 2.5, but the input's typing precision stays 0.1.
+  it('accepts 0.1 typing precision (#39)', () => {
+    render(<WeightInput value="100" onChange={() => {}} unit="lbs" />)
     expect((screen.getByRole('spinbutton') as HTMLInputElement).step).toBe('0.1')
   })
 
-  it('disabled disables the field and both buttons', () => {
+  it('disabled disables the field', () => {
     render(<WeightInput value="100" onChange={() => {}} unit="lbs" disabled />)
     expect((screen.getByRole('spinbutton') as HTMLInputElement).disabled).toBe(true)
-    expect((screen.getByLabelText(/decrease/i) as HTMLButtonElement).disabled).toBe(true)
-    expect((screen.getByLabelText(/increase/i) as HTMLButtonElement).disabled).toBe(true)
   })
 })

--- a/web/src/components/WeightInput.tsx
+++ b/web/src/components/WeightInput.tsx
@@ -1,116 +1,62 @@
-import { Minus, Plus } from 'lucide-react'
 import { useNumericText } from '../hooks/useNumericText'
-import { BODYWEIGHT_STEP, clampStep } from '../utils/number'
 
 interface Props {
   value: string
   onChange: (next: string) => void
   unit: string
-  /** Increment for the +/- stepper buttons. Typing is always 0.1-precision regardless. */
-  step?: number
   autoFocus?: boolean
   size?: 'sm' | 'md' | 'lg'
-  /** Show the +/- stepper buttons (prominent inputs). Off = bare field for compact rows. */
-  stepper?: boolean
   placeholder?: string
   disabled?: boolean
-  /** Optional upper bound (display units) — clamps the +/- stepper. Submit-time
-   *  validation/messaging is the caller's job (an html max would preempt it with
-   *  a native browser tooltip). */
-  max?: number
 }
 
-// Two different granularities that happen to be the same number right now, and must
-// not be collapsed into one: INPUT_STEP is what the field accepts typed (the #39
-// feature — always tenths, whatever the buttons do), STEP_DEFAULT is how far one
-// +/- tap moves. They coincide because bodyweight, the only caller that shows the
-// buttons, wants the finest step the field can hold (#80).
-//
-// Nothing overrides `step` today: the sets tables pass stepper={false}, and gym mode
-// builds its own tiles from StepperTile + NumberField (see PLATE_STEP). The prop
-// stays for a caller that wants a coarser jump.
-//
-// That gym mode uses a different component for the same job is the inconsistency
-// tracked in #91: web is the only place a stepper flanks the field instead of
-// sitting in a tile footer, and mobile's bodyweight screens already use the tile.
-// Converging the four web bodyweight inputs onto StepperTile deletes the stepper
-// half of this component outright — both buttons, `stepper`, `step`, STEP_DEFAULT —
-// since the remaining callers all pass stepper={false}. Deliberately a follow-up,
-// not part of #80: it is a visual change to four screens, not a constant.
+// Typing is always 0.1-precision (the #39 feature), whatever the caller does with
+// the value afterwards.
 const INPUT_STEP = 0.1
-const STEP_DEFAULT = BODYWEIGHT_STEP
 
-// Single component for every weight input in the app. Conversion-agnostic: the
-// caller owns lbs↔display unit (pass display-unit strings in/out). `stepper`
-// toggles the prominent +/- layout (bodyweight, gym mode) vs a bare field for
-// compact sets-table rows. (Gym set tiles use the borderless NumberField instead.)
+// A bordered number field with the unit rendered inside it, for the compact rows of
+// the sets tables (add/edit workout, program day editor, active workout).
+//
+// It used to carry an optional +/- stepper too, but every prominent input that
+// wanted buttons has moved to StepperTile — bodyweight in #91, gym mode long before
+// that — and the callers left here all opted out of it. Reach for StepperTile if you
+// need buttons; this component is the bare field on purpose.
 export default function WeightInput({
   value,
   onChange,
   unit,
-  step = STEP_DEFAULT,
   autoFocus = false,
   size = 'md',
-  stepper = true,
   placeholder = '0.0',
   disabled = false,
-  max,
 }: Props) {
   // Raw typed text (see useNumericText) so in-progress entry isn't clobbered by the
   // parent re-deriving `value` from a rounded/0→'' number on every keystroke.
   const [text, setText] = useNumericText(value)
-
-  const emit = (next: string) => {
-    setText(next)
-    onChange(next)
-  }
-
-  const adjust = (delta: number) => emit(String(clampStep(parseFloat(text), delta, { max })))
 
   const inputSize = size === 'lg'
     ? 'text-3xl py-4 font-display font-bold'
     : size === 'sm'
       ? 'text-sm py-2.5'
       : 'text-base py-2.5'
-  const compact = !stepper || size === 'sm'
-  const pad = compact ? 'pr-7' : 'pr-12'
-  const unitPos = compact ? 'right-2' : 'right-3.5'
 
-  const field = (
+  return (
     <div className="relative flex-1 min-w-0">
       <input
         type="number"
         inputMode="decimal"
         enterKeyHint="done"
         value={text}
-        onChange={e => emit(e.target.value.replace(/-/g, ''))}
+        onChange={e => { const v = e.target.value.replace(/-/g, ''); setText(v); onChange(v) }}
         onKeyDown={e => { if (['e', 'E', '+', '-'].includes(e.key)) e.preventDefault() }}
         step={INPUT_STEP}
         min="0"
         autoFocus={autoFocus}
         disabled={disabled}
-        className={`input ${inputSize} ${pad} text-center w-full tabular-nums ${disabled ? 'opacity-40' : ''}`}
+        className={`input ${inputSize} pr-7 text-center w-full tabular-nums ${disabled ? 'opacity-40' : ''}`}
         placeholder={placeholder}
       />
-      <span className={`absolute ${unitPos} top-1/2 -translate-y-1/2 text-xs text-tx-muted pointer-events-none`}>{unit}</span>
-    </div>
-  )
-
-  if (!stepper) return field
-
-  const buttonSize = size === 'lg' ? 'p-4' : 'p-2.5'
-  const iconSize = size === 'lg' ? 'w-6 h-6' : 'w-4 h-4'
-  const btn = `${buttonSize} bg-surface-overlay border border-surface-border rounded-lg text-tx-secondary hover:bg-surface-muted active:scale-95 transition-all flex items-center justify-center flex-shrink-0 disabled:opacity-30`
-
-  return (
-    <div className="flex items-stretch gap-2">
-      <button type="button" onClick={() => adjust(-step)} disabled={disabled} className={btn} aria-label={`Decrease by ${step}`}>
-        <Minus className={iconSize} />
-      </button>
-      {field}
-      <button type="button" onClick={() => adjust(step)} disabled={disabled} className={btn} aria-label={`Increase by ${step}`}>
-        <Plus className={iconSize} />
-      </button>
+      <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-tx-muted pointer-events-none">{unit}</span>
     </div>
   )
 }

--- a/web/src/components/programs/DayExercisesEditor.tsx
+++ b/web/src/components/programs/DayExercisesEditor.tsx
@@ -157,7 +157,7 @@ export default function DayExercisesEditor({ exercises, onChange, pickerExercise
                       </div>
                       <div className="flex-1 min-w-0">
                         <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Target Weight</label>
-                        <WeightInput stepper={false} size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
+                        <WeightInput size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
                       </div>
                       <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                         <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/components/ui/NumberField.tsx
+++ b/web/src/components/ui/NumberField.tsx
@@ -12,12 +12,20 @@ interface Props {
   placeholder?: string
   disabled?: boolean
   min?: number
+  /** Focus on mount — for tiles that open in a modal or sheet the user came here to fill in. */
+  autoFocus?: boolean
   'aria-label'?: string
 }
 
+// An <input type="number"> has step=1 unless told otherwise, and the browser treats
+// any value off that grid as invalid — which silently blocks form submission with
+// "the two nearest valid values are 183 and 184". Decimal fields must therefore
+// spell out the app's 0.1 typing precision (#39); integer fields keep the default.
+const inputStepFor = (inputMode: 'numeric' | 'decimal') => (inputMode === 'numeric' ? 1 : 0.1)
+
 // Borderless numeric field for use inside a StepperTile. Robust typing via
 // useNumericText; the parent owns conversion/validation in onChange.
-export default function NumberField({ value, onChange, inputMode = 'decimal', placeholder = '0', disabled = false, min = 0, ...aria }: Props) {
+export default function NumberField({ value, onChange, inputMode = 'decimal', placeholder = '0', disabled = false, min = 0, autoFocus = false, ...aria }: Props) {
   const [text, setText] = useNumericText(value)
   // Non-negative always; integer fields (inputMode "numeric") also reject a decimal
   // point so reps can't be typed fractional.
@@ -27,9 +35,11 @@ export default function NumberField({ value, onChange, inputMode = 'decimal', pl
       type="number"
       inputMode={inputMode}
       enterKeyHint="done"
+      step={inputStepFor(inputMode)}
       min={min}
       value={text}
       disabled={disabled}
+      autoFocus={autoFocus}
       placeholder={placeholder}
       onKeyDown={e => { if (blocked.includes(e.key)) e.preventDefault() }}
       onChange={e => { const v = e.target.value.replace(/-/g, ''); setText(v); onChange(v) }}

--- a/web/src/components/ui/StepperTile.test.tsx
+++ b/web/src/components/ui/StepperTile.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Scale } from 'lucide-react'
+import StepperTile from './StepperTile'
+import NumberField from './NumberField'
+
+// The +/- half of every prominent numeric input: bodyweight (#91) and gym mode both
+// render through here, so the button wiring is tested once rather than per screen.
+const renderTile = (props: Partial<React.ComponentProps<typeof StepperTile>> = {}) => {
+  const onStep = vi.fn()
+  render(
+    <StepperTile icon={Scale} label="Weight (lbs)" name="weight" step={0.1} onStep={onStep} {...props}>
+      <NumberField value="183.6" onChange={() => {}} aria-label="Weight" />
+    </StepperTile>,
+  )
+  return onStep
+}
+
+describe('StepperTile', () => {
+  it('renders the label and the value field between the two buttons', () => {
+    renderTile()
+    expect(screen.getByText('Weight (lbs)')).toBeTruthy()
+    expect((screen.getByLabelText('Weight') as HTMLInputElement).value).toBe('183.6')
+    expect(screen.getByLabelText(/decrease/i)).toBeTruthy()
+    expect(screen.getByLabelText(/increase/i)).toBeTruthy()
+  })
+
+  it('reports the step signed by direction — the caller owns the arithmetic', () => {
+    const onStep = renderTile()
+    fireEvent.click(screen.getByLabelText(/increase/i))
+    expect(onStep).toHaveBeenCalledWith(0.1)
+    fireEvent.click(screen.getByLabelText(/decrease/i))
+    expect(onStep).toHaveBeenLastCalledWith(-0.1)
+  })
+
+  // 2.5, not the 0.1 above: a step equal to the other case's would pass whether or
+  // not the prop is read at all.
+  it('honours a coarser step', () => {
+    const onStep = renderTile({ step: 2.5, name: 'weight' })
+    fireEvent.click(screen.getByLabelText(/increase/i))
+    expect(onStep).toHaveBeenCalledWith(2.5)
+  })
+
+  it('names the metric in both button labels, for screen readers', () => {
+    renderTile({ name: 'reps' })
+    expect(screen.getByLabelText('Increase reps')).toBeTruthy()
+    expect(screen.getByLabelText('Decrease reps')).toBeTruthy()
+  })
+
+  // Regression: NumberField shipped without a step attribute, so type=number fell
+  // back to step=1 and the browser rejected every tenth — "the two nearest valid
+  // values are 183 and 184" — blocking submit before any request was made (#91).
+  it('a decimal field accepts tenths, so the browser does not reject them', () => {
+    renderTile()
+    expect((screen.getByLabelText('Weight') as HTMLInputElement).step).toBe('0.1')
+  })
+
+  it('an integer field keeps whole-number steps', () => {
+    render(
+      <StepperTile icon={Scale} label="Reps" name="reps" step={1} onStep={() => {}}>
+        <NumberField value="8" inputMode="numeric" onChange={() => {}} aria-label="Reps" />
+      </StepperTile>,
+    )
+    expect((screen.getByLabelText('Reps') as HTMLInputElement).step).toBe('1')
+  })
+
+  it('disabled disables both buttons and the field', () => {
+    renderTile({ disabled: true })
+    expect((screen.getByLabelText(/decrease/i) as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByLabelText(/increase/i) as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/web/src/pages/ActiveWorkout.tsx
+++ b/web/src/pages/ActiveWorkout.tsx
@@ -349,7 +349,6 @@ export default function ActiveWorkout() {
 
                         {/* Weight */}
                         <WeightInput
-                          stepper={false}
                           value={set.actual_weight ? String(displayWeight(set.actual_weight, wUnit)) : ''}
                           onChange={v => updateSet(exIdx, setIdx, 'actual_weight', displayToLbs(Number(v) || 0, wUnit))}
                           unit={wUnit}

--- a/web/src/pages/AddWorkout.tsx
+++ b/web/src/pages/AddWorkout.tsx
@@ -249,7 +249,7 @@ export default function AddWorkout() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                          <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
+                          <WeightInput size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                         </div>
                         <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/pages/EditWorkout.tsx
+++ b/web/src/pages/EditWorkout.tsx
@@ -235,7 +235,7 @@ export default function EditWorkout() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
-                          <WeightInput stepper={false} size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
+                          <WeightInput size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                         </div>
                         <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />

--- a/web/src/pages/Weight.tsx
+++ b/web/src/pages/Weight.tsx
@@ -7,7 +7,9 @@ import Loading from '../components/Loading'
 import PageHeader from '../components/ui/PageHeader'
 import DateInput from '../components/ui/DateInput'
 import PeriodSelector from '../components/PeriodSelector'
-import WeightInput from '../components/WeightInput'
+import StepperTile from '../components/ui/StepperTile'
+import NumberField from '../components/ui/NumberField'
+import { BODYWEIGHT_STEP, clampStep } from '../utils/number'
 import { useServerInfiniteList } from '../hooks/useServerInfiniteList'
 import { todayStr, dayToIsoNoon, isoToDayInput } from '../utils/dateUtils'
 import { weightAPI } from '../services/api'
@@ -377,13 +379,15 @@ export default function Weight() {
           )}
         </div>
         <form ref={logFormRef} onSubmit={handleLog} className="space-y-3">
-          <WeightInput
-            value={newWeight}
-            onChange={setNewWeight}
-            unit={wUnit}
-            max={maxWeight(settings.weight_unit)}
-            size="lg"
-          />
+          <StepperTile
+            icon={Scale}
+            label={`Weight (${wUnit})`}
+            name="weight"
+            step={BODYWEIGHT_STEP}
+            onStep={d => setNewWeight(String(clampStep(parseFloat(newWeight) || 0, d, { max: maxWeight(settings.weight_unit) })))}
+          >
+            <NumberField value={newWeight} onChange={setNewWeight} aria-label="Weight" />
+          </StepperTile>
 
           {showNotes ? (
             <div className="space-y-2 bg-surface-overlay border border-surface-border rounded-xl p-3">

--- a/web/src/pages/WeightDetail.tsx
+++ b/web/src/pages/WeightDetail.tsx
@@ -8,7 +8,9 @@ import { useSettingsStore, weightShort, displayWeight, weightError, maxWeight, r
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
 import { todayStr, dayToIsoNoon, isoToDayInput } from '../utils/dateUtils'
-import WeightInput from '../components/WeightInput'
+import StepperTile from '../components/ui/StepperTile'
+import NumberField from '../components/ui/NumberField'
+import { BODYWEIGHT_STEP, clampStep } from '../utils/number'
 import * as types from '../types'
 
 export default function WeightDetail() {
@@ -185,18 +187,15 @@ export default function WeightDetail() {
               </div>
             )}
 
-            <div>
-              <label className="label">Weight</label>
-              <div className="mt-1">
-                <WeightInput
-                  value={editWeight}
-                  onChange={setEditWeight}
-                  unit={wUnit}
-                  max={maxWeight(settings.weight_unit)}
-                  size="lg"
-                />
-              </div>
-            </div>
+            <StepperTile
+              icon={Scale}
+              label={`Weight (${wUnit})`}
+              name="weight"
+              step={BODYWEIGHT_STEP}
+              onStep={d => setEditWeight(String(clampStep(parseFloat(editWeight) || 0, d, { max: maxWeight(settings.weight_unit) })))}
+            >
+              <NumberField value={editWeight} onChange={setEditWeight} aria-label="Weight" />
+            </StepperTile>
 
             <div>
               <label className="label">Date</label>

--- a/web/src/utils/number.test.ts
+++ b/web/src/utils/number.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { BODYWEIGHT_STEP, PLATE_STEP, REP_STEP, clampStep, clampValue } from './number'
+
+// The stepping math behind every +/- button in the app. It used to be covered only
+// through WeightInput's buttons; those moved to StepperTile (#91), so it's tested
+// directly here instead of through whichever component happens to render it.
+describe('clampStep', () => {
+  it('steps by delta', () => {
+    expect(clampStep(100, 2.5)).toBe(102.5)
+    expect(clampStep(100, -2.5)).toBe(97.5)
+  })
+
+  it('keeps repeated tenths exact — no float dust', () => {
+    // 183.6 + 0.1 is 183.70000000000002 in raw IEEE754.
+    const up = clampStep(183.6, 0.1)
+    expect(up).toBe(183.7)
+    expect(clampStep(up, -0.1)).toBe(183.6)
+  })
+
+  it('never goes below min, which defaults to 0', () => {
+    expect(clampStep(0, -0.1)).toBe(0)
+    expect(clampStep(0.05, -1)).toBe(0)
+    expect(clampStep(10, -1, { min: 5 })).toBe(9)
+    expect(clampStep(5, -1, { min: 5 })).toBe(5)
+  })
+
+  it('never goes above max', () => {
+    expect(clampStep(999, 2.5, { max: 1000 })).toBe(1000)
+    expect(clampStep(100, 2.5, { max: 1000 })).toBe(102.5)
+  })
+
+  it('treats a non-finite base as 0 — an empty field steps up from nothing', () => {
+    expect(clampStep(NaN, 0.1)).toBe(0.1)
+    expect(clampStep(Infinity, 0.1)).toBe(0.1)
+  })
+})
+
+describe('stepper increments', () => {
+  // Locks the three apart. They answer different questions (a body's daily drift, a
+  // barbell's smallest plate pair, whole reps) and collapsing any two would silently
+  // change what a button does on a screen nobody was looking at.
+  it('are distinct, and bodyweight is the finest', () => {
+    expect(BODYWEIGHT_STEP).toBe(0.1)
+    expect(PLATE_STEP).toBe(2.5)
+    expect(REP_STEP).toBe(1)
+    expect(new Set([BODYWEIGHT_STEP, PLATE_STEP, REP_STEP]).size).toBe(3)
+  })
+
+  it('bodyweight is as fine as clampStep can express', () => {
+    expect(clampStep(100, BODYWEIGHT_STEP)).toBe(100.1)
+    // Half a step vanishes: clampStep rounds to 1dp, and 100.05 lands just under the
+    // midpoint in IEEE754 so toFixed(1) takes it back to 100. A step finer than
+    // BODYWEIGHT_STEP would be a button that does nothing — hence the floor.
+    expect(clampStep(100, BODYWEIGHT_STEP / 2)).toBe(100)
+  })
+})
+
+describe('clampValue', () => {
+  it('parses strings and numbers, flooring at min', () => {
+    expect(clampValue('170.3')).toBe(170.3)
+    expect(clampValue(170.3)).toBe(170.3)
+    expect(clampValue('-5')).toBe(0)
+    expect(clampValue('-5', 1)).toBe(1)
+  })
+
+  it('falls back to min on junk', () => {
+    expect(clampValue('')).toBe(0)
+    expect(clampValue('abc')).toBe(0)
+    expect(clampValue('abc', 5)).toBe(5)
+  })
+})


### PR DESCRIPTION
Closes #91. Follow-up to #85, which named the stepper increments and exposed that the
two platforms render the same control two different ways.

## The inconsistency

| | Bodyweight | Gym mode |
|---|---|---|
| Mobile | `StepperTile` | `StepperTile` |
| Web | `WeightInput` (buttons flanking the field) | `StepperTile` |

Web was the only place a stepper was `[−] [field] [+]` rather than a tile with the
value full-width and a split ⊖/⊕ footer — the layout `StepperTile` exists for:

> Value spans the full tile (buttons are below, not flanking) so long weights never clip.

## The change

The four web bodyweight inputs — `Weight`, `WeightDetail`, `EditWeightModal`,
`QuickWeighInSheet` — now use `StepperTile` + `NumberField`, mirroring mobile: unit
in the tile label, `max` clamp in the `onStep` handler.

Their old `<label>Weight</label>` headings are gone, since the tile carries its own.

## The payoff is a deletion

Nothing renders `WeightInput`'s stepper any more, so it's gone: both buttons,
`stepper`, `step`, `STEP_DEFAULT`, and the size-dependent padding that existed only
to leave room for flanking buttons. The six remaining callers are sets-table rows
that all passed `stepper={false}` — they now get the bare field they always wanted.

## A regression this caught before it shipped

`NumberField` had no `step` attribute, so `type=number` fell back to `step=1` and the
browser rejected every tenth:

> Please enter a valid value. The two nearest valid values are 183 and 184.

That blocks submit natively, before any request is made. Bodyweight is the one field
that exists to hold tenths (#39, #80), so the conversion would have made the log form
useless for its actual purpose.

Decimal fields now declare 0.1; integer fields keep 1 — which also repairs the same
latent flaw in gym mode's weight tile, where it was invisible only because that tile
isn't inside a validated form.

**The suite could not have caught this:** both weight E2E cases filled integers,
which pass whether or not `step` is set. One now fills `170.4`. Verified it fails
without the fix and passes with it.

## Coverage moved rather than vanished

`clampStep` — the stepping math behind all seven steppers — had no direct test; it
was only exercised through `WeightInput`'s buttons, which this deletes. Now:

- `web/src/utils/number.test.ts` — rounding, float dust, both clamps, non-finite
  base, and a case locking `BODYWEIGHT_STEP` / `PLATE_STEP` / `REP_STEP` apart
- `web/src/components/ui/StepperTile.test.tsx` — button wiring, aria labels, the
  step-attribute regression

Net +12 web unit tests (133 → 145) despite removing four.

## Verification

- web `tsc` clean, **145 unit tests pass**
- **88 E2E pass**, 1 skipped
- Go `./controllers/` uncached pass (untouched, per repo policy)
- Manual at **390px** in a real browser: tile renders without overflow,
  183.6 → 183.7 → 183.6 with no float dust, `−` at 0 stays 0, and a decimal
  bodyweight now actually saves (screenshot evidence taken before and after the fix)
