### PR TITLE
Add CodeQL, dependency review, and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,141 @@
+# Dependency updates.
+#
+# Shaped for one maintainer, not a team: monthly rather than daily, grouped so a
+# framework bump is one pull request instead of nine, and a cooldown so a release that
+# gets yanked in its first week never reaches you. Patch updates are ignored outright —
+# wger does the same, and they are almost never worth a review on their own. Security
+# advisories are unaffected by any of this; Dependabot raises those regardless of
+# schedule, grouping, or the patch-ignore rule below.
+#
+# The `ignore` entries at the bottom of the npm block record decisions already taken in
+# the dependency audit (#120), so they are not re-proposed every month. Delete an entry
+# to re-open that question deliberately.
+version: 2
+updates:
+  # ── Workspace: web + mobile + shared, one lockfile at the root ──────────────────
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      expo:
+        patterns:
+          - expo
+          - expo-*
+          - "@expo/*"
+          - react-native
+          - react-native-*
+          - "@react-native/*"
+          - metro
+          - metro-*
+      react:
+        patterns:
+          - react
+          - react-dom
+          - react-router
+          - react-router-dom
+          - "@types/react"
+          - "@types/react-dom"
+      lint:
+        patterns:
+          - eslint
+          - eslint-*
+          - "@typescript-eslint/*"
+          - typescript
+      test:
+        patterns:
+          - vitest
+          - "@vitest/*"
+          - jest
+          - jest-*
+          - "@playwright/*"
+          - "@testing-library/*"
+      build:
+        patterns:
+          - vite
+          - "@vitejs/*"
+          - tailwindcss
+          - nativewind
+          - autoprefixer
+          - postcss
+    ignore:
+      # Reviewing every patch bump costs more than it returns.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+      # Expo majors are SDK upgrades with their own migration guides and their own
+      # testing — a build has to be produced and run on a device before one can land, so
+      # they do not belong in an automated dependency PR. Raise them deliberately.
+      - dependency-name: expo
+        update-types: ["version-update:semver-major"]
+      - dependency-name: expo-*
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-native
+        update-types: ["version-update:semver-major"]
+      # React Router 7 fixes two advisories that cannot fire here — one needs SSR, which
+      # this SPA does not do, and the other needs a user-controlled navigation target,
+      # which no route in the app has. See #120. Worth doing on its own merits, not as a
+      # security bump.
+      - dependency-name: react-router
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-router-dom
+        update-types: ["version-update:semver-major"]
+
+  # ── Backend ────────────────────────────────────────────────────────────────────
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - backend
+    groups:
+      golang-x:
+        patterns:
+          - golang.org/x/*
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
+  # ── Workflow actions ───────────────────────────────────────────────────────────
+  #
+  # A pinned action is a supply-chain dependency like any other, and these are the one
+  # ecosystem where patch updates matter: actions are usually pinned to a major tag that
+  # moves under you, so an explicit bump is the only visible record.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - ci
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # ── Container base images ──────────────────────────────────────────────────────
+  #
+  # Nothing watched these before. golang:1.26-alpine and node:20-alpine float to the
+  # latest patch on rebuild, but alpine:3.19 and nginx:alpine are the runtime layers that
+  # actually ship, and a pinned alpine minor goes stale quietly.
+  - package-ecosystem: docker
+    directory: /backend
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - docker
+  - package-ecosystem: docker
+    directory: /web
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,81 @@
+name: CodeQL
+
+# Static analysis for the Go backend, the TypeScript in web/mobile/shared, and the
+# workflow files themselves. Free on public repositories, including the Actions minutes.
+#
+# What this does and does not buy: CodeQL finds the pattern-shaped classes — injection,
+# path traversal, XSS, unsafe deserialization, hardcoded credentials. It does not find
+# semantic defects. The three real bugs the password work turned up (a 500 on any
+# password over bcrypt's 72-byte limit, a 12x login timing oracle, and case-sensitive
+# email collisions) would all have sailed past it. Treat this as covering a class that
+# manual review is bad at, not as a substitute for review.
+#
+# Separate from ci.yml on purpose: that workflow gates its jobs behind a `changes` filter
+# so unrelated pushes skip them, and a scheduled security scan wants the opposite —
+# to run on a fixed cadence whatever changed, because the queries improve even when the
+# code does not.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays, 04:17 UTC. Off the hour so it does not land in the crowd of jobs that
+    # every repo schedules at :00.
+    - cron: "17 4 * * 1"
+
+# A superseded run has nothing to say; cancel it rather than paying for it.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          # One TypeScript job covers web, mobile and packages/shared — CodeQL analyses
+          # the checkout, and splitting it would only duplicate work.
+          - language: javascript-typescript
+            build-mode: none
+          # The workflows themselves. Actions are a supply-chain surface and this is the
+          # only thing that looks at them.
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The go directive is 1.26.6; without this the runner's default toolchain may be
+      # older and autobuild fails before any analysis happens.
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache-dependency-path: backend/go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds the lower-confidence queries. On a codebase this size
+          # the extra noise is manageable, and the point of turning this on is coverage.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,38 @@
+name: Dependency review
+
+# Fails a pull request that *introduces* a dependency with a known advisory, or one under
+# a licence the project cannot ship.
+#
+# This is the counterpart to Dependabot rather than a duplicate of it. Dependabot tells
+# you about what is already installed — a backlog, most of which needs a major version
+# bump nobody is going to take this week. This only looks at what the diff adds, so it
+# stays quiet until a pull request would make things worse. That makes it the one
+# security check here that can be a hard failure without becoming noise.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  # Needed to leave the summary comment on the pull request.
+  pull-requests: write
+
+jobs:
+  review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review
+        uses: actions/dependency-review-action@v4
+        with:
+          # Moderate and above fails. The existing moderate findings are all either
+          # unreachable or blocked behind a major (see #120), but that is an argument for
+          # not adding more, not for tolerating new ones.
+          fail-on-severity: moderate
+          comment-summary-in-pr: always
+          # Copyleft licences would make the project undistributable as it stands.
+          deny-licenses: AGPL-3.0, GPL-3.0


### PR DESCRIPTION
The repo had secret scanning and push protection on and nothing else. This adds the three pieces that need files in the tree.

Already enabled via the API, no file needed: **Dependabot alerts** and **private vulnerability reporting**.

Not enabled, and worth knowing why: **secret scanning validity checks** and **non-provider patterns** are part of GitHub Secret Protection, a paid add-on. They are not free on public repos — the API accepts the PATCH with a 200 and silently changes nothing.

## Shaped after what peers actually run

Surveyed six comparable self-hosted projects rather than working from the docs:

| repo | CodeQL | dep updates |
|---|---|---|
| Immich | ✅ | Renovate |
| wger | ✅ | Dependabot |
| paperless-ngx | ✅ | Dependabot |
| Jellyfin | ✅ | — |
| Gitea | — | — |
| Vaultwarden | — | — |

Dependabot rather than Renovate: Immich's config leans on a shared org preset, which a single maintainer ends up maintaining alone.

## What each piece does

**CodeQL** — Go, TypeScript, and the workflow files. Workflows are a supply-chain surface and nothing else looks at them. Deliberately separate from `ci.yml`: that workflow gates jobs behind a `changes` filter so unrelated pushes skip them, and a scheduled security scan wants the opposite — a fixed cadence, because the queries improve even when the code does not.

**Dependency review** — fails a PR that *introduces* an advisory. The counterpart to Dependabot rather than a duplicate: Dependabot reports the existing backlog, most of which needs a major nobody will take this week; this reads only the diff. Being diff-scoped is what lets it be a hard failure without becoming noise. Verified no AGPL or GPL-3.0 package is already installed, so the licence rule cannot fire spuriously.

**Dependabot** — monthly, 7-day cooldown, grouped so an Expo bump is one PR instead of nine, patch updates ignored. The shape wger and paperless-ngx converged on. Security advisories bypass all of it and are raised regardless.

Two ecosystems nothing watched before: `github-actions`, where pinned major tags move underneath you silently, and `docker`, where `alpine:3.19` and `nginx:alpine` are the layers that actually ship.

The npm `ignore` list records decisions already argued in #120 — the Expo majors, and React Router 7 for two advisories that cannot fire in an SPA with no user-controlled navigation targets — so they are not re-proposed every month. Deleting an entry re-opens that question deliberately.

## Expect the Security tab to light up

This is the first CodeQL run, at `security-extended`, against a codebase that has never been scanned. Findings on this PR are a baseline to triage, not a regression it introduced.

## Worth stating plainly

None of this would have caught the three defects the password work turned up — the 500 on any password over bcrypt's 72-byte limit, the 12x login timing oracle, or the case-sensitive email collisions (#119). Those are semantic. This covers a class manual review is bad at; it is not a substitute for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWC4KiFeoRZ3gtApGFHv1u