### PR TITLE
Fix the Load-from-Program dialog rendering off-centre with a partial overlay

### DIFF
--- a/web/src/components/ProgramPicker.tsx
+++ b/web/src/components/ProgramPicker.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { X, BookOpen, ChevronRight, Dumbbell, AlertCircle, Moon } from 'lucide-react'
 import { programAPI } from '../services/api'
 import { workoutDays, dayLabel, todaysDay } from '../utils/programUtils'
@@ -35,7 +36,14 @@ export default function ProgramPicker({ onSelect, onClose }: Props) {
   const title = dayPickFor ? dayPickFor.name : 'Load from Program'
   const subtitle = dayPickFor ? 'Pick a day to pre-fill exercises' : 'Pick a program to pre-fill exercises'
 
-  return (
+  // Portalled to document.body like every other overlay here (ExercisePicker,
+  // DiscardConfirm, QuickWeighInSheet, BarcodeScanner, Toast). Rendered inline it
+  // sat inside AddWorkout's `.animate-slide-up`, whose `animation-fill-mode: both`
+  // leaves `transform: translateY(0)` applied for good. A transform — even an
+  // identity one — makes that element the containing block for `position: fixed`
+  // descendants, so `inset-0` resolved to the form's box: the scrim covered only
+  // part of the screen and the dialog centred on the form rather than the viewport.
+  return createPortal(
     <div className="fixed inset-0 bg-black/60 z-[60] flex items-center justify-center p-4">
       <div className="bg-surface-base border border-surface-border rounded-2xl w-full sm:max-w-lg flex flex-col max-h-[80vh]">
         <div className="flex items-center justify-between px-4 py-3 border-b border-surface-border flex-shrink-0">
@@ -137,6 +145,7 @@ export default function ProgramPicker({ onSelect, onClose }: Props) {
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }


### PR DESCRIPTION
The "Load from Program" dialog on **Log Workout** renders with the scrim covering only part of the screen — you can see the page around a dim rectangle — and the dialog itself sits above centre.

## Cause

`ProgramPicker` returned its `fixed inset-0` overlay **inline**, inside AddWorkout's tree. AddWorkout's root element carries `animate-slide-up`, defined in `web/src/index.css:174`:

```css
@keyframes slide-up {
  from { opacity: 0; transform: translateY(6px); }
  to   { opacity: 1; transform: translateY(0); }
}
.animate-slide-up { animation: slide-up 0.2s ease-out both; }
```

`animation-fill-mode: both` keeps the final keyframe applied after the animation finishes, so `transform: translateY(0)` stays on the element permanently. A transform — even an identity matrix — makes that element the **containing block for `position: fixed` descendants**, so `inset-0` resolved to the form's box instead of the viewport.

Measured in the browser at a 1280x900 viewport:

| | before | after |
|---|---|---|
| overlay rect | `84, 85` — `1112x648` | **`0, 0` — `1280x900`** |
| covers viewport | no | **yes** |
| dialog off-centre (Y) | 41px | **0px** |
| containing-block ancestor | `div.animate-slide-up` (`transform: matrix(1,0,0,1,0,0)`) | **none** |

## Fix

Portal to `document.body`, which is what every other overlay in the app already does. `ProgramPicker` was the only one that didn't:

| Overlay | portalled before this PR |
|---|---|
| `ExercisePicker` | yes |
| `DiscardConfirm` | yes |
| `QuickWeighInSheet` | yes |
| `BarcodeScanner` | yes |
| `Toast` | yes |
| **`ProgramPicker`** | **no** |

Deliberately fixing the overlay rather than the animation: `animate-slide-up` is used across many pages and the transform is what makes it an animation at all.

## Swept for siblings

Every `fixed inset-0` in `web/src` was checked. Two others render inline and are both safe — `Loading` and GymModeWorkout's three root containers sit under `main.animate-fade-in`, which animates opacity only and creates no containing block (confirmed at runtime: that ancestor reports `containingBlockCause: null`). GymModeWorkout's three confirm dialogs were already portalled.

## Not a React 19 regression

Found while smoke-testing #99, but unrelated to it: this reproduces on `main`, and #99's entire diff is `package.json`, `package-lock.json` and one type annotation — no CSS, no markup.

## Verification

- `vitest run` — 152 passed (includes `ProgramPicker.test.tsx`, 6 tests, which pass through the portal)
- `npm run lint` — 0 errors, 79 warnings (unchanged ceiling)
- `npm run build` — clean
- `npm run test:e2e` — 88 passed, 1 skipped
- `go test ./controllers/` — ok
- Overlay geometry re-measured in a real browser before and after (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxKyZy6vR6xKu7Sp2MrEwn