### PR TITLE
Add the sponsorship and support links across the repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,23 @@
 # Puts a "Sponsor" button on the repo header and on every release page.
-# Add ko_fi here once that account exists — it catches people who won't make a
-# GitHub account, which is most of the self-hosting audience.
-github: [Cawlumm]
+#
+# Every platform GitHub supports is listed below. Uncomment a line once the
+# account actually exists — a key pointing at a missing account renders a
+# dead button, which is worse than no button.
+#
+# ko_fi is the one most likely to be worth adding next: it catches people who
+# will not create a GitHub account, which is a large share of the self-hosting
+# audience, and it takes 0% on donations (only the Stripe/PayPal processing fee).
+
+github: [Cawlumm] # up to 4 users + 1 org
+
+# ko_fi: lyftr                       # username only, not the full URL
+# buy_me_a_coffee: lyftr             # takes 5%; ko_fi is the better default
+# liberapay: lyftr                   # 0% fee, non-profit, popular with FOSS purists
+# open_collective: lyftr             # public ledger; ~10% + fiscal host. For teams, not solo
+# patreon: lyftr
+# polar: lyftr
+# issuehunt: lyftr
+# thanks_dev: u/gh/Cawlumm           # note the u/gh/ prefix — a bare username will not resolve
+# tidelift: npm/lyftr                # PLATFORM-NAME/PACKAGE-NAME; only for published packages
+# community_bridge: lyftr            # LFX Mentorship project name
+# custom: ["https://lyftr-app.pages.dev/support/"]   # up to 4 URLs; quote any containing a colon

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Puts a "Sponsor" button on the repo header and on every release page.
+# Add ko_fi here once that account exists — it catches people who won't make a
+# GitHub account, which is most of the self-hosting audience.
+github: [Cawlumm]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Surfaces Discord and the docs at the moment someone is about to file — a fair share of
+# issues are setup questions that get answered faster in chat. blank_issues_enabled stays
+# true: an issue that fits neither template is still worth having.
+blank_issues_enabled: true
+contact_links:
+  - name: Discord
+    url: https://discord.gg/hfFWsrebQA
+    about: Setup help and questions — usually faster than an issue.
+  - name: Documentation
+    url: https://lyftr-app.pages.dev
+    about: Install, configuration, HTTPS, backups and troubleshooting.
+  - name: Support Lyftr
+    url: https://lyftr-app.pages.dev/support/
+    about: Ways to help the project, including sponsorship.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,3 +170,8 @@ Never commit with failing tests. Fix root cause — don't skip or comment out.
 ## Questions?
 
 Open a [discussion](../../discussions) or an issue.
+
+## Not a coder?
+
+Bug reports, doc fixes and telling other self-hosters it exists all help. If you'd rather
+help with the running costs, see [Support Lyftr](https://lyftr-app.pages.dev/support/).

--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ for how the test suite is organised.
 > **Beta** — actively built, expect rough edges and frequent updates. The software equivalent of
 > going to the gym for the first time.
 
+## Support
+
+Lyftr is free and open source under the MIT license — run it on your own hardware, no subscription.
+
+The most useful things you can do are free: file a reproducible bug report, fix a doc page that was
+wrong, or tell another self-hoster it exists.
+
+If you'd rather help with the running costs, sponsorship covers the demo server (~$4/month) and the
+developer accounts Lyftr needs to reach more platforms — the iOS app is blocked on a $99/year Apple
+Developer account, not on the code.
+
+[Sponsor on GitHub](https://github.com/sponsors/Cawlumm) · [All the ways to help](https://lyftr-app.pages.dev/support/)
+
 ## License
 
 [MIT](LICENSE)

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -56,7 +56,10 @@ export default defineConfig({
         },
         {
           label: 'Help',
-          items: [{ label: 'FAQ', slug: 'faq' }],
+          items: [
+            { label: 'FAQ', slug: 'faq' },
+            { label: 'Support Lyftr', slug: 'support' },
+          ],
         },
       ],
     }),

--- a/site/src/content/docs/support.md
+++ b/site/src/content/docs/support.md
@@ -1,0 +1,54 @@
+---
+title: Support Lyftr
+description: Ways to help Lyftr — reporting bugs, contributing code, and funding the running costs.
+---
+
+Lyftr is free and open source under the MIT license. You can run it on your own hardware,
+keep your data in a single SQLite file, and there is no subscription.
+
+If Lyftr is useful to you, here are the ways to help — the free ones matter more than
+you'd think.
+
+## Free ways to help
+
+**Report a bug.** A reproducible bug report is worth more than a donation. Include what
+you did, what happened, and what you expected — plus your deployment (Docker or local dev)
+and the relevant lines from `docker compose logs`.
+
+[Open an issue](https://github.com/Cawlumm/lyftr/issues/new/choose)
+
+**Star the repo.** It is how other self-hosters find the project.
+
+[github.com/Cawlumm/lyftr](https://github.com/Cawlumm/lyftr)
+
+**Write something down.** If a doc page was wrong, unclear, or missing the one detail you
+needed, fixing it helps the next person hit the same wall. Docs live in `site/` and a typo
+fix is a perfectly good first pull request.
+
+**Contribute code.** Setup and conventions are in
+[CONTRIBUTING.md](https://github.com/Cawlumm/lyftr/blob/main/CONTRIBUTING.md), and the test
+layout is in [docs/TESTING.md](https://github.com/Cawlumm/lyftr/blob/main/docs/TESTING.md).
+Open an issue before large changes.
+
+**Tell someone.** Most people who self-host Lyftr found it because another self-hoster
+mentioned it.
+
+## Funding it
+
+Lyftr is built by one person outside of a full-time job. Sponsorship covers the running
+costs and the developer accounts Lyftr needs to reach more platforms.
+
+[Sponsor on GitHub](https://github.com/sponsors/Cawlumm)
+
+### What the money actually pays for
+
+| Item | Cost |
+|---|---|
+| Live demo hosting ([lyftr-demo.fly.dev](https://lyftr-demo.fly.dev), always-on) | ~$4/month |
+| Apple Developer Program | $99/year — currently what blocks an iOS build |
+| Google Play developer account | $25 one-time |
+| Domain | ~$15/year |
+
+Documentation hosting, CI, and Android builds run on free tiers and cost nothing.
+
+The iOS app is the honest headline: it is blocked on a $99/year account, not on the code.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -302,6 +302,7 @@ docker compose up -d</code></pre>
           <a href={DISCORD} class="hover:text-tx-primary">Discord</a>
           <a href={DEMO} class="hover:text-tx-primary">Live demo</a>
           <a href={`${base}getting-started/`} class="hover:text-tx-primary">Docs</a>
+          <a href={`${base}support/`} class="hover:text-tx-primary">Support</a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
GitHub Sponsors is live and public, but nothing in the repo pointed at it. This wires up the links and adds a support page. **No app code** — web and mobile are untouched.

## What's here

| File | |
|---|---|
| `.github/FUNDING.yml` | **new** — Sponsor button on the repo header and every release page |
| `.github/ISSUE_TEMPLATE/config.yml` | **new** — Discord, docs and support in the issue chooser |
| `site/src/content/docs/support.md` | **new** — the support page |
| `site/astro.config.mjs` | sidebar entry under Help |
| `site/src/pages/index.astro` | footer link |
| `README.md` | Support section, near the bottom |
| `CONTRIBUTING.md` | "Not a coder?" pointer |

## Decisions worth reviewing

**Free help leads, funding follows.** Bug reports, doc fixes and word-of-mouth come first on the page; the ask is below them. This is the ordering Immich uses, and the self-hosted audience reacts badly to the reverse.

**The real bill is published**, not an abstract ask — ~$4/month for the demo server, $99/year for the Apple Developer account, $25 one-time for Play, ~$15/year for a domain. The iOS app being blocked on an account rather than on code is the honest and most fundable detail.

**No "nothing will ever be paywalled" promise.** It reads well and it is a permanent commitment made on behalf of a project that has a hosted option on its own roadmap. The page describes what Lyftr is today instead.

**Mobile carries no funding links, deliberately.** Google Play restricts linking to payment outside Play Billing and donations have no compliant path there — StreetComplete was flagged for exactly this, over an in-app link to a homepage that listed sponsors. An Android build carrying one would trade a store listing for a link that already exists in three other places. A web-only Settings row is left for a separate change.

## Testing

- `go test ./controllers/` — pass
- `site` build — clean, 12 pages
- **Playwright not run.** The local dev servers on :5173–:5175 have been up since Aug 13–14, predating the beta.6 merge and the `@lyftr/shared` consolidation, so they serve a stale module graph and the app never mounts — every spec times out waiting for elements. Environmental, not caused by this branch, and no app code changed here. Worth restarting those before the next e2e run.

## Follow-ups

- Sponsors page still needs its bio, tiers ($3/$5/$10) and goal (5 sponsors) — GitHub UI only
- Ko-fi, once that account exists — add `ko_fi:` to `FUNDING.yml`
- README line 39 and the FAQ both still say "no paywalled features", predating this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)