### PR TITLE
Fix the release badge and every APK download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,20 @@
 <p align="center">
   <a href="https://lyftr-demo.fly.dev">Live demo</a> ·
   <a href="https://lyftr-app.pages.dev">Docs</a> ·
-  <a href="https://github.com/Cawlumm/lyftr/releases/latest">Download APK</a> ·
+  <a href="https://github.com/Cawlumm/lyftr/releases">Download APK</a> ·
   <a href="https://discord.gg/hfFWsrebQA">Discord</a>
 </p>
 
+<!-- include_prereleases is load-bearing: every release ships prerelease:true (see
+     eas-build.yml), so nothing is marked "latest" and the plain badge renders
+     "no releases or repo not found". Same reason the links above point at /releases
+     rather than /releases/latest, which 302s to the list anyway. -->
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <img src="https://img.shields.io/badge/status-beta-orange" alt="Beta" />
+  <a href="https://github.com/Cawlumm/lyftr/stargazers"><img src="https://img.shields.io/github/stars/Cawlumm/lyftr?style=flat&color=f0a830" alt="GitHub stars" /></a>
   <a href="https://selfh.st/weekly/2026-04-24/"><img src="https://img.shields.io/badge/Featured%20in-selfh.st-6366f1" alt="Featured in selfh.st" /></a>
-  <a href="https://github.com/Cawlumm/lyftr/releases/latest"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?label=Android&logo=android&logoColor=white&color=3ddc84" alt="Android APK" /></a>
+  <a href="https://github.com/Cawlumm/lyftr/releases"><img src="https://img.shields.io/github/v/release/Cawlumm/lyftr?include_prereleases&label=Android&logo=android&logoColor=white&color=3ddc84" alt="Android APK" /></a>
   <img src="https://img.shields.io/badge/iOS-planned-black?logo=apple&logoColor=white" alt="iOS planned" />
 </p>
 
@@ -72,7 +77,7 @@ Open `http://localhost` and create your account.
 ## Try it
 
 - **Live demo** — [lyftr-demo.fly.dev](https://lyftr-demo.fly.dev) · `demo@lyftr.local` / `password123` (resets hourly; that account is demo-only — your own install has no default login)
-- **Android** — [download the APK](https://github.com/Cawlumm/lyftr/releases/latest), then point it at your server ([mobile docs](https://lyftr-app.pages.dev/mobile/)). iOS is planned.
+- **Android** — [download the APK](https://github.com/Cawlumm/lyftr/releases) from the newest release, then point it at your server ([mobile docs](https://lyftr-app.pages.dev/mobile/)). iOS is planned.
 
 ## Roadmap
 

--- a/site/src/content/docs/getting-started.md
+++ b/site/src/content/docs/getting-started.md
@@ -27,7 +27,7 @@ up on it.
 ## Get the app
 
 - **Android** — download the latest signed APK from the
-  [Releases](https://github.com/Cawlumm/lyftr/releases/latest) page, install it, and point it at
+  [Releases](https://github.com/Cawlumm/lyftr/releases) page, install it, and point it at
   your server. Side-loaded builds don't auto-update — reinstall over the old one when a new
   release drops.
 - **Web** — served by your self-hosted instance (see [Self-Hosting](../self-hosting/)).

--- a/site/src/content/docs/mobile.md
+++ b/site/src/content/docs/mobile.md
@@ -9,7 +9,7 @@ talking to **your** server.
 ## Android
 
 1. Download the latest signed APK from the
-   [Releases](https://github.com/Cawlumm/lyftr/releases/latest) page.
+   [Releases](https://github.com/Cawlumm/lyftr/releases) page.
 2. Open the `.apk` on your phone and allow **"install from unknown sources"** if prompted.
 3. Launch Lyftr and enter your server URL when asked.
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -16,7 +16,10 @@ const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const DEMO = 'https://lyftr-demo.fly.dev';
 const REPO = 'https://github.com/Cawlumm/lyftr';
 const DISCORD = 'https://discord.gg/hfFWsrebQA';
-const APK = 'https://github.com/Cawlumm/lyftr/releases?q=mobile-v';
+// Not /releases/latest and not ?q=mobile-v: every release ships as a prerelease so
+// /latest 302s to the list, and mobile-v* was retired when #77 unified the tag namespace
+// (RELEASING.md) — that filter still resolves, to a stale July build.
+const APK = 'https://github.com/Cawlumm/lyftr/releases';
 
 const title = 'Lyftr — Self-Hosted Workout Tracker & Hevy / Strong Alternative (Open Source)';
 const description =
@@ -27,7 +30,7 @@ const ogImage = new URL(banner.src, Astro.site).href;
 const logoUrl = new URL('logo.svg', Astro.site).href;
 
 const proof = [
-  { label: '160+ GitHub stars', href: REPO },
+  { label: '300+ GitHub stars', href: REPO }, // hand-maintained; bump it when it drifts
   { label: 'Featured in selfh.st', href: 'https://selfh.st/weekly/2026-04-24/' },
   { label: 'Runs on Pi · NAS · $5 VPS' },
   { label: 'MIT · Free · No subscription' },


### PR DESCRIPTION
The Android badge at the top of the README is currently rendering:

> **Android: no releases or repo not found**

on a repo with 302 stars. Not a shields outage — a real bug, and it has siblings.

## Root cause

Every release ships `prerelease: true` (`eas-build.yml` sets `make_latest: false`, deliberately, until a stable tag lands). So GitHub has **no release marked latest**:

```
GET /repos/Cawlumm/lyftr/releases/latest   → 404
GET https://github.com/Cawlumm/lyftr/releases/latest → 302 → /releases
```

Everything that assumed a "latest" release quietly degraded.

## What was broken

| Location | Problem |
|---|---|
| `README.md` badge | rendered "no releases or repo not found" |
| `README.md` ×2 links | primary "Download APK" CTA redirected to a list page |
| `site/.../getting-started.md` | same redirect |
| `site/.../mobile.md` | same redirect |
| `site/src/pages/index.astro` | APK link filtered `?q=mobile-v` — **a tag scheme retired by #77** |

That last one is the worst: the filter still resolves, which is why nobody caught it, but it resolves to **`mobile-v0.2.0` from July** rather than the current `v0.1.0-beta.6`.

## Fixes

- Badge gains `include_prereleases`. Verified: now renders `Android: v0.1.0-beta.6`
- All download links point at `/releases` — where `/latest` was redirecting anyway, minus the misdirection
- Landing page APK link off the retired `mobile-v` filter
- Added a stars badge. Verified: renders `302 stars`. Better social proof than any claim in the copy, and it maintains itself
- Landing page's hand-written "160+ GitHub stars" corrected to 300+, with a comment noting it's manual

Comments added at both badge and APK-link sites explaining *why* `include_prereleases` and `/releases` are load-bearing, so nobody "simplifies" them back.

## Testing

- Badges verified live against shields.io, not assumed
- `/releases` returns 200
- `site` builds clean, 11 pages
- No app code touched

## Not included

Screenshots in `docs/screenshots/` were last refreshed **2026-04-22** and predate the dashboard redesign, the registration changes and the rest-panel work. Worth a separate pass — they need a running app with demo data, and the visual result wants a human eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)