### PR TITLE
Let a saved food be removed from My Foods

### DIFF
--- a/mobile/app/(tabs)/nutrition/log.tsx
+++ b/mobile/app/(tabs)/nutrition/log.tsx
@@ -10,10 +10,11 @@ import {
   type FoodSearchResult, type SavedFood,
 } from '@lyftr/shared'
 import {
-  AppText, Button, Card, DateInput, IconButton, Label, NumberField,
+  Alert, AppText, Button, Card, DateInput, IconButton, Label, NumberField,
   NumericKeyboardAccessory, NUMERIC_ACCESSORY_ID, Screen, SearchField, SegmentedControl, Toggle,
 } from '../../../src/components/ui'
 import { BarcodeScanner } from '../../../src/components/nutrition/BarcodeScanner'
+import { FoodResultRow } from '../../../src/components/nutrition/FoodResultRow'
 import {
   MACRO_COLORS, MACRO_TEXT, MEALS, MEAL_COLORS, MEAL_ICONS, MEAL_LABELS, type Meal,
 } from '../../../src/components/nutrition/nutritionMeta'
@@ -33,43 +34,6 @@ const TAB_OPTIONS = [
 ] as const
 
 // Port of web/pages/LogFood.tsx — the search / detail / scan food-logging flow.
-function FoodResultRow({ item, onPress }: { item: FoodSearchResult; onPress: () => void }) {
-  const { colors } = useTheme()
-  return (
-    <Pressable
-      onPress={onPress}
-      className="w-full flex-row items-center gap-3 border-b border-surface-border px-4 py-3.5 active:bg-surface-muted"
-    >
-      {item.image_url ? (
-        <Image source={{ uri: item.image_url }} className="h-11 w-11 rounded-xl border border-surface-border" />
-      ) : (
-        <View className="h-11 w-11 items-center justify-center rounded-xl border border-surface-border bg-surface-muted">
-          <Utensils size={20} color={colors.txMuted} />
-        </View>
-      )}
-      <View className="min-w-0 flex-1">
-        <AppText variant="bodySemibold" numberOfLines={1}>{item.name}</AppText>
-        {item.brand ? <AppText variant="caption" color="muted" numberOfLines={1} className="mt-0.5">{item.brand}</AppText> : null}
-        <View className="mt-1 flex-row flex-wrap items-center gap-x-1.5">
-          <AppText variant="caption" color="secondary" style={{ fontWeight: '600', fontVariant: ['tabular-nums'] }}>{Math.round(item.calories)} kcal</AppText>
-          <Dot />
-          <AppText variant="caption" style={{ color: MACRO_TEXT.protein, fontVariant: ['tabular-nums'] }}>{item.protein.toFixed(0)}g P</AppText>
-          <Dot />
-          <AppText variant="caption" style={{ color: MACRO_TEXT.carbs, fontVariant: ['tabular-nums'] }}>{item.carbs.toFixed(0)}g C</AppText>
-          <Dot />
-          <AppText variant="caption" style={{ color: MACRO_TEXT.fat, fontVariant: ['tabular-nums'] }}>{item.fat.toFixed(0)}g F</AppText>
-          {item.serving_size ? (<><Dot /><AppText variant="caption" color="muted" style={{ fontSize: 10 }}>{item.serving_size}</AppText></>) : null}
-        </View>
-      </View>
-      <ChevronRight size={16} color={colors.txMuted} />
-    </Pressable>
-  )
-}
-
-function Dot() {
-  return <AppText variant="caption" color="muted" style={{ fontSize: 10 }}>·</AppText>
-}
-
 export default function LogFood() {
   const { colors, brand, accent, isDark } = useTheme()
   const params = useLocalSearchParams<{ meal?: string; date?: string; edit?: string }>()
@@ -94,6 +58,7 @@ export default function LogFood() {
   const [saveToMyFoods, setSaveToMyFoods] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -323,7 +288,26 @@ export default function LogFood() {
                 savedFoods.length === 0 ? (
                   <EmptyBlock icon={Bookmark} title="No saved foods yet" subtitle="Save foods while logging to find them here" />
                 ) : (
-                  savedFoods.map((sf) => <FoodResultRow key={sf.id} item={savedToResult(sf)} onPress={() => selectResult(savedToResult(sf))} />)
+                  <>
+                    {deleteError ? (
+                      <View className="px-4 pt-3">
+                        <Alert variant="error">{deleteError}</Alert>
+                      </View>
+                    ) : null}
+                    {savedFoods.map((sf) => (
+                      <FoodResultRow
+                        key={sf.id}
+                        item={savedToResult(sf)}
+                        onPress={() => selectResult(savedToResult(sf))}
+                        savedFoodId={sf.id}
+                        onDeleted={(id) => {
+                          setDeleteError(null)
+                          setSavedFoods((prev) => prev.filter((f) => f.id !== id))
+                        }}
+                        onDeleteFailed={setDeleteError}
+                      />
+                    ))}
+                  </>
                 )
               ) : null}
 

--- a/mobile/src/components/nutrition/FoodResultRow.test.tsx
+++ b/mobile/src/components/nutrition/FoodResultRow.test.tsx
@@ -1,0 +1,127 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native'
+import type { FoodSearchResult } from '@lyftr/shared'
+
+// Same preamble as the programs component tests: expo-router can't load under bare jest,
+// and the ui barrel reaches it via useTheme → lib/lyftr.
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn(), navigate: jest.fn(), replace: jest.fn() },
+}))
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+)
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}))
+jest.mock('expo-haptics', () => ({
+  selectionAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  impactAsync: jest.fn(() => Promise.resolve()),
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning', Error: 'error' },
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+}))
+
+import { FoodResultRow } from './FoodResultRow'
+import { client } from '../../lib/lyftr'
+
+const item = (overrides: Partial<FoodSearchResult> = {}): FoodSearchResult => ({
+  name: 'Chicken Breast',
+  calories: 165,
+  protein: 31,
+  carbs: 0,
+  fat: 3.6,
+  fiber: 0,
+  serving_size: '100g',
+  source: 'off',
+  ...overrides,
+})
+
+const OPTIONS_LABEL = 'Chicken Breast options'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('FoodResultRow', () => {
+  // The Recent and search tabs render this same row and must not gain a delete control —
+  // they show foods the user does not own. This is the regression guard for #115's
+  // restructure of a component shared by all three tabs.
+  it('renders no options menu when it is not a saved food', () => {
+    render(<FoodResultRow item={item()} onPress={() => {}} />)
+    expect(screen.queryByLabelText(OPTIONS_LABEL)).toBeNull()
+  })
+
+  it('renders no options menu when savedFoodId is given without onDeleted', () => {
+    render(<FoodResultRow item={item()} onPress={() => {}} savedFoodId={7} />)
+    expect(screen.queryByLabelText(OPTIONS_LABEL)).toBeNull()
+  })
+
+  it('renders the options menu for a saved food', () => {
+    render(<FoodResultRow item={item()} onPress={() => {}} savedFoodId={7} onDeleted={() => {}} />)
+    expect(screen.getByLabelText(OPTIONS_LABEL)).toBeTruthy()
+  })
+
+  it('tapping the row still selects the food rather than opening the menu', () => {
+    const onPress = jest.fn()
+    render(<FoodResultRow item={item()} onPress={onPress} savedFoodId={7} onDeleted={() => {}} />)
+    fireEvent.press(screen.getByText('Chicken Breast'))
+    expect(onPress).toHaveBeenCalled()
+  })
+
+  it('deletes through the API and reports the id back after confirming', async () => {
+    jest.useFakeTimers()
+    const del = jest.spyOn(client.savedFoodsAPI, 'delete').mockResolvedValue(undefined as never)
+    const onDeleted = jest.fn()
+    const onDeleteFailed = jest.fn()
+
+    render(
+      <FoodResultRow
+        item={item()}
+        onPress={() => {}}
+        savedFoodId={7}
+        onDeleted={onDeleted}
+        onDeleteFailed={onDeleteFailed}
+      />,
+    )
+
+    fireEvent.press(screen.getByLabelText(OPTIONS_LABEL))
+    fireEvent.press(screen.getByText('Remove from My Foods'))
+    // ActionSheet defers the action until after its dismiss animation so the confirm
+    // sheet isn't presented mid-close.
+    act(() => { jest.runOnlyPendingTimers() })
+
+    fireEvent.press(screen.getByText('Remove'))
+
+    await waitFor(() => expect(del).toHaveBeenCalledWith(7))
+    expect(onDeleted).toHaveBeenCalledWith(7)
+    expect(onDeleteFailed).not.toHaveBeenCalled()
+    jest.useRealTimers()
+  })
+
+  // A swallowed failure leaves the row on screen with no explanation, which reads as a
+  // dead button — the exact shape of the complaint in #115.
+  it('reports a failed delete instead of dropping the row', async () => {
+    jest.useFakeTimers()
+    jest.spyOn(client.savedFoodsAPI, 'delete').mockRejectedValue(new Error('boom'))
+    const onDeleted = jest.fn()
+    const onDeleteFailed = jest.fn()
+
+    render(
+      <FoodResultRow
+        item={item()}
+        onPress={() => {}}
+        savedFoodId={7}
+        onDeleted={onDeleted}
+        onDeleteFailed={onDeleteFailed}
+      />,
+    )
+
+    fireEvent.press(screen.getByLabelText(OPTIONS_LABEL))
+    fireEvent.press(screen.getByText('Remove from My Foods'))
+    act(() => { jest.runOnlyPendingTimers() })
+    fireEvent.press(screen.getByText('Remove'))
+
+    await waitFor(() => expect(onDeleteFailed).toHaveBeenCalled())
+    expect(onDeleted).not.toHaveBeenCalled()
+    jest.useRealTimers()
+  })
+})

--- a/mobile/src/components/nutrition/FoodResultRow.tsx
+++ b/mobile/src/components/nutrition/FoodResultRow.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { Image, Pressable, View } from 'react-native'
+import * as Haptics from 'expo-haptics'
+import { ChevronRight, MoreVertical, Utensils } from 'lucide-react-native'
+import type { FoodSearchResult } from '@lyftr/shared'
+import {
+  ActionSheet, AppText, ConfirmSheet, IconButton, deleteAction, deleteConfirmProps,
+} from '../ui'
+import { useTheme } from '../../theme/useTheme'
+import { client } from '../../lib/lyftr'
+import { MACRO_TEXT } from './nutritionMeta'
+
+interface Props {
+  item: FoodSearchResult
+  /** Tap the row → pick this food and go to the detail step. */
+  onPress: () => void
+  /**
+   * The saved_foods row id, when this result came from My Foods. Its presence is what
+   * puts the ⋮ menu on the row — Recent and search results are not owned by the user and
+   * have nothing to delete.
+   */
+  savedFoodId?: number
+  /** Called after a successful server delete so the screen can drop the row. */
+  onDeleted?: (id: number) => void
+  /**
+   * Surface a failed delete. FoodEntryRow swallows this case, which leaves the row on
+   * screen with no explanation — indistinguishable from a dead button, and #115 was
+   * already a report about a missing affordance.
+   */
+  onDeleteFailed?: (message: string) => void
+}
+
+// The search / Recent / My Foods result row, extracted from the log screen so the delete
+// path can be tested without rendering the whole flow.
+//
+// The menu mirrors FoodEntryRow: a ⋮ IconButton inside the row Pressable opening an
+// ActionSheet, with Delete routed through the shared ConfirmSheet. Nesting the button in
+// the Pressable is what that component already does and ships.
+export function FoodResultRow({ item, onPress, savedFoodId, onDeleted, onDeleteFailed }: Props) {
+  const { colors } = useTheme()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [confirming, setConfirming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const deletable = savedFoodId !== undefined && onDeleted !== undefined
+
+  const handleDelete = async () => {
+    if (savedFoodId === undefined) return
+    setDeleting(true)
+    try {
+      await client.savedFoodsAPI.delete(savedFoodId)
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {})
+      onDeleted?.(savedFoodId)
+    } catch {
+      onDeleteFailed?.(`Couldn't remove ${item.name} from My Foods.`)
+      setDeleting(false)
+      setConfirming(false)
+    }
+  }
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className="w-full flex-row items-center gap-3 border-b border-surface-border px-4 py-3.5 active:bg-surface-muted"
+    >
+      {item.image_url ? (
+        <Image source={{ uri: item.image_url }} className="h-11 w-11 rounded-xl border border-surface-border" />
+      ) : (
+        <View className="h-11 w-11 items-center justify-center rounded-xl border border-surface-border bg-surface-muted">
+          <Utensils size={20} color={colors.txMuted} />
+        </View>
+      )}
+      <View className="min-w-0 flex-1">
+        <AppText variant="bodySemibold" numberOfLines={1}>{item.name}</AppText>
+        {item.brand ? <AppText variant="caption" color="muted" numberOfLines={1} className="mt-0.5">{item.brand}</AppText> : null}
+        <View className="mt-1 flex-row flex-wrap items-center gap-x-1.5">
+          <AppText variant="caption" color="secondary" style={{ fontWeight: '600', fontVariant: ['tabular-nums'] }}>{Math.round(item.calories)} kcal</AppText>
+          <Dot />
+          <AppText variant="caption" style={{ color: MACRO_TEXT.protein, fontVariant: ['tabular-nums'] }}>{item.protein.toFixed(0)}g P</AppText>
+          <Dot />
+          <AppText variant="caption" style={{ color: MACRO_TEXT.carbs, fontVariant: ['tabular-nums'] }}>{item.carbs.toFixed(0)}g C</AppText>
+          <Dot />
+          <AppText variant="caption" style={{ color: MACRO_TEXT.fat, fontVariant: ['tabular-nums'] }}>{item.fat.toFixed(0)}g F</AppText>
+          {item.serving_size ? (<><Dot /><AppText variant="caption" color="muted" style={{ fontSize: 10 }}>{item.serving_size}</AppText></>) : null}
+        </View>
+      </View>
+
+      {deletable ? (
+        <IconButton
+          icon={MoreVertical}
+          label={`${item.name} options`}
+          variant="ghost"
+          size="sm"
+          onPress={() => setMenuOpen(true)}
+          disabled={deleting}
+        />
+      ) : null}
+      <ChevronRight size={16} color={colors.txMuted} />
+
+      {deletable ? (
+        <>
+          <ActionSheet
+            open={menuOpen}
+            title="Saved food"
+            subtitle={item.name}
+            onClose={() => setMenuOpen(false)}
+            actions={[deleteAction(() => setConfirming(true), 'Remove from My Foods')]}
+          />
+          <ConfirmSheet
+            {...deleteConfirmProps({ title: 'Remove from My Foods?', subject: `"${item.name}"` })}
+            confirmLabel="Remove"
+            busyLabel="Removing…"
+            open={confirming}
+            busy={deleting}
+            onConfirm={handleDelete}
+            onCancel={() => setConfirming(false)}
+          />
+        </>
+      ) : null}
+    </Pressable>
+  )
+}
+
+function Dot() {
+  return <AppText variant="caption" color="muted" style={{ fontSize: 10 }}>·</AppText>
+}

--- a/web/e2e/food.spec.ts
+++ b/web/e2e/food.spec.ts
@@ -364,6 +364,33 @@ test.describe('Food', () => {
     await expect(page.getByText(savedName)).toBeVisible({ timeout: 8000 })
   })
 
+  // #115: the delete endpoint and the client method both existed, but nothing called
+  // them — a saved food could not be removed from either app. Creates its own row rather
+  // than using the shared seed so the other My Foods tests keep theirs.
+  test('removes a saved food from My Foods', async ({ page, request }) => {
+    const name = `E2EDelete-${Date.now()}`
+    const created = await request.post(`${API}/food/saved`, {
+      headers: { Authorization: `Bearer ${authToken}` },
+      data: { name, calories: 120, protein: 10, carbs: 12, fat: 4, serving_size: '1 cup' },
+    })
+    expect(created.ok()).toBeTruthy()
+
+    await page.goto('/food/log')
+    await page.getByRole('button', { name: 'My Foods' }).click()
+    await expect(page.getByText(name)).toBeVisible({ timeout: 5000 })
+
+    await page.getByRole('button', { name: `Remove ${name} from My Foods` }).click()
+    await page.getByRole('button', { name: 'Remove', exact: true }).click()
+
+    await expect(page.getByText(name)).not.toBeVisible({ timeout: 5000 })
+
+    // The row vanishing only proves local state was filtered. Reload to prove the
+    // DELETE actually reached the server.
+    await page.reload()
+    await page.getByRole('button', { name: 'My Foods' }).click()
+    await expect(page.getByText(name)).not.toBeVisible({ timeout: 5000 })
+  })
+
   test('selecting from My Foods goes to detail phase', async ({ page }) => {
     await page.goto('/food/log')
     await page.getByRole('button', { name: 'My Foods' }).click()

--- a/web/src/pages/LogFood.tsx
+++ b/web/src/pages/LogFood.tsx
@@ -3,10 +3,10 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
   ArrowLeft, Search, Scan, Minus, Plus, X,
   Bookmark, BookmarkCheck, AlertCircle, Utensils, Zap,
-  Coffee, Sun, Moon, Cookie, ChevronRight,
+  Coffee, Sun, Moon, Cookie, ChevronRight, Trash2,
 } from 'lucide-react'
 import { foodAPI, savedFoodsAPI } from '../services/api'
-import { todayStr, dayToInstant, entryDay, MACRO_COLORS, types, entryToResult, savedToResult, scaleServing } from '@lyftr/shared'
+import { todayStr, dayToInstant, entryDay, MACRO_COLORS, types, entryToResult, savedToResult, scaleServing, apiErrorMessage } from '@lyftr/shared'
 import BarcodeScanner from '../components/BarcodeScanner'
 import IconButton from '../components/ui/IconButton'
 import SegmentedControl from '../components/ui/SegmentedControl'
@@ -27,12 +27,19 @@ const MEAL_COLORS: Record<string, string> = {
   dinner: 'text-indigo-400', snacks: 'text-pink-400',
 }
 
-function FoodResultRow({ item, onClick }: { item: types.FoodSearchResult; onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      className="flex items-center gap-3 w-full px-4 py-3.5 hover:bg-surface-muted active:bg-surface-muted/80 transition-colors border-b border-surface-border last:border-0 text-left"
-    >
+// `onDelete` is optional and only the My Foods tab passes it. Without it this renders
+// exactly the markup it always has — Recent and the search results are the hot path in
+// this screen, so the delete affordance is added around them rather than through them.
+//
+// It has to be a sibling of the row button, not a child: a <button> inside a <button> is
+// invalid HTML and React warns about it, which is the whole reason the two-branch shape
+// below exists instead of one container.
+function FoodResultRow(
+  { item, onClick, onDelete, deleteLabel }:
+  { item: types.FoodSearchResult; onClick: () => void; onDelete?: () => void; deleteLabel?: string },
+) {
+  const content = (
+    <>
       {item.image_url ? (
         <img src={item.image_url} alt="" className="w-11 h-11 rounded-xl object-cover flex-shrink-0 border border-surface-border" />
       ) : (
@@ -60,7 +67,27 @@ function FoodResultRow({ item, onClick }: { item: types.FoodSearchResult; onClic
         </div>
       </div>
       <ChevronRight className="w-4 h-4 text-tx-muted flex-shrink-0" />
-    </button>
+    </>
+  )
+
+  if (!onDelete) {
+    return (
+      <button
+        onClick={onClick}
+        className="flex items-center gap-3 w-full px-4 py-3.5 hover:bg-surface-muted active:bg-surface-muted/80 transition-colors border-b border-surface-border last:border-0 text-left"
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 w-full px-4 hover:bg-surface-muted transition-colors border-b border-surface-border last:border-0">
+      <button onClick={onClick} className="flex items-center gap-3 flex-1 min-w-0 py-3.5 text-left">
+        {content}
+      </button>
+      <IconButton icon={Trash2} variant="danger" label={deleteLabel ?? 'Delete'} onClick={onDelete} />
+    </div>
   )
 }
 
@@ -89,6 +116,10 @@ export default function LogFood() {
   const [saveToMyFoods, setSaveToMyFoods] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -158,6 +189,26 @@ export default function LogFood() {
       } else {
         setSearchError('Product not found — enter details manually')
       }
+    }
+  }
+
+  // Deliberately not the `.catch(() => {})` this file uses elsewhere. Swallowing a failed
+  // delete leaves the row on screen with no explanation, which reads as the button being
+  // broken — the complaint in #115 was already about a missing affordance, and a silent
+  // one is not an improvement. The row is dropped from local state rather than refetched:
+  // the list is small, and a refetch would blank it on a flaky connection.
+  const handleDeleteSaved = async (id: number) => {
+    if (deletingId !== null) return
+    setDeletingId(id)
+    setDeleteError(null)
+    try {
+      await savedFoodsAPI.delete(id)
+      setSavedFoods(prev => prev.filter(f => f.id !== id))
+      setDeleteConfirmId(null)
+    } catch (err) {
+      setDeleteError(apiErrorMessage(err, 'Failed to remove from My Foods'))
+    } finally {
+      setDeletingId(null)
     }
   }
 
@@ -334,7 +385,41 @@ export default function LogFood() {
                     <p className="text-xs text-tx-muted mt-1 opacity-60">Save foods while logging to find them here</p>
                   </div>
                 )
-                : savedFoods.map(sf => <FoodResultRow key={sf.id} item={savedToResult(sf)} onClick={() => selectResult(savedToResult(sf))} />)
+                : savedFoods.map(sf => (
+                  deleteConfirmId === sf.id ? (
+                    // Replaces the row rather than sitting beside it, matching how Food.tsx
+                    // confirms a log deletion — the row is the thing being acted on, so the
+                    // question belongs in its place.
+                    <div key={sf.id} className="px-4 py-3 flex items-center justify-between gap-3 bg-error-500/5 border-l-2 border-error-500 border-b border-surface-border last:border-b-0">
+                      <p className="text-xs text-tx-secondary flex-1 min-w-0">
+                        Remove <span className="font-medium text-tx-primary">{sf.name}</span> from My Foods?
+                      </p>
+                      <div className="flex gap-2 flex-shrink-0">
+                        <button onClick={() => { setDeleteConfirmId(null); setDeleteError(null) }} className="btn-secondary btn-sm">
+                          Cancel
+                        </button>
+                        <button onClick={() => handleDeleteSaved(sf.id)} disabled={deletingId === sf.id} className="btn-danger-solid btn-sm disabled:opacity-50">
+                          {deletingId === sf.id ? '…' : 'Remove'}
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <FoodResultRow
+                      key={sf.id}
+                      item={savedToResult(sf)}
+                      onClick={() => selectResult(savedToResult(sf))}
+                      onDelete={() => { setDeleteConfirmId(sf.id); setDeleteError(null) }}
+                      deleteLabel={`Remove ${sf.name} from My Foods`}
+                    />
+                  )
+                ))
+            )}
+
+            {tab === 'myfoods' && deleteError && (
+              <div className="px-4 py-3 flex items-center gap-2 border-t border-surface-border">
+                <AlertCircle className="w-4 h-4 text-error-400 flex-shrink-0" />
+                <p className="text-xs text-error-400">{deleteError}</p>
+              </div>
             )}
 
             {tab === 'all' && !query.trim() && (


### PR DESCRIPTION
Closes #115

`DELETE /api/v1/food/saved/:id` has existed since saved foods shipped — user-scoped, 404s on a miss, covered by `TestDeleteSavedFood_success` and `TestDeleteSavedFood_ownershipEnforced`. `savedFoodsAPI.delete` has been sitting in the shared client alongside `list` and `create`. Neither app ever called it.

So My Foods was a list you could only add to. @pdschneider hit exactly that in #115: two identical rows, no way to remove either. He went looking for "an ellipses or trash can" — the affordance genuinely wasn't there.

**Backend is untouched.** This is client-only.

## Web

Delete hangs off the row the way `Food.tsx` already does it: a danger `IconButton`, then an inline confirm strip that replaces the row.

That required restructuring `FoodResultRow` — it was a `<button>` wrapping the whole row, and a `<button>` inside a `<button>` is invalid HTML that React warns about. The component now branches on `onDelete`: without it, it renders exactly the markup it always did. Recent and search results are the hot path on this screen and are not what's being changed here.

## Mobile

Follows `FoodEntryRow`, the nearest neighbour in the same screen family — a `⋮` opening an `ActionSheet`, with delete routed through the shared `ConfirmSheet` via `deleteConfirmProps`. No new primitives; `ActionSheet` already defers its action until after the dismiss animation so the confirm sheet isn't presented mid-close.

The row moves to `mobile/src/components/nutrition/FoodResultRow.tsx` so the delete path is testable without standing up the whole log flow.

## Failures aren't swallowed

`FoodEntryRow` currently discards a failed delete. Copying that here would leave the row on screen with no explanation — indistinguishable from a dead button, which is a poor thing to add to a report about a missing affordance. Web surfaces it inline; mobile surfaces it through the existing `Alert`.

## Tests

- **Web e2e** (`food.spec.ts`): creates its own saved food, deletes it through the UI, then **reloads and re-checks** — the row vanishing on its own only proves local state was filtered, not that the request reached the server.
- **Mobile unit** (6 cases): mostly guarding that Recent and search *didn't* grow a delete control, since the row is shared by all three tabs. Also covers the success and failure paths.

## Verification

| Gate | Result |
|---|---|
| `go test ./controllers/ ./db/ ./routes/` | pass |
| `shared:type-check` + `shared:test` | pass (224) |
| web type-check / lint / unit / build | pass (83 unit; lint at the 52-warning cap, no new ones) |
| mobile type-check / lint / test | pass (39) |
| Playwright, full suite | **99 passed, 1 skipped** |

## Deliberately not in this PR

@pdschneider was saving the same food twice *on purpose*, trying to keep two serving sizes. A unique constraint on `(user_id, name, brand)` would block that rather than help it. The actual gap is that there's no way to edit a saved food, which needs a `PATCH /food/saved/:id` that doesn't exist yet — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
