### PR TITLE
Build the tester APK on Node 22, which eas-cli now requires

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -88,7 +88,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # 22, not the 20 the other workflows use: eas-cli's own dependency tree
+          # (@oclif/plugin-autocomplete) declares engines.node >= 22, so installing the
+          # CLI fails outright on 20 - "Found incompatible module", before any build
+          # step runs. Only this workflow installs eas-cli, so only this one needs it.
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - uses: expo/expo-github-action@v8
@@ -136,7 +140,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # 22, not the 20 the other workflows use: eas-cli's own dependency tree
+          # (@oclif/plugin-autocomplete) declares engines.node >= 22, so installing the
+          # CLI fails outright on 20 - "Found incompatible module", before any build
+          # step runs. Only this workflow installs eas-cli, so only this one needs it.
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       # Local Android builds compile with Gradle on this runner, so the JDK is ours to


### PR DESCRIPTION
Split out of #147 at review request — it is CI plumbing, not part of the decimal fix.

## The break

The APK workflow fails in setup, before it builds anything. `expo/expo-github-action`
installs eas-cli, and eas-cli 22.4.0 pulls `@oclif/plugin-autocomplete@3.3.0`, which
declares `engines.node >= 22`. yarn refuses:

```
error @oclif/plugin-autocomplete@3.3.0: The engine "node" is incompatible with this
module. Expected version ">=22.0.0". Got "20.20.2"
error Found incompatible module.
##[error]The process '/usr/local/bin/yarn' failed with exit code 1
```

Nothing in this repo changed to cause it — eas-cli moved, and the workflow pinned Node 20.
So it is a latent break: it would have surfaced on whoever next dispatched a tester or
release build, including a `v*` tag, where it would fail *after* the tag was pushed.

## Proof, not inference

| run | node | outcome |
|---|---|---|
| [32874687733](https://github.com/Cawlumm/lyftr/actions/runs/32874687733) | 20 | failed in "Run expo/expo-github-action" |
| [32874931009](https://github.com/Cawlumm/lyftr/actions/runs/32874931009) | 22 | green through Gradle to a signed APK |

The second run is the build that produced the tester APK linked on #141, so this is
verified end to end rather than just past the failing step.

## Scope

Both jobs in `eas-build.yml` install the CLI, so both move to 22. `ci.yml` and `site.yml`
stay on 20 deliberately — they never touch eas-cli, and the app builds fine there. The
comment in the diff says so, since the version now differs between workflows for a reason
that is not obvious from the file.

Worth landing on its own and ahead of the other mobile PRs: without it, no APK can be built
from `main` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWC4KiFeoRZ3gtApGFHv1u