### PR TITLE
Refresh the cache by id, and stop the picker double-fetching its first page

### DIFF
--- a/backend/oedb/client.go
+++ b/backend/oedb/client.go
@@ -446,3 +446,48 @@ func (c *Client) Export(ctx context.Context) ([]Exercise, error) {
 	}
 	return out.Exercises, nil
 }
+
+// maxIDsPerRequest is oedb's documented cap for the ids filter. Exceeding it is
+// a 422, not a truncation, so the batching below has to respect it rather than
+// discover it.
+const maxIDsPerRequest = 100
+
+// ListByIDs fetches specific exercises by their oedb UUIDs.
+//
+// This is what refreshing a cache should cost: a request proportional to what is
+// held, rather than the full catalog export filtered down afterwards. Until oedb
+// grew this filter the export was the only route, which meant ~300 KB to
+// re-read a handful of rows.
+//
+// Requests are issued one batch at a time rather than concurrently. The batches
+// are few, each response is cached upstream, and a burst of parallel requests is
+// exactly the shape that trips a rate limiter for no gain in wall-clock worth
+// having.
+func (c *Client) ListByIDs(ctx context.Context, ids []string) ([]Exercise, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	out := make([]Exercise, 0, len(ids))
+	for start := 0; start < len(ids); start += maxIDsPerRequest {
+		end := start + maxIDsPerRequest
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		// per_page must cover the batch, or the response is paginated and the
+		// tail of the batch is silently missing — the failure would look like
+		// "some rows just never refresh".
+		batch := ids[start:end]
+		q := url.Values{}
+		q.Set("ids", strings.Join(batch, ","))
+		q.Set("per_page", strconv.Itoa(len(batch)))
+
+		var res ListResult
+		if err := c.getJSON(ctx, "/api/v1/exercises?"+q.Encode(), &res); err != nil {
+			return nil, err
+		}
+		out = append(out, res.Exercises...)
+	}
+	return out, nil
+}

--- a/backend/oedb/client_test.go
+++ b/backend/oedb/client_test.go
@@ -345,3 +345,76 @@ func TestRetryAfter(t *testing.T) {
 		t.Errorf("retryAfter(\"2\") = %v, %v", d, ok)
 	}
 }
+
+// oedb rejects more than 100 ids per request outright, so the batching has to
+// respect that boundary rather than discover it. Getting this wrong loses the
+// tail of a refresh silently — rows that simply never update.
+func TestListByIDs_BatchesAtTheCap(t *testing.T) {
+	var requests []struct {
+		ids     []string
+		perPage string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("ids") == "" {
+			t.Errorf("request without ids: %s", r.URL)
+		}
+		ids := strings.Split(q.Get("ids"), ",")
+		if len(ids) > 100 {
+			// Mirror oedb: over the cap is a rejection, not a truncation.
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
+		requests = append(requests, struct {
+			ids     []string
+			perPage string
+		}{ids, q.Get("per_page")})
+
+		items := make([]string, 0, len(ids))
+		for _, id := range ids {
+			items = append(items, fmt.Sprintf(
+				`{"id":%q,"slug":"ex","translation":{"name":"Exercise %s","instructions":[]}}`, id, id))
+		}
+		fmt.Fprintf(w, `{"exercises":[%s],"total":%d,"page":1,"per_page":%d}`,
+			strings.Join(items, ","), len(items), len(items))
+	}))
+	defer srv.Close()
+
+	ids := make([]string, 250)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("uuid-%03d", i)
+	}
+
+	got, err := New(srv.URL, "test").ListByIDs(context.Background(), ids)
+	if err != nil {
+		t.Fatalf("list by ids: %v", err)
+	}
+	if len(got) != 250 {
+		t.Fatalf("got %d exercises, want 250 — a batch was lost", len(got))
+	}
+	if len(requests) != 3 {
+		t.Fatalf("made %d requests, want 3 batches of at most 100", len(requests))
+	}
+	for i, req := range requests {
+		if len(req.ids) > 100 {
+			t.Errorf("batch %d had %d ids, over the cap", i, len(req.ids))
+		}
+		// per_page must cover the batch or the response is paginated and the
+		// tail goes missing without an error.
+		if req.perPage != fmt.Sprint(len(req.ids)) {
+			t.Errorf("batch %d: per_page=%s for %d ids", i, req.perPage, len(req.ids))
+		}
+	}
+}
+
+func TestListByIDs_EmptyMakesNoRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for an empty id set: %s", r.URL)
+	}))
+	defer srv.Close()
+
+	got, err := New(srv.URL, "test").ListByIDs(context.Background(), nil)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("got %v, %v; want no rows and no error", got, err)
+	}
+}

--- a/backend/stores/exercise.go
+++ b/backend/stores/exercise.go
@@ -321,9 +321,10 @@ func (s *ExerciseStore) CachedCount() (int, error) { return s.Count() }
 // upstream without importing the catalog. New exercises arrive the same way every
 // other row did — the first time someone's search returns one.
 //
-// It reads the bulk export and intersects locally rather than fetching each row
-// by id, because oedb has no batch-by-ids endpoint: refreshing 873 rows one at a
-// time would be 873 requests against a 60/minute limit, or about a quarter hour.
+// It asks for exactly the rows it holds, in batches of a hundred. This used to
+// read the whole export and intersect locally, because oedb had no way to fetch
+// a named set — so refreshing thirty exercises cost a 300 KB response, and the
+// only alternative was one request per row against a per-minute limit.
 func (s *ExerciseStore) RefreshCached(ctx context.Context) (int, error) {
 	if s.catalog == nil {
 		return 0, ErrNoCatalog
@@ -337,38 +338,31 @@ func (s *ExerciseStore) RefreshCached(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	items, err := s.catalog.Export(ctx)
+	items, err := s.catalog.ListByIDs(ctx, held)
 	if err != nil {
 		return 0, err
 	}
 
-	keep := items[:0]
-	for _, it := range items {
-		if held[it.ID] {
-			keep = append(keep, it)
-		}
-	}
-
-	out, err := s.Materialize(keep, s.catalog.BaseURL())
+	out, err := s.Materialize(items, s.catalog.BaseURL())
 	if err != nil {
 		return 0, err
 	}
 	return len(out), nil
 }
 
-func (s *ExerciseStore) cachedOedbIDs() (map[string]bool, error) {
+func (s *ExerciseStore) cachedOedbIDs() ([]string, error) {
 	rows, err := s.db.Query(`SELECT oedb_id FROM exercises WHERE oedb_id IS NOT NULL AND oedb_id != ''`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	held := map[string]bool{}
+	var held []string
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}
-		held[id] = true
+		held = append(held, id)
 	}
 	return held, rows.Err()
 }

--- a/backend/stores/exercise_test.go
+++ b/backend/stores/exercise_test.go
@@ -248,12 +248,26 @@ func TestClearUnreferenced_KeepsReferencedRows(t *testing.T) {
 // Refresh applies upstream edits to rows already held, and must not import rows
 // the instance has never seen — that is the line between refreshing a cache and
 // seeding a library.
+//
+// It now asks for the rows by id rather than pulling the export and filtering,
+// so this asserts on the request as well as the result: fetching the whole
+// catalog to update two rows is the cost this replaced.
 func TestRefreshCached_UpdatesHeldRowsWithoutImporting(t *testing.T) {
+	var paths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"exercises":[
-			{"id":"uuid-1","slug":"held","muscle_group":"chest","translation":{"name":"Held Renamed","instructions":[]}},
-			{"id":"uuid-2","slug":"new","muscle_group":"back","translation":{"name":"Never Seen","instructions":[]}}
-		],"total":2}`)
+		paths = append(paths, r.URL.Path)
+		ids := r.URL.Query().Get("ids")
+		if ids == "" {
+			t.Errorf("refresh fetched %s without naming ids", r.URL)
+		}
+		// Answer only what was asked for, the way the real endpoint does.
+		var items []string
+		for _, id := range strings.Split(ids, ",") {
+			if id == "uuid-1" {
+				items = append(items, `{"id":"uuid-1","slug":"held","muscle_group":"chest","translation":{"name":"Held Renamed","instructions":[]}}`)
+			}
+		}
+		fmt.Fprintf(w, `{"exercises":[%s],"total":%d,"page":1,"per_page":100}`, strings.Join(items, ","), len(items))
 	}))
 	defer srv.Close()
 
@@ -273,6 +287,12 @@ func TestRefreshCached_UpdatesHeldRowsWithoutImporting(t *testing.T) {
 		t.Errorf("refreshed %d, want 1", n)
 	}
 
+	for _, p := range paths {
+		if strings.Contains(p, "export") {
+			t.Errorf("refresh pulled the export (%s); it should ask for the ids it holds", p)
+		}
+	}
+
 	var total int
 	conn.QueryRow(`SELECT COUNT(*) FROM exercises`).Scan(&total)
 	if total != 1 {
@@ -282,6 +302,24 @@ func TestRefreshCached_UpdatesHeldRowsWithoutImporting(t *testing.T) {
 	conn.QueryRow(`SELECT name FROM exercises WHERE oedb_id = 'uuid-1'`).Scan(&name)
 	if name != "Held Renamed" {
 		t.Errorf("name = %q, want the upstream edit applied", name)
+	}
+}
+
+// An instance with nothing cached has nothing to refresh, and must not reach for
+// the catalog to discover that.
+func TestRefreshCached_EmptyCacheMakesNoRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request with an empty cache: %s", r.URL)
+	}))
+	defer srv.Close()
+
+	conn := testDB(t)
+	s := NewExerciseStore(conn)
+	s.UseCatalog(oedb.New(srv.URL, "test"))
+
+	n, err := s.RefreshCached(context.Background())
+	if err != nil || n != 0 {
+		t.Fatalf("got %d, %v; want 0 and no error", n, err)
 	}
 }
 

--- a/web/src/components/ExercisePicker.test.tsx
+++ b/web/src/components/ExercisePicker.test.tsx
@@ -75,24 +75,50 @@ describe('ExercisePicker', () => {
 
   // A slow earlier response must not overwrite a newer one. Without a sequence
   // guard the list ends up showing results for a query the user has moved past.
+  //
+  // Both requests are searches, spaced past the debounce, rather than relying on
+  // the opening fetch: a keystroke that lands before the mount timer fires now
+  // cancels it, so the opening request is not reliably in flight to race with.
   it('ignores a stale response that arrives after a newer one', async () => {
     let releaseFirst: (v: types.Exercise[]) => void = () => {}
     listMock
+      .mockImplementationOnce(() => Promise.resolve(fullPage('Unfiltered')))
       .mockImplementationOnce(() => new Promise(resolve => { releaseFirst = resolve }))
       .mockImplementation(() => Promise.resolve([exercise(2, 'Front Squat')]))
 
     render(<ExercisePicker selectedIds={[]} onSelect={() => {}} onClose={() => {}} />)
-    fireEvent.change(screen.getByPlaceholderText(/search exercises/i), { target: { value: 'squat' } })
+    const box = screen.getByPlaceholderText(/search exercises/i)
 
+    // First search: fires, then hangs.
+    fireEvent.change(box, { target: { value: 'squa' } })
+    await waitFor(() => expect(listMock).toHaveBeenCalledTimes(2))
+
+    // Second search, after the debounce window, resolves while the first is open.
+    fireEvent.change(box, { target: { value: 'squat' } })
     expect(await screen.findByText('Front Squat')).toBeTruthy()
 
-    // The initial unfiltered page lands late; it must not replace the search results.
-    releaseFirst([exercise(1, 'Stale Unfiltered Row')])
+    // The stale first search lands late and must not replace the newer results.
+    releaseFirst([exercise(1, 'Stale Row')])
 
     await waitFor(() => {
-      expect(screen.queryByText('Stale Unfiltered Row')).toBeNull()
+      expect(screen.queryByText('Stale Row')).toBeNull()
     })
     expect(screen.getByText('Front Squat')).toBeTruthy()
+  })
+
+  // Opening the picker used to fetch page 1 twice: an initial load effect and a
+  // debounced query effect both fired on mount, and the debounce only staggered
+  // them. Cheap to reintroduce, invisible without a count.
+  it('fetches the first page exactly once on open', async () => {
+    listMock.mockResolvedValue(fullPage('Exercise'))
+    render(<ExercisePicker selectedIds={[]} onSelect={() => {}} onClose={() => {}} />)
+
+    await waitFor(() => expect(listMock).toHaveBeenCalled())
+    // Let the debounce window pass, so a second mount-time load would land.
+    await new Promise(r => setTimeout(r, 400))
+
+    const firstPageCalls = listMock.mock.calls.filter(([params]) => (params?.page ?? 1) === 1)
+    expect(firstPageCalls).toHaveLength(1)
   })
 
   it('asks the server for each page rather than filtering locally', async () => {

--- a/web/src/components/ExercisePicker.tsx
+++ b/web/src/components/ExercisePicker.tsx
@@ -61,13 +61,15 @@ export default function ExercisePicker({ selectedIds, onSelect, onClose }: Props
     }
   }, [])
 
-  useEffect(() => { load('', 1) }, [load])
-
+  // One effect, not two. An initial load plus a debounced query effect both fire
+  // on mount, so opening the picker fetched page 1 twice — the debounce only
+  // staggered them. Debouncing the empty query by zero gives the first page
+  // immediately and still waits out typing.
   useEffect(() => {
     const t = setTimeout(() => {
       setExhausted(false)
       load(query, 1)
-    }, 250)
+    }, query ? 250 : 0)
     return () => clearTimeout(t)
   }, [query, load])
 

--- a/web/src/pages/WorkoutExercisePicker.tsx
+++ b/web/src/pages/WorkoutExercisePicker.tsx
@@ -41,13 +41,15 @@ export default function WorkoutExercisePicker() {
     finally { if (reqRef.current === id) setLoading(false) }
   }, [])
 
-  useEffect(() => { load('', 1) }, [load])
-
+  // One effect, not two. An initial load plus a debounced query effect both fire
+  // on mount, so opening the picker fetched page 1 twice — the debounce only
+  // staggered them. Debouncing the empty query by zero gives the first page
+  // immediately and still waits out typing.
   useEffect(() => {
     const t = setTimeout(() => {
       setExhausted(false)
       load(query, 1)
-    }, 250)
+    }, query ? 250 : 0)
     return () => clearTimeout(t)
   }, [query, load])
 


### PR DESCRIPTION
Refreshing asked open-exercise-db for its **entire export** and then discarded
everything it wasn't already holding. That was the only route available — nothing
could fetch a named set of rows — so re-reading thirty exercises cost a 300 KB
response.

oedb now has an `ids` filter (Cawlumm/open-exercise-db#21), so refresh asks for
exactly the rows it holds, in batches of 100.

**Measured against production**, 235 cached exercises:

| | before | after |
|---|---|---|
| requests | 1 export | 3 batched |
| transferred | ~300 KB | proportional to what's held |
| time | — | **3.1s** |
| export calls | 1 | **0** |

## Details worth reviewing

- **Batches are sequential, not concurrent.** There are few of them, each response
  is cached upstream, and a burst of parallel requests is exactly the shape that
  trips a rate limiter for a wall-clock saving not worth having.
- **`per_page` is set to the batch size** on every request. Without it the response
  comes back paginated at the default and the tail of each batch goes missing —
  which surfaces as "some rows never seem to update", not as an error.
- **Empty cache makes no request at all**, rather than reaching for the catalog to
  discover it has nothing to refresh.

## Verification

The test asserts on the *request*, not just the result — "it refreshed the right
rows" was true of the old implementation too. Pointing refresh back at the export
fails it with:

```
refresh fetched /api/v1/exercises/export without naming ids
refresh pulled the export; it should ask for the ids it holds
```

Batching is covered at the boundary (250 ids → 3 requests, none over 100, each
with a matching `per_page`), since that's where rows would be lost silently.

`stores` and `oedb` pass locally; CI runs the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)