### PR TITLE
No blank screens, no invented dates

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -9,7 +9,7 @@ import {
 import {
   Activity, AlertCircle, ArrowRight, BookOpen, ChevronRight, Dumbbell, Play, Plus, Scale, Timer, TrendingUp,
 } from 'lucide-react-native'
-import { activeSessionExercisesForDay, dayLabel, displayVolume, displayWeight, sessionNameForDay, weightShort, type DailyStats, type Program, type WeightLog, type WeightStats, type Workout, workoutDay, entryDay, dayToLocalDate, nextStartableDay, muscleRoast, muscleHex, calcVolume, greeting } from '@lyftr/shared'
+import { activeSessionExercisesForDay, dayLabel, displayVolume, displayWeight, sessionNameForDay, weightShort, type DailyStats, type Program, type WeightLog, type WeightStats, type Workout, workoutDay, entryDay, nextStartableDay, muscleRoast, muscleHex, calcVolume, greeting, formatDay } from '@lyftr/shared'
 import { AppText, Card, IconButton, Label, Screen, SectionHeader, SegmentedControl } from '../../src/components/ui'
 import { ExerciseImage } from '../../src/components/workouts/ExerciseImage'
 import {
@@ -175,7 +175,7 @@ export default function Dashboard() {
   }
 
   const chartData = workouts.slice(0, Number(volumePeriod)).reverse().map((w) => ({
-    date: format(dayToLocalDate(workoutDay(w)), 'M/d'),
+    date: formatDay(workoutDay(w), 'M/d'),
     volume: displayVolume(calcVolume(w), unit),
     name: w.name,
   }))
@@ -229,7 +229,7 @@ export default function Dashboard() {
   const fatPct = Math.min(100, (food.total_fat / settings.fat_target) * 100) || 0
 
   const sparkData = [...weightLogs].reverse().map((l) => ({
-    date: format(dayToLocalDate(entryDay(l)), 'M/d'),
+    date: formatDay(entryDay(l), 'M/d'),
     weight: displayWeight(l.weight, unit),
   }))
 
@@ -472,7 +472,7 @@ export default function Dashboard() {
                       <Label className="mb-1">Last workout</Label>
                       <Text className="font-sans-semibold text-base text-tx-primary" numberOfLines={1}>{lastWorkout.name}</Text>
                       <AppText variant="caption" color="muted" className="mt-0.5">
-                        {format(dayToLocalDate(workoutDay(lastWorkout)), 'MMM d')}
+                        {formatDay(workoutDay(lastWorkout), 'MMM d')}
                         {mins > 0 ? ` · ${mins} min` : ''}
                         {totalSets > 0 ? ` · ${totalSets} sets` : ''}
                         {totalVolume > 0 ? ` · ${totalVolume.toLocaleString()} ${wUnit}` : ''}

--- a/mobile/app/(tabs)/nutrition/[id].tsx
+++ b/mobile/app/(tabs)/nutrition/[id].tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Image, Pressable, ScrollView, Text, View } from 'react-native'
 import { router, useLocalSearchParams } from 'expo-router'
-import { format } from 'date-fns'
 import { AlertCircle, ArrowLeft, Edit2, Flame, Trash2 } from 'lucide-react-native'
-import { entryDay, type FoodLog, dayToLocalDate} from '@lyftr/shared'
+import { entryDay, type FoodLog, formatDay } from '@lyftr/shared'
 import {
   AppText, Card, ConfirmSheet, Loading, Screen, deleteConfirmProps,
 } from '../../../src/components/ui'
@@ -87,7 +86,7 @@ export default function NutritionDetail() {
     ...(entry.serving_size ? [{ label: 'Serving size', value: entry.serving_size }] : []),
     { label: 'Servings', value: String(entry.servings), tabular: true },
     { label: 'Meal', value: MEAL_LABELS[meal] },
-    { label: 'Logged', value: format(dayToLocalDate(entryDay(entry)), 'EEE, MMM d, yyyy') },
+    { label: 'Logged', value: formatDay(entryDay(entry), 'EEE, MMM d, yyyy') },
   ]
 
   return (

--- a/mobile/app/(tabs)/weight/[id].tsx
+++ b/mobile/app/(tabs)/weight/[id].tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import { router, useLocalSearchParams } from 'expo-router'
-import { format } from 'date-fns'
 import * as Haptics from 'expo-haptics'
 import { AlertCircle, ArrowLeft, Edit2, Scale, Trash2 } from 'lucide-react-native'
-import { apiErrorMessage, dayToInstant, displayWeight, maxWeight, resolveWeightLbs, weightError, weightShort, type WeightLog, entryDay, dayToLocalDate, BODYWEIGHT_STEP, clampStep } from '@lyftr/shared'
+import { apiErrorMessage, dayToInstant, displayWeight, maxWeight, resolveWeightLbs, weightError, weightShort, type WeightLog, entryDay, BODYWEIGHT_STEP, clampStep, formatDay } from '@lyftr/shared'
 import {
   AppText, Button, Card, ConfirmSheet, DateInput, Field, Label, Loading, NumberField,
   NumericKeyboardAccessory, NUMERIC_ACCESSORY_ID, Screen, StepperTile, deleteConfirmProps,
@@ -173,7 +172,7 @@ export default function WeightDetail() {
                       <AppText variant="body" color="muted" className="mb-1.5">{wUnit}</AppText>
                     </View>
                     <AppText variant="body" color="muted" className="mt-1">
-                      {format(dayToLocalDate(entryDay(log)), 'EEEE, MMMM d, yyyy')}
+                      {formatDay(entryDay(log), 'EEEE, MMMM d, yyyy')}
                     </AppText>
                     {log.notes ? (
                       <AppText variant="body" color="secondary" className="mt-2 italic">"{log.notes}"</AppText>
@@ -240,7 +239,7 @@ export default function WeightDetail() {
       <ConfirmSheet
         {...deleteConfirmProps({
           title: 'Delete Entry?',
-          subject: `${format(dayToLocalDate(entryDay(log)), 'MMMM d, yyyy')} · ${displayWeight(log.weight, unit)} ${wUnit}`,
+          subject: `${formatDay(entryDay(log), 'MMMM d, yyyy')} · ${displayWeight(log.weight, unit)} ${wUnit}`,
         })}
         open={confirming}
         busy={deleting}

--- a/mobile/app/(tabs)/weight/index.tsx
+++ b/mobile/app/(tabs)/weight/index.tsx
@@ -7,7 +7,7 @@ import {
   Activity, AlertCircle, ArrowDown, ArrowUp, Calendar, Minus, Scale, Sunrise,
   TrendingDown, TrendingUp, X,
 } from 'lucide-react-native'
-import { apiErrorMessage, dayToInstant, daysAgoStr, displayToLbs, displayWeight, maxWeight, todayStr, weightError, weightShort, type WeightLog, type WeightStats, entryDay, dayToLocalDate, BODYWEIGHT_STEP, clampStep } from '@lyftr/shared'
+import { apiErrorMessage, dayToInstant, daysAgoStr, displayToLbs, displayWeight, maxWeight, todayStr, weightError, weightShort, type WeightLog, type WeightStats, entryDay, dayToLocalDate, BODYWEIGHT_STEP, clampStep, formatDay } from '@lyftr/shared'
 import {
   AppText, Button, Card, DateInput, Field, Label, NumberField, NumericKeyboardAccessory,
   NUMERIC_ACCESSORY_ID, PageHeader, Screen, SegmentedControl, StepperTile,
@@ -290,7 +290,7 @@ export default function Weight() {
                     <AlertCircle size={16} color={brand.warningSoft} style={{ marginTop: 2 }} />
                     <View className="min-w-0 flex-1">
                       <Text className="font-sans-semibold text-sm text-warning-400">
-                        Already logged on {format(dayToLocalDate(entryDay(items[0])), 'MMM d')} ({displayWeight(items[0].weight, unit)} {wUnit}). Log again anyway?
+                        Already logged on {formatDay(entryDay(items[0]), 'MMM d')} ({displayWeight(items[0].weight, unit)} {wUnit}). Log again anyway?
                       </Text>
                       <View className="mt-2 flex-row gap-2">
                         <Pressable

--- a/mobile/app/(tabs)/workouts/[id].tsx
+++ b/mobile/app/(tabs)/workouts/[id].tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Pressable, ScrollView, View } from 'react-native'
 import { router, useLocalSearchParams, type Href } from 'expo-router'
-import { format } from 'date-fns'
 import {
   AlertCircle, ArrowLeft, ChevronRight, Clock, Edit2, Layers, Pause, TimerOff, Trash2, TrendingUp,
 } from 'lucide-react-native'
-import { apiErrorMessage, displayVolume, displayWeight, weightShort, type Workout, type Set as WorkoutSet, workoutDay, dayToLocalDate, restLabel, calcVolume, countWorkingSets, exerciseVolume } from '@lyftr/shared'
+import { apiErrorMessage, displayVolume, displayWeight, weightShort, type Workout, type Set as WorkoutSet, workoutDay, restLabel, calcVolume, countWorkingSets, exerciseVolume, formatDay } from '@lyftr/shared'
 import { AppText, ConfirmSheet, Loading, Screen, deleteConfirmProps } from '../../../src/components/ui'
 import { ExerciseImage } from '../../../src/components/workouts/ExerciseImage'
 import { client, useSettingsStore } from '../../../src/lib/lyftr'
@@ -181,7 +180,7 @@ export default function WorkoutDetail() {
               <View className="flex-1">
                 <AppText variant="heading">{workout.name}</AppText>
                 <AppText variant="body" color="muted" className="mt-0.5">
-                  {format(dayToLocalDate(workoutDay(workout)), 'EEEE, MMMM d, yyyy')}
+                  {formatDay(workoutDay(workout), 'EEEE, MMMM d, yyyy')}
                 </AppText>
               </View>
             </View>

--- a/mobile/src/components/nutrition/NutritionCharts.tsx
+++ b/mobile/src/components/nutrition/NutritionCharts.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react'
 import { View } from 'react-native'
 import * as Haptics from 'expo-haptics'
 import Svg, { Circle, G, Line, Path, Rect, Text as SvgText } from 'react-native-svg'
-import { format } from 'date-fns'
-import { dayToLocalDate } from '@lyftr/shared'
+import { formatDay } from '@lyftr/shared'
 import { AppText } from '../ui'
 import { useTheme } from '../../theme/useTheme'
 import { MACRO_COLORS } from './nutritionMeta'
@@ -115,7 +114,7 @@ export function MacroHistoryChart({ data, width, height = 200 }: {
   // Thin x-labels so they never overlap (recharts auto-skips too).
   const maxLabels = Math.max(2, Math.floor(plotW / 44))
   const every = Math.ceil(n / maxLabels)
-  const fmt = (d: string) => format(dayToLocalDate(d), 'M/d')
+  const fmt = (d: string) => formatDay(d, 'M/d')
 
   const selPt = sel != null ? data[sel] : null
 
@@ -167,7 +166,7 @@ export function MacroHistoryChart({ data, width, height = 200 }: {
           className="absolute rounded-lg border border-surface-border bg-surface-raised px-2.5 py-1.5"
           style={{ left: clamp(xAt(sel!) - 60, 0, Math.max(0, width - 120)), top: 0, width: 120 }}
         >
-          <AppText variant="caption" color="muted">{format(dayToLocalDate(selPt.date), 'MMM d')}</AppText>
+          <AppText variant="caption" color="muted">{formatDay(selPt.date, 'MMM d')}</AppText>
           <View className="mt-0.5 gap-0.5">
             {[
               { label: 'Protein', value: selPt.protein, color: MACRO_COLORS.protein },

--- a/mobile/src/components/weight/WeightEntryRow.tsx
+++ b/mobile/src/components/weight/WeightEntryRow.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { router } from 'expo-router'
-import { format } from 'date-fns'
 import * as Haptics from 'expo-haptics'
 import { ChevronRight, MoreVertical, Scale, TrendingDown, TrendingUp } from 'lucide-react-native'
-import { displayWeight, entryDay, weightShort, type WeightLog, dayToLocalDate} from '@lyftr/shared'
+import { displayWeight, entryDay, weightShort, type WeightLog, formatDay } from '@lyftr/shared'
 import { ActionSheet, AppText, Card, ConfirmSheet, IconButton, deleteAction, deleteConfirmProps, editAction } from '../ui'
 import { useTheme } from '../../theme/useTheme'
 import { client } from '../../lib/lyftr'
@@ -32,7 +31,7 @@ export function WeightEntryRow({ item, next, unit, onDeleted }: Props) {
   const deltaLbs = next ? item.weight - next.weight : 0
   const displayW = displayWeight(item.weight, unit)
   const displayDelta = displayWeight(Math.abs(deltaLbs), unit)
-  const dateLabel = format(dayToLocalDate(entryDay(item)), 'MMM d, yyyy')
+  const dateLabel = formatDay(entryDay(item), 'MMM d, yyyy')
 
   const handleDelete = async () => {
     setDeleting(true)

--- a/mobile/src/components/workouts/WorkoutCard.tsx
+++ b/mobile/src/components/workouts/WorkoutCard.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 import { Pressable, View } from 'react-native'
 import { router } from 'expo-router'
-import { format } from 'date-fns'
 import { ChevronRight, Clock, Dumbbell, MoreVertical, TrendingUp } from 'lucide-react-native'
-import { displayVolume, type Workout, workoutDay, dayToLocalDate} from '@lyftr/shared'
+import { displayVolume, type Workout, workoutDay, formatDay } from '@lyftr/shared'
 import { ActionSheet, AppText, Card, ConfirmSheet, IconButton, deleteAction, deleteConfirmProps, editAction } from '../ui'
 import { useTheme } from '../../theme/useTheme'
 import { client } from '../../lib/lyftr'
@@ -62,7 +61,7 @@ export function WorkoutCard({ workout, unit, onPress, onDeleted }: Props) {
               then exercises + volume — three items on one line truncated at 390pt. */}
           <View className="flex-row items-center gap-x-2 mt-0.5">
             <AppText variant="caption" color="muted" numberOfLines={1}>
-              {format(dayToLocalDate(workoutDay(workout)), 'MMM d, yyyy')}
+              {formatDay(workoutDay(workout), 'MMM d, yyyy')}
             </AppText>
             {durationMin > 0 && (
               <>
@@ -121,7 +120,7 @@ export function WorkoutCard({ workout, unit, onPress, onDeleted }: Props) {
             <View className="flex-1">
               <AppText variant="subheading" numberOfLines={1}>{workout.name}</AppText>
               <AppText variant="caption" color="muted" numberOfLines={1} className="mt-0.5">
-                {format(dayToLocalDate(workoutDay(workout)), 'MMM d, yyyy')}
+                {formatDay(workoutDay(workout), 'MMM d, yyyy')}
                 {durationMin > 0 ? ` · ${durationMin} min` : ''}
                 {` · ${workout.exercises?.length || 0} exercises`}
               </AppText>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20074,7 +20074,8 @@
       "name": "@lyftr/shared",
       "version": "0.0.0",
       "dependencies": {
-        "axios": "^1.6.2"
+        "axios": "^1.6.2",
+        "date-fns": "^3.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "axios": "^1.6.2"
+    "axios": "^1.6.2",
+    "date-fns": "^3.0.0"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/packages/shared/src/stores/workoutSession.test.ts
+++ b/packages/shared/src/stores/workoutSession.test.ts
@@ -203,6 +203,67 @@ describe('workoutSession hydrate (async storage adaptation)', () => {
     expect(s.gymPhase).toBe('overview')
   })
 
+  // Valid JSON of the WRONG SHAPE used to sail past the JSON.parse try/catch and kill
+  // the first consumer that walked it — a white screen on boot, still signed in, with
+  // no in-app way out (a user cannot clear their own localStorage). Each of these was
+  // reproduced against the running web app before the guard went in.
+  it.each([
+    ['a bare string', '"hello"'],
+    ['an array', '[1,2,3]'],
+    ['an object with no exercises', '{"name":"X"}'],
+    ['exercises explicitly null', '{"name":"X","exercises":null}'],
+    ['exercises holding non-objects', '{"name":"X","exercises":[1,2]}'],
+    ['an exercise with no sets', '{"name":"X","exercises":[{"exercise_id":1}]}'],
+    ['a nameless session', '{"exercises":[]}'],
+    ['the literal null', 'null'],
+  ])('hydrate() discards a session that is %s', async (_label, raw) => {
+    const { store } = setup({ [WORKOUT_SESSION_KEY]: raw })
+    await store().hydrate()
+    expect(store().session).toBeNull()
+    expect(store().isHydrated).toBe(true)
+  })
+
+  it('hydrate() keeps a well-shaped session with exercises and sets', async () => {
+    const session = {
+      name: 'Push A', started_at: '2026-07-01T10:00:00Z',
+      exercises: [{ exercise_id: 1, exercise: { id: 1, name: 'Bench' }, notes: '', sets: [] }],
+    }
+    const { store } = setup({ [WORKOUT_SESSION_KEY]: JSON.stringify(session) })
+    await store().hydrate()
+    expect(store().session?.exercises).toHaveLength(1)
+  })
+
+  it('hydrate() clears an unreadable session from storage so the next boot is clean', async () => {
+    const { store, storage } = setup({ [WORKOUT_SESSION_KEY]: '{"name":"X"}' })
+    await store().hydrate()
+    expect(await storage.get(WORKOUT_SESSION_KEY)).toBeNull()
+  })
+
+  it('hydrate() does not clear storage when there was nothing to read', async () => {
+    const { store, storage } = setup()
+    const removed: string[] = []
+    const realRemove = storage.remove.bind(storage)
+    storage.remove = async (k: string) => { removed.push(k); return realRemove(k) }
+    await store().hydrate()
+    expect(removed).not.toContain(WORKOUT_SESSION_KEY)
+  })
+
+  // Same class, on the gym UI blob: a bad phase drove an unrenderable screen and a
+  // non-integer index read undefined off the exercises array.
+  // Each bad field falls back on its own — an unreadable phase does not discard indices
+  // that were perfectly good, which is what makes this a fallback and not a reset.
+  it.each([
+    ['a bare string', '"hello"', 'overview', 0, 0],
+    ['an unknown phase', '{"phase":"nope","exIdx":2,"setIdx":1}', 'overview', 2, 1],
+    ['a non-integer index', '{"phase":"exercise","exIdx":1.5,"setIdx":-3}', 'exercise', 0, 0],
+  ])('hydrate() falls back on gym UI that is %s', async (_l, raw, phase, exIdx, setIdx) => {
+    const { store } = setup({ [GYM_UI_KEY]: raw })
+    await store().hydrate()
+    expect(store().gymPhase).toBe(phase)
+    expect(store().gymExIdx).toBe(exIdx)
+    expect(store().gymSetIdx).toBe(setIdx)
+  })
+
   it('hydrate() never resurrects rest-timer state', async () => {
     const { store } = setup({
       // Even if a rogue writer stuffed rest fields into the session blob, they are

--- a/packages/shared/src/stores/workoutSession.ts
+++ b/packages/shared/src/stores/workoutSession.ts
@@ -13,6 +13,54 @@ type GymUiState = { phase: GymPhase; exIdx: number; setIdx: number }
 
 const DEFAULT_GYM_UI: GymUiState = { phase: 'overview', exIdx: 0, setIdx: 0 }
 
+// Persisted state is not trusted input. The old hydrate wrapped only JSON.parse, which
+// catches `{{{not json` and nothing else -- so any VALID json of the wrong shape parsed
+// clean and then killed the first consumer to reach into it. Measured against the live
+// app: `"hello"`, `[1,2,3]`, `{"name":"X"}` and `{"name":"X","exercises":null}` each
+// rendered a white screen on boot, still signed in, unrecoverable without devtools.
+// A user cannot clear their own localStorage; a session written by an older build, or a
+// half-finished write, is enough to reach this. Shape-check, and treat a value we cannot
+// read as no session at all -- losing an unreadable session beats losing the app.
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v)
+
+// Only what the consumers actually walk: every screen maps exercises, then maps sets.
+// Field-by-field validation would be a second copy of the type to keep in step.
+function parseSession(raw: string | null): types.ActiveSession | null {
+  if (!raw) return null
+  let val: unknown
+  try {
+    val = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isRecord(val)) return null
+  if (!Array.isArray(val.exercises)) return null
+  if (!val.exercises.every(ex => isRecord(ex) && Array.isArray(ex.sets))) return null
+  if (typeof val.name !== 'string') return null
+  return val as unknown as types.ActiveSession
+}
+
+function parseGymUi(raw: string | null): GymUiState {
+  if (!raw) return DEFAULT_GYM_UI
+  let val: unknown
+  try {
+    val = JSON.parse(raw)
+  } catch {
+    return DEFAULT_GYM_UI
+  }
+  if (!isRecord(val)) return DEFAULT_GYM_UI
+  const phase = val.phase
+  const known = phase === 'overview' || phase === 'exercise-info' || phase === 'exercise'
+  const idx = (v: unknown) => (Number.isInteger(v) && (v as number) >= 0 ? (v as number) : 0)
+  return {
+    phase: known ? phase : DEFAULT_GYM_UI.phase,
+    // A non-finite index indexes past the array and reads undefined downstream.
+    exIdx: idx(val.exIdx),
+    setIdx: idx(val.setIdx),
+  }
+}
+
 export interface WorkoutSessionStore {
   session: types.ActiveSession | null
   gymOpen: boolean
@@ -91,18 +139,11 @@ export function createWorkoutSession(storage: StorageAdapter) {
         storage.get(WORKOUT_SESSION_KEY),
         storage.get(GYM_UI_KEY),
       ])
-      let session: types.ActiveSession | null = null
-      try {
-        session = sessionRaw ? JSON.parse(sessionRaw) : null
-      } catch {
-        session = null
-      }
-      let gym = DEFAULT_GYM_UI
-      try {
-        gym = gymRaw ? JSON.parse(gymRaw) : DEFAULT_GYM_UI
-      } catch {
-        gym = DEFAULT_GYM_UI
-      }
+      const session = parseSession(sessionRaw)
+      const gym = parseGymUi(gymRaw)
+      // An unreadable session is dropped from storage too, so the next boot is clean
+      // rather than re-parsing the same corrupt value forever.
+      if (sessionRaw && !session) void storage.remove(WORKOUT_SESSION_KEY)
       // Deliberately does NOT touch rest-timer fields (ephemeral) or gymOpen (the
       // user decides per-launch whether the gym sheet is expanded).
       set({ session, gymPhase: gym.phase, gymExIdx: gym.exIdx, gymSetIdx: gym.setIdx, isHydrated: true })

--- a/packages/shared/src/utils/dateUtils.test.ts
+++ b/packages/shared/src/utils/dateUtils.test.ts
@@ -1,4 +1,4 @@
-import { todayStr, dayToInstant, dayToLocalDate, instantToDay, entryDay, workoutDay, memberSince } from './dateUtils'
+import { todayStr, dayToInstant, dayToLocalDate, instantToDay, entryDay, workoutDay, memberSince, withLoggedOn, formatDay, UNKNOWN_DAY } from './dateUtils'
 
 
 describe('dayToInstant', () => {
@@ -148,6 +148,81 @@ describe('dayToLocalDate', () => {
     for (const day of ['2026-01-01', '2026-03-08', '2026-11-01', '2026-12-31']) {
       expect(instantToDay(dayToLocalDate(day).toISOString())).toBe(day)
     }
+  })
+})
+
+// An unreadable instant used to become the string "NaN-NaN-NaN", which is not obviously
+// wrong to anything downstream: it groups, it sorts, and it compares unequal to every
+// real day. A row with a missing started_at therefore formed its own silent bucket, and
+// withLoggedOn posted it to the server as the row's day.
+describe('instantToDay — an unreadable instant has no day', () => {
+  it.each(['', 'not-a-date', 'undefined', '2026-13-45T99:99:99Z'])(
+    'returns empty string for %p rather than a NaN-shaped day', (bad) => {
+      const day = instantToDay(bad)
+      expect(day).toBe('')
+      expect(day).not.toContain('NaN')
+    })
+
+  it('still reads a real instant', () => {
+    expect(instantToDay('2026-08-01T10:00:00Z')).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('entryDay falls through to logged_on when the instant is unreadable', () => {
+    expect(entryDay({ logged_on: '2026-08-01', logged_at: 'not-a-date' })).toBe('2026-08-01')
+    // and reports "unknown" rather than a fake day when there is no stored day either
+    expect(entryDay({ logged_at: 'not-a-date' })).toBe('')
+  })
+
+  it('workoutDay reports unknown rather than a fake day', () => {
+    expect(workoutDay({ started_at: 'not-a-date' })).toBe('')
+    expect(workoutDay({ started_at: '', tz_offset_minutes: -240 })).toBe('')
+  })
+
+  it('withLoggedOn sends no day rather than a NaN one, so the server falls back', () => {
+    const sent = withLoggedOn({ logged_at: 'not-a-date' })
+    expect(sent.logged_on).toBe('')
+    expect(sent.logged_on).not.toContain('NaN')
+  })
+})
+
+// The idiom this replaces had no safe outcome for an unknown day: it either threw
+// RangeError out of date-fns and unmounted the route, or -- for '' -- rendered a
+// confident "Jan 1, 1900". Both were observed in the running app.
+describe('formatDay', () => {
+  it('draws a real day', () => {
+    expect(formatDay('2026-08-01', 'MMM d, yyyy')).toBe('Aug 1, 2026')
+    expect(formatDay('2026-08-01', 'M/d')).toBe('8/1')
+  })
+
+  it.each([
+    ['empty', ''],
+    ['the NaN-shaped day instantToDay used to build', 'NaN-NaN-NaN'],
+    ['an instant, not a day', '2026-08-01T10:00:00Z'],
+    ['a rolled-over month', '2026-13-45'],
+    ['a rolled-over day', '2026-02-31'],
+    ['null', null],
+    ['undefined', undefined],
+  ])('reads as unknown when the day is %s', (_label, day) => {
+    expect(formatDay(day as string, 'MMM d, yyyy')).toBe(UNKNOWN_DAY)
+  })
+
+  it('never renders a 1900 for a day it could not read', () => {
+    // The specific lie: Number('') === 0, and new Date(0, -1, 1) is a valid 1899.
+    expect(formatDay('', 'MMM d, yyyy')).not.toContain('1900')
+    expect(formatDay('', 'MMM d, yyyy')).not.toContain('1899')
+  })
+
+  it('never throws, whatever it is handed', () => {
+    for (const bad of ['', 'x', 'NaN-NaN-NaN', '9999999-01-01', '0000-00-00']) {
+      expect(() => formatDay(bad, 'EEEE, MMMM d, yyyy')).not.toThrow()
+    }
+  })
+
+  it('composes with the day helpers, so an unreadable row reads as unknown end to end', () => {
+    expect(formatDay(workoutDay({ started_at: 'not-a-date' }), 'MMM d, yyyy')).toBe(UNKNOWN_DAY)
+    expect(formatDay(entryDay({ logged_at: '' }), 'MMM d, yyyy')).toBe(UNKNOWN_DAY)
+    expect(formatDay(workoutDay({ started_at: '2026-08-01T10:00:00Z', tz_offset_minutes: 0 }), 'MMM d, yyyy'))
+      .toBe('Aug 1, 2026')
   })
 })
 

--- a/packages/shared/src/utils/dateUtils.ts
+++ b/packages/shared/src/utils/dateUtils.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns'
 // The one place a calendar day is produced or read on the client.
 //
 // The model, which is the one Fitbit, Garmin, Strava and Health Connect all use: a
@@ -37,6 +38,13 @@ export const todayStr = (): string => {
  */
 export const instantToDay = (iso: string): string => {
   const d = new Date(iso)
+  // An unreadable instant has no day, and must not be given one that looks real.
+  // This used to build the string from NaN components and hand back "NaN-NaN-NaN",
+  // which is a plausible-looking key: it groups, it sorts, it compares unequal to
+  // every real day, so a row with a missing started_at quietly formed its own bucket
+  // instead of being recognised as unknown. '' is falsy, so callers that already
+  // guard (entryDay's `logged_on || ...`) fall through correctly.
+  if (Number.isNaN(d.getTime())) return ''
   const pad = (n: number) => String(n).padStart(2, '0')
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
@@ -86,6 +94,12 @@ export const dayToLocalDate = (yyyyMmDd: string): Date => {
   const [y, m, d] = yyyyMmDd.split('-').map(Number)
   return new Date(y, (m ?? 1) - 1, d ?? 1, 12, 0, 0, 0)
 }
+// NOT total: given anything that is not a YYYY-MM-DD day it returns an Invalid Date,
+// and date-fns `format` throws RangeError on one rather than rendering a placeholder.
+// Every display site is the idiom `format(dayToLocalDate(x), pattern)`, so an unknown
+// day throws where it is drawn. That is contained by the route ErrorBoundary today; the
+// real repair is one guarded day-formatter shared by both apps, which needs date-fns in
+// @lyftr/shared and so is its own change.
 /**
  * The local calendar day `n` days before today.
  *
@@ -153,6 +167,36 @@ export const workoutDay = (w: { started_at: string; tz_offset_minutes?: number }
   if (w.tz_offset_minutes == null) return instantToDay(w.started_at)
   const shifted = new Date(new Date(w.started_at).getTime() + w.tz_offset_minutes * 60_000)
   return Number.isNaN(shifted.getTime()) ? instantToDay(w.started_at) : shifted.toISOString().slice(0, 10)
+}
+
+/** What a date reads as when we do not know it. Same mark `memberSince` already uses. */
+export const UNKNOWN_DAY = '—'
+
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * A calendar day, drawn. The single point of truth for turning a `YYYY-MM-DD` into text
+ * a person reads — the day equivalent of `formatNumber`, and the only place the idiom
+ * `format(dayToLocalDate(x), pattern)` should appear.
+ *
+ * It exists because that idiom has no safe outcome when the day is unknown, and both of
+ * its unsafe ones were observed in the running app. `dayToLocalDate` is not total: given
+ * "NaN-NaN-NaN" (what `instantToDay` used to build from an unreadable instant) it yields
+ * an Invalid Date and date-fns `format` throws RangeError, unmounting the whole route —
+ * one bad row in a list of ten took the page down. Given `''` it is worse than that: the
+ * components parse as 0, `new Date(0, -1, 1)` is a perfectly valid 1899, and the row
+ * renders "Jan 1, 1900" as though it were the day the workout happened.
+ *
+ * A day we cannot read has to read as unknown. Validating the day STRING rather than the
+ * resulting Date is what separates the two cases, since only one of them is NaN.
+ */
+export const formatDay = (day: string | null | undefined, pattern: string): string => {
+  if (!day || !DAY_RE.test(day)) return UNKNOWN_DAY
+  const d = dayToLocalDate(day)
+  // '2026-13-45' matches the shape but rolls over into another month; a day that does
+  // not survive the round trip was never a real one.
+  if (Number.isNaN(d.getTime()) || instantToDay(d.toISOString()) !== day) return UNKNOWN_DAY
+  return format(d, pattern)
 }
 
 const MONTH_NAMES = [

--- a/web/e2e/resilience.spec.ts
+++ b/web/e2e/resilience.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures'
+import { corruptStorage } from './faults'
+
+// Three ways the app went blank, each found by driving the running app rather than by
+// reading it. A white screen is the least visible failure this app can have: no nav, no
+// error, and nothing to click — the only way out is a manual reload, and on mobile there
+// is not even that.
+//
+// These are e2e and not unit tests on purpose. The shapes themselves are pinned in
+// workoutSession.test.ts; what cannot be asserted below the browser is that the app still
+// *boots* and still draws its chrome, which is the whole claim.
+
+test.describe('The app does not go blank', () => {
+  // Signed in there was no catch-all route at all — only the signed-OUT branch had one —
+  // so any unknown path matched nothing and React Router rendered nothing. A stale
+  // bookmark or a typo was enough.
+  for (const path of ['/nonsense-route', '/a/b/c', '/workouts/741/nope']) {
+    test(`an unknown URL (${path}) lands somewhere real`, async ({ page }) => {
+      await page.goto(path)
+      await expect(page.locator('nav')).toBeVisible()
+      expect(page.url()).not.toContain(path)
+    })
+  }
+
+  // hydrate() wrapped only JSON.parse, so valid JSON of the wrong shape parsed clean and
+  // then killed the first consumer to walk it. A user cannot clear their own localStorage,
+  // so this was unrecoverable from inside the app.
+  const CORRUPT = [
+    ['a bare string', '"hello"'],
+    ['an array', '[1,2,3]'],
+    ['an object with no exercises', '{"name":"X"}'],
+    ['exercises explicitly null', '{"name":"X","exercises":null}'],
+    ['exercises holding non-objects', '{"name":"X","exercises":[1,2]}'],
+    ['malformed json', '{{{not json'],
+  ] as const
+
+  for (const [label, value] of CORRUPT) {
+    test(`a stored session that is ${label} still boots`, async ({ page }) => {
+      await corruptStorage(page, 'lyftr_active_session', value)
+      await page.goto('/')
+
+      await expect(page.locator('nav')).toBeVisible()
+      // and the unreadable value is swept, so the next boot is clean rather than
+      // re-parsing the same corrupt blob forever
+      await expect
+        .poll(() => page.evaluate(() => window.localStorage.getItem('lyftr_active_session')))
+        .toBeNull()
+    })
+  }
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,11 @@ function App() {
             <Route path="/weight/:id" element={<WeightDetail />} />
             <Route path="/settings" element={<Settings />} />
             <Route path="/settings/password" element={<ChangePassword />} />
+            {/* Signed in, there was no catch-all at all — only the signed-OUT branch had
+                one — so any unknown path matched no route and React Router rendered
+                nothing: a white screen, still signed in, with no nav to click. A stale
+                bookmark or a mistyped URL was enough. Inside Layout so the nav survives. */}
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
         ) : (
           <Route path="*" element={<Navigate to="/login" />} />

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -16,7 +16,7 @@ import { workoutAPI, foodAPI, weightAPI, userAPI, programAPI } from '../services
 import { useWorkoutSession } from '../stores/workoutSession'
 import { useAuthStore } from '../stores/auth'
 import { useSettingsStore, weightShort, displayWeight, displayVolume } from '../stores/settings'
-import { workoutDay, entryDay, dayToLocalDate, types, activeSessionExercisesForDay, dayLabel, sessionNameForDay, nextStartableDay, muscleRoast, muscleHex, calcVolume, greeting } from '@lyftr/shared'
+import { workoutDay, entryDay, types, activeSessionExercisesForDay, dayLabel, sessionNameForDay, nextStartableDay, muscleRoast, muscleHex, calcVolume, greeting, formatDay } from '@lyftr/shared'
 import { useNavigate, Link } from 'react-router-dom'
 import { muscleColor } from '../utils/exerciseUtils'
 
@@ -148,7 +148,7 @@ export default function Dashboard() {
 
   // Volume chart: slice by selected period, oldest→newest
   const chartData = workouts.slice(0, Number(volumePeriod)).reverse().map(w => ({
-    date: format(dayToLocalDate(workoutDay(w)), 'M/d'),
+    date: formatDay(workoutDay(w), 'M/d'),
     volume: displayVolume(calcVolume(w), settings.weight_unit),
     name: w.name,
   }))
@@ -215,7 +215,7 @@ export default function Dashboard() {
 
   // Weight sparkline
   const sparkData = [...weightLogs].reverse().map(l => ({
-    date: format(dayToLocalDate(entryDay(l)), 'M/d'),
+    date: formatDay(entryDay(l), 'M/d'),
     weight: displayWeight(l.weight, settings.weight_unit),
   }))
 
@@ -494,7 +494,7 @@ export default function Dashboard() {
                 <div className="min-w-0">
                   <p className="text-sm font-semibold text-tx-primary truncate">{lastWorkout.name}</p>
                   <p className="text-xs text-tx-muted mt-0.5">
-                    {format(dayToLocalDate(workoutDay(lastWorkout)), 'MMM d')}
+                    {formatDay(workoutDay(lastWorkout), 'MMM d')}
                     {mins > 0 && ` · ${mins} min`}
                     {totalSets > 0 && ` · ${totalSets} sets`}
                     {totalVolume > 0 && ` · ${totalVolume.toLocaleString()} ${wUnit}`}

--- a/web/src/pages/Food.tsx
+++ b/web/src/pages/Food.tsx
@@ -14,7 +14,7 @@ import {
 import Loading from '../components/Loading'
 import PeriodSelector from '../components/PeriodSelector'
 import { foodAPI, userAPI } from '../services/api'
-import { todayStr, dayToLocalDate, MACRO_COLORS, types } from '@lyftr/shared'
+import { todayStr, dayToLocalDate, MACRO_COLORS, types, formatDay } from '@lyftr/shared'
 
 const MEALS = ['breakfast', 'lunch', 'dinner', 'snacks'] as const
 const MEAL_LABELS: Record<string, string> = {
@@ -421,7 +421,7 @@ export default function Food() {
               </defs>
               <XAxis
                 dataKey="date"
-                tickFormatter={d => format(dayToLocalDate(d), 'M/d')}
+                tickFormatter={d => formatDay(d, 'M/d')}
                 tick={{ fontSize: 10, fill: 'var(--color-tx-muted)' }}
                 axisLine={false}
                 tickLine={false}
@@ -442,7 +442,7 @@ export default function Food() {
                   fontSize: '12px',
                   color: 'var(--color-tx-primary)',
                 }}
-                labelFormatter={d => format(dayToLocalDate(d), 'MMM d')}
+                labelFormatter={d => formatDay(d, 'MMM d')}
                 formatter={(val: number, name: string) => [`${Math.round(val)}g`, name]}
                 cursor={{ stroke: 'rgba(99,102,241,0.15)', strokeWidth: 1 }}
               />

--- a/web/src/pages/Weight.tsx
+++ b/web/src/pages/Weight.tsx
@@ -9,7 +9,7 @@ import DateInput from '../components/ui/DateInput'
 import PeriodSelector from '../components/PeriodSelector'
 import StepperTile from '../components/ui/StepperTile'
 import NumberField from '../components/ui/NumberField'
-import { BODYWEIGHT_STEP, clampStep, todayStr, daysAgoStr, dayToInstant, entryDay, dayToLocalDate, types } from '@lyftr/shared'
+import { BODYWEIGHT_STEP, clampStep, todayStr, daysAgoStr, dayToInstant, entryDay, dayToLocalDate, types, formatDay } from '@lyftr/shared'
 import { useServerInfiniteList } from '../hooks/useServerInfiniteList'
 import { weightAPI } from '../services/api'
 import { useSettingsStore, weightShort, lbsToDisplay, displayToLbs, displayWeight, round1 , weightError, maxWeight } from '../stores/settings'
@@ -422,7 +422,7 @@ export default function Weight() {
             <div className="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-400" role="alert">
               <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
               <div className="flex-1 min-w-0">
-                <p className="font-medium">Already logged on {format(dayToLocalDate(entryDay(items[0])), 'MMM d')} ({displayWeight(items[0].weight, settings.weight_unit)} {wUnit}). Log again anyway?</p>
+                <p className="font-medium">Already logged on {formatDay(entryDay(items[0]), 'MMM d')} ({displayWeight(items[0].weight, settings.weight_unit)} {wUnit}). Log again anyway?</p>
                 <div className="flex gap-2 mt-2">
                   <button
                     type="button"
@@ -553,7 +553,7 @@ export default function Weight() {
                       {Math.round(displayW)} {wUnit}
                     </p>
                     <p className="text-xs text-tx-muted mt-0.5">
-                      {format(dayToLocalDate(entryDay(entry)), 'MMM d, yyyy')}
+                      {formatDay(entryDay(entry), 'MMM d, yyyy')}
                     </p>
                     {(deltaLbs !== 0 || entry.notes) && (
                       <div className="flex items-center gap-x-2 mt-0.5 min-w-0 overflow-hidden">

--- a/web/src/pages/WeightDetail.tsx
+++ b/web/src/pages/WeightDetail.tsx
@@ -1,13 +1,12 @@
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { format } from 'date-fns'
 import { ArrowLeft, Scale, Trash2, Edit2, Save, X, AlertCircle, Loader } from 'lucide-react'
 import { weightAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayWeight, weightError, maxWeight, resolveWeightLbs } from '../stores/settings'
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock'
 import { useEscapeKey } from '../hooks/useEscapeKey'
-import { todayStr, dayToInstant, entryDay, dayToLocalDate, BODYWEIGHT_STEP, clampStep, types } from '@lyftr/shared'
+import { todayStr, dayToInstant, entryDay, BODYWEIGHT_STEP, clampStep, types, formatDay } from '@lyftr/shared'
 import StepperTile from '../components/ui/StepperTile'
 import NumberField from '../components/ui/NumberField'
 
@@ -162,7 +161,7 @@ export default function WeightDetail() {
                   <span className="text-tx-muted text-lg mb-1">{wUnit}</span>
                 </div>
                 <p className="text-sm text-tx-muted mt-1">
-                  {format(dayToLocalDate(entryDay(log)), 'EEEE, MMMM d, yyyy')}
+                  {formatDay(entryDay(log), 'EEEE, MMMM d, yyyy')}
                 </p>
                 {log.notes && (
                   <p className="text-sm text-tx-secondary mt-2 italic">"{log.notes}"</p>
@@ -246,7 +245,7 @@ export default function WeightDetail() {
             <div className="mx-auto w-10 h-1 rounded-full bg-surface-muted mb-4 sm:hidden" />
             <h3 className="font-display font-bold text-lg text-tx-primary mb-1">Delete Entry?</h3>
             <p className="text-sm text-tx-muted mb-5">
-              {format(dayToLocalDate(entryDay(log)), 'MMMM d, yyyy')} · {displayWeight(log.weight, settings.weight_unit)} {wUnit} will be permanently deleted.
+              {formatDay(entryDay(log), 'MMMM d, yyyy')} · {displayWeight(log.weight, settings.weight_unit)} {wUnit} will be permanently deleted.
             </p>
             <div className="flex gap-3">
               <button

--- a/web/src/pages/WorkoutDetail.tsx
+++ b/web/src/pages/WorkoutDetail.tsx
@@ -1,13 +1,12 @@
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { format } from 'date-fns'
 import {
   ArrowLeft, Clock, Dumbbell, TrendingUp, Edit2, Trash2, ChevronRight, AlertCircle, Loader, Pause, TimerOff,
 } from 'lucide-react'
 import { workoutAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayWeight, displayVolume } from '../stores/settings'
-import { types, workoutDay, dayToLocalDate, restLabel, calcVolume, countWorkingSets, exerciseVolume } from '@lyftr/shared'
+import { types, workoutDay, restLabel, calcVolume, countWorkingSets, exerciseVolume, formatDay } from '@lyftr/shared'
 import { muscleColor } from '../utils/exerciseUtils'
 
 function SetChip({ set, isBest, unit }: { set: types.Set; isBest: boolean; unit: string }) {
@@ -149,7 +148,7 @@ export default function WorkoutDetail() {
           <div className="min-w-0 flex-1">
             <h1 className="font-display font-bold text-xl text-tx-primary leading-tight">{workout.name}</h1>
             <p className="text-sm text-tx-muted mt-0.5">
-              {format(dayToLocalDate(workoutDay(workout)), 'EEEE, MMMM d, yyyy')}
+              {formatDay(workoutDay(workout), 'EEEE, MMMM d, yyyy')}
             </p>
           </div>
         </div>

--- a/web/src/pages/Workouts.tsx
+++ b/web/src/pages/Workouts.tsx
@@ -10,7 +10,7 @@ import { Toast } from '../components/ui'
 import { useServerInfiniteList } from '../hooks/useServerInfiniteList'
 import { workoutAPI } from '../services/api'
 import { useSettingsStore, weightShort, displayVolume } from '../stores/settings'
-import { types, workoutDay, dayToLocalDate, calcVolume } from '@lyftr/shared'
+import { types, workoutDay, calcVolume, formatDay } from '@lyftr/shared'
 
 function WorkoutCard({ workout, onEdit, onDelete }: { workout: types.Workout; onEdit: (id: number) => void; onDelete: (id: number) => void }) {
   const navigate = useNavigate()
@@ -94,7 +94,7 @@ function WorkoutCard({ workout, onEdit, onDelete }: { workout: types.Workout; on
           )}
           <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold text-tx-primary truncate">{workout.name}</p>
-            <p className="text-xs text-tx-muted mt-0.5 whitespace-nowrap">{format(dayToLocalDate(workoutDay(workout)), 'MMM d, yyyy')}</p>
+            <p className="text-xs text-tx-muted mt-0.5 whitespace-nowrap">{formatDay(workoutDay(workout), 'MMM d, yyyy')}</p>
             <div className="flex items-center gap-x-2 mt-0.5 min-w-0 overflow-hidden">
               {durationMin > 0 && (
                 <span className="flex items-center gap-1 text-xs text-tx-muted whitespace-nowrap">


### PR DESCRIPTION
Third slice off #150. **Three crash classes**, each found by driving the running app, each
independently revertible.

A white screen is the least visible failure this app can have: no nav, no error, nothing to
click. None of these were recoverable from inside the app.

## 1. An unknown URL blanked it

The catch-all `path="*"` existed **only in the signed-OUT branch**. Signed in, any unknown
path matched no route and React Router rendered nothing. A stale bookmark or a typo was
enough. The new one lives inside `Layout`, so the nav survives.

## 2. A corrupt stored session blanked it on boot

`hydrate()` wrapped only `JSON.parse` — which catches `{{{not json` and nothing else. Valid
JSON of the *wrong shape* parsed clean and then killed the first consumer to walk it:
`"hello"`, `[1,2,3]`, `{"name":"X"}`, `{"name":"X","exercises":null}`. A user cannot clear
their own localStorage, so this was terminal. Both blobs are now shape-checked, and an
unreadable value is dropped so the next boot is clean rather than re-parsing it forever.

## 3. An unreadable date had no safe outcome

`instantToDay` built `"NaN-NaN-NaN"` — a fake day that groups, sorts, and got posted to the
server as the row's day via `withLoggedOn`. Guarding only that traded the crash for
something worse: `dayToLocalDate('')` parses as `0`, `new Date(0, -1, 1)` is a valid 1899,
and the row rendered **"Jan 1, 1900" as fact**.

So the 24 copies of `format(dayToLocalDate(x), pattern)` across both apps become one
`formatDay`, reading `—` for a day it cannot read — the mark `memberSince` already uses.
Validating the day **string** rather than the resulting Date is what separates the two
failures, since only one of them is NaN.

## How to verify (≤5 min)

```bash
npm run shared:test                                    # 303, incl. the 1900 lie
cd web && npx playwright test resilience.spec.ts --project=chromium
```

To see the old behaviour: swap `web/src/App.tsx` and
`packages/shared/src/stores/workoutSession.ts` for main's copies and re-run — **all 9 e2e
cases fail.** I ran exactly that.

## Tests

- `web/e2e/resilience.spec.ts` (new, 9 cases) — covers what no unit test can: that the app
  still **boots** and still draws its chrome.
- `packages/shared/src/utils/dateUtils.test.ts` — the `formatDay` table, including an
  explicit assertion that it never renders 1900.
- `packages/shared/src/stores/workoutSession.test.ts` — eight hostile shapes, plus the sweep.

Mobile was driven on the emulator after the change: workout and weight history both render
real dates through `formatDay`, no regression.

## Scope

Deliberately **not** included, though they sat in the same original commit: the
`ErrorBoundary` (it renders `ErrorState`, which arrives with the failed-load slice) and the
`useServerList` shape guard (belongs with the lists slice).

`date-fns` is declared on `@lyftr/shared`; both apps already ship `^3`, so nothing new
enters a bundle — the lockfile moves by one line.

## Gate

shared 303 · web 84 + build · mobile 43 · e2e 12 · tsc and lint clean on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWC4KiFeoRZ3gtApGFHv1u