### PR TITLE
Accessible names, and gym mode is a dialog

### DIFF
--- a/web/e2e/a11y.spec.ts
+++ b/web/e2e/a11y.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures'
+
+// Icon-only controls had no accessible name: a screen reader announced "button", and
+// nothing else. The fix is one attribute per control, which is the kind of change that
+// rots silently — nobody notices a missing aria-label by looking at the screen.
+//
+// So the names are asserted by ROLE here rather than by CSS or position. That is what
+// makes them load-bearing: delete an aria-label and this fails, which is the only way a
+// label stays correct over time.
+test.describe('Icon-only controls have accessible names', () => {
+  const BACK_ON = ['/workouts/new', '/programs/new', '/food/log', '/workout/start']
+
+  for (const path of BACK_ON) {
+    test(`${path} names its back button`, async ({ page }) => {
+      await page.goto(path)
+      await expect(page.getByRole('button', { name: 'Go back' })).toBeVisible()
+    })
+  }
+
+  // The destructive ones matter most: a control that removes a set or an exercise is the
+  // worst thing to announce as an unnamed "button".
+  test('the workout form names its destructive controls', async ({ page }) => {
+    await page.goto('/workouts/new')
+
+    await page.getByRole('button', { name: /add exercise/i }).click()
+    await page.getByPlaceholder(/search exercises/i).fill('bench press')
+    await page.getByText(/bench press/i).first().click()
+
+    await expect(page.getByRole('button', { name: 'Remove exercise' }).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Remove set' }).first()).toBeVisible()
+  })
+})

--- a/web/e2e/workouts.spec.ts
+++ b/web/e2e/workouts.spec.ts
@@ -314,6 +314,35 @@ test.describe('Gym Mode', { tag: '@mobile' }, () => {
     await expect(page.getByRole('button', { name: /start workout/i })).toBeVisible({ timeout: 3000 })
   })
 
+  // The overlay covers the app but was not announced as covering it. aria-modal tells
+  // assistive tech to ignore what is behind; inert is what actually stops Tab walking
+  // into it. Both matter: without inert, Finish and Remove set are invisible but still
+  // reachable by keyboard, and pressing one of them mid-workout is unrecoverable.
+  test('the gym overlay is a modal dialog and the app behind it is inert', async ({ page }) => {
+    await seedGymSession(page, 'E2E A11y Test', 'Bench Press',
+      [{ set_number: 1, target_reps: 5, target_weight: 100, actual_reps: 5, actual_weight: 100, completed: false }]
+    )
+
+    await page.goto('/workout/active')
+    const dialog = page.getByRole('dialog', { name: 'Workout' })
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+    await expect(dialog).toHaveAttribute('aria-modal', 'true')
+
+    // The page behind is marked inert, so nothing inside it can take focus.
+    await expect(page.locator('main')).toHaveAttribute('inert', /.*/)
+
+    // Walk the keyboard a while; focus must never land behind the overlay.
+    for (let i = 0; i < 25; i++) {
+      await page.keyboard.press('Tab')
+      const escaped = await page.evaluate(() => {
+        const el = document.activeElement
+        if (!el || el === document.body) return false
+        return el.closest('main') !== null   // main is the inert region
+      })
+      expect(escaped, `Tab #${i + 1} escaped into the inert page behind the dialog`).toBe(false)
+    }
+  })
+
   test('gym mode overview shows exercise list and stats', async ({ page }) => {
     await seedGymSession(page, 'E2E Stats Test', 'Bench Press', [
       { set_number: 1, target_reps: 5, target_weight: 100, actual_reps: 5, actual_weight: 100, completed: false },

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -160,6 +160,8 @@ export default function Layout() {
   const { session, gymOpen, gymPhase } = useWorkoutSession()
   const { settings } = useSettingsStore()
   const wUnit = weightShort(settings.weight_unit)
+  // The one condition that decides whether the gym overlay is covering the app.
+  const gymOverlayUp = !!session && settings.workout_layout === 'gym' && gymOpen
 
   return (
     <div className="min-h-screen flex flex-col bg-surface-base">
@@ -176,14 +178,18 @@ export default function Layout() {
         </div>
       </header>
 
-      <main className="flex-1 max-w-6xl mx-auto w-full min-w-0 overflow-x-hidden px-5 py-7 animate-fade-in">
+      {/* inert while the gym overlay is up: aria-modal hides this from assistive tech,
+          but only inert stops Tab walking into the controls underneath — Finish and
+          Remove set among them, invisible but clickable. */}
+      <main
+        inert={gymOverlayUp}
+        className="flex-1 max-w-6xl mx-auto w-full min-w-0 overflow-x-hidden px-5 py-7 animate-fade-in"
+      >
         <Outlet />
       </main>
 
       {/* Gym mode overlay — rendered at root so it persists across routes */}
-      {session && settings.workout_layout === 'gym' && gymOpen && (
-        <GymModeWorkout wUnit={wUnit} />
-      )}
+      {gymOverlayUp && <GymModeWorkout wUnit={wUnit} />}
 
       {/* Rest timer floating panel — only INSIDE the workout, on the gym overview /
           exercise-info screens. The set screen docks its own copy (pushes content up),

--- a/web/src/components/programs/DayExercisesEditor.test.tsx
+++ b/web/src/components/programs/DayExercisesEditor.test.tsx
@@ -37,10 +37,13 @@ describe('DayExercisesEditor', () => {
     expect(screen.getByText(/No exercises yet/)).toBeTruthy()
   })
 
+  // This asserted "1 sets", which pinned the missing singular. The program side of
+  // the app already used the {n} set{n === 1 ? '' : 's'} idiom in ten places; the
+  // workout side did not, and this row was one of the gaps.
   it('shows the cached exercise name and its set count', () => {
     renderEditor([draft()])
     expect(screen.getByText('Bench Press')).toBeTruthy()
-    expect(screen.getByText('1 sets')).toBeTruthy()
+    expect(screen.getByText('1 set')).toBeTruthy()
   })
 
   it('Add Set appends a set copying the previous set\'s reps/weight', () => {

--- a/web/src/components/programs/DayExercisesEditor.tsx
+++ b/web/src/components/programs/DayExercisesEditor.tsx
@@ -116,7 +116,7 @@ export default function DayExercisesEditor({ exercises, onChange, pickerExercise
                     </div>
                     <p className="text-xs text-tx-muted ml-8">{exercise?.muscle_group} • {exercise?.equipment}</p>
                   </div>
-                  <button type="button" onClick={() => removeExercise(exIdx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+                  <button type="button" aria-label="Remove exercise" onClick={() => removeExercise(exIdx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                     <Trash2 className="w-4 h-4 text-error-400" />
                   </button>
                 </div>
@@ -143,7 +143,7 @@ export default function DayExercisesEditor({ exercises, onChange, pickerExercise
                 <div className="space-y-2 mb-3">
                   <div className="flex items-center justify-between">
                     <label className="text-xs text-tx-muted font-medium uppercase tracking-wider">Target Sets</label>
-                    <span className="text-xs text-tx-muted">{workoutEx.sets.length} sets</span>
+                    <span className="text-xs text-tx-muted">{workoutEx.sets.length} set{workoutEx.sets.length === 1 ? '' : 's'}</span>
                   </div>
                   {workoutEx.sets.map((set, setIdx) => (
                     <div key={setIdx} className="flex gap-2 items-end bg-surface-raised/40 p-3 rounded-lg border border-surface-border/50">
@@ -159,7 +159,7 @@ export default function DayExercisesEditor({ exercises, onChange, pickerExercise
                         <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Target Weight</label>
                         <WeightInput size="sm" value={set.target_weight ? String(set.target_weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'target_weight', v)} unit={wUnit} placeholder="135" />
                       </div>
-                      <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+                      <button type="button" aria-label="Remove set" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                         <Trash2 className="w-4 h-4 text-error-400" />
                       </button>
                     </div>

--- a/web/src/components/programs/ProgramDaysEditor.tsx
+++ b/web/src/components/programs/ProgramDaysEditor.tsx
@@ -58,10 +58,10 @@ export default function ProgramDaysEditor({ days, onChange, pickerExercises, onC
           <div key={idx} className={`border rounded-lg overflow-hidden ${day.is_rest_day ? 'border-surface-border bg-surface-muted/20' : 'border-surface-border bg-surface-muted/30'}`}>
             <div className="flex items-center gap-2 p-3">
               <div className="flex flex-col flex-shrink-0">
-                <button type="button" onClick={() => moveDay(idx, -1)} disabled={idx === 0} className="p-0.5 text-tx-muted hover:text-tx-primary disabled:opacity-20 transition-colors">
+                <button type="button" aria-label="Move day up" onClick={() => moveDay(idx, -1)} disabled={idx === 0} className="p-0.5 text-tx-muted hover:text-tx-primary disabled:opacity-20 transition-colors">
                   <ChevronUp className="w-3.5 h-3.5" />
                 </button>
-                <button type="button" onClick={() => moveDay(idx, 1)} disabled={idx === days.length - 1} className="p-0.5 text-tx-muted hover:text-tx-primary disabled:opacity-20 transition-colors">
+                <button type="button" aria-label="Move day down" onClick={() => moveDay(idx, 1)} disabled={idx === days.length - 1} className="p-0.5 text-tx-muted hover:text-tx-primary disabled:opacity-20 transition-colors">
                   <ChevronDown className="w-3.5 h-3.5" />
                 </button>
               </div>
@@ -96,12 +96,12 @@ export default function ProgramDaysEditor({ days, onChange, pickerExercises, onC
               </div>
 
               {!day.is_rest_day && (
-                <button type="button" onClick={() => setExpanded(isOpen ? null : idx)} className="p-1.5 hover:bg-surface-muted rounded-lg transition-colors flex-shrink-0">
+                <button type="button" aria-label={isOpen ? 'Collapse day' : 'Expand day'} aria-expanded={isOpen} onClick={() => setExpanded(isOpen ? null : idx)} className="p-1.5 hover:bg-surface-muted rounded-lg transition-colors flex-shrink-0">
                   {isOpen ? <ChevronCollapse className="w-4 h-4 text-tx-muted rotate-90" /> : <ChevronRight className="w-4 h-4 text-tx-muted" />}
                 </button>
               )}
 
-              <button type="button" onClick={() => removeDay(idx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+              <button type="button" aria-label="Remove day" onClick={() => removeDay(idx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                 <Trash2 className="w-4 h-4 text-error-400" />
               </button>
             </div>

--- a/web/src/pages/ActiveWorkout.tsx
+++ b/web/src/pages/ActiveWorkout.tsx
@@ -340,7 +340,13 @@ export default function ActiveWorkout() {
                         />
 
                         {/* Complete toggle */}
+                        {/* The most-pressed control in the app, and it had no
+                            accessible name and no state: a screen reader announced
+                            "button" with no way to tell a done set from a pending one.
+                            aria-pressed carries what the fill colour conveys visually. */}
                         <button
+                          aria-label={`Set ${set.set_number}, mark done`}
+                          aria-pressed={!!set.completed}
                           onClick={() => handleCompleteSet(exIdx, setIdx)}
                           className={`flex items-center justify-center transition-colors min-h-[3rem] ${
                             set.completed

--- a/web/src/pages/AddProgram.tsx
+++ b/web/src/pages/AddProgram.tsx
@@ -60,7 +60,7 @@ export default function AddProgram() {
   return (
     <div className="space-y-6 animate-slide-up pb-10">
       <div className="flex items-center gap-3">
-        <button onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
+        <button aria-label="Go back" onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
           <ArrowLeft className="w-5 h-5 text-tx-muted" />
         </button>
         <div>

--- a/web/src/pages/AddWorkout.tsx
+++ b/web/src/pages/AddWorkout.tsx
@@ -114,7 +114,7 @@ export default function AddWorkout() {
   return (
     <div className="space-y-6 animate-slide-up pb-10">
       <div className="flex items-center gap-3">
-        <button onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
+        <button aria-label="Go back" onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
           <ArrowLeft className="w-5 h-5 text-tx-muted" />
         </button>
         <div>
@@ -214,7 +214,7 @@ export default function AddWorkout() {
                       </div>
                       <p className="text-xs text-tx-muted ml-8">{exercise?.muscle_group} • {exercise?.equipment}</p>
                     </div>
-                    <button type="button" onClick={() => removeExercise(exIdx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+                    <button type="button" aria-label="Remove exercise" onClick={() => removeExercise(exIdx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                       <Trash2 className="w-4 h-4 text-error-400" />
                     </button>
                   </div>
@@ -251,7 +251,7 @@ export default function AddWorkout() {
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
                           <WeightInput size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                         </div>
-                        <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+                        <button type="button" aria-label="Remove set" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />
                         </button>
                       </div>

--- a/web/src/pages/AddWorkout.tsx
+++ b/web/src/pages/AddWorkout.tsx
@@ -119,7 +119,7 @@ export default function AddWorkout() {
         </button>
         <div>
           <h1 className="font-display font-bold text-2xl text-tx-primary">Log Workout</h1>
-          <p className="text-xs text-tx-muted">{formData.exercises.length} exercises • {totalSets} sets</p>
+          <p className="text-xs text-tx-muted">{formData.exercises.length} exercise{formData.exercises.length === 1 ? '' : 's'} • {totalSets} set{totalSets === 1 ? '' : 's'}</p>
         </div>
       </div>
 
@@ -235,7 +235,7 @@ export default function AddWorkout() {
                   <div className="space-y-2 mb-3">
                     <div className="flex items-center justify-between">
                       <label className="text-xs text-tx-muted font-medium uppercase tracking-wider">Sets</label>
-                      <span className="text-xs text-tx-muted">{workoutEx.sets.length} sets</span>
+                      <span className="text-xs text-tx-muted">{workoutEx.sets.length} set{workoutEx.sets.length === 1 ? '' : 's'}</span>
                     </div>
                     {workoutEx.sets.map((set, setIdx) => (
                       <div key={setIdx} className="flex gap-2 items-end bg-surface-raised/40 p-3 rounded-lg border border-surface-border/50">

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -496,7 +496,7 @@ export default function Dashboard() {
                   <p className="text-xs text-tx-muted mt-0.5">
                     {formatDay(workoutDay(lastWorkout), 'MMM d')}
                     {mins > 0 && ` · ${mins} min`}
-                    {totalSets > 0 && ` · ${totalSets} sets`}
+                    {totalSets > 0 && ` · ${totalSets} set${totalSets === 1 ? '' : 's'}`}
                     {totalVolume > 0 && ` · ${totalVolume.toLocaleString()} ${wUnit}`}
                   </p>
                 </div>
@@ -619,7 +619,7 @@ export default function Dashboard() {
           <SectionHeader
             icon={Dumbbell}
             title="Muscle Balance"
-            right={<span className="text-xs text-tx-muted">{workouts.length} workouts</span>}
+            right={<span className="text-xs text-tx-muted">{workouts.length} workout{workouts.length === 1 ? '' : 's'}</span>}
             className="mb-1"
           />
 
@@ -659,7 +659,7 @@ export default function Dashboard() {
                   <Tooltip
                     contentStyle={TOOLTIP_STYLE}
                     formatter={(v: number, _: string, props: { payload?: { name: string } }) => [
-                      `${v} sets (${Math.round((v / totalMuscSets) * 100)}%)`,
+                      `${v} set${v === 1 ? '' : 's'} (${Math.round((v / totalMuscSets) * 100)}%)`,
                       props.payload?.name ?? '',
                     ]}
                   />

--- a/web/src/pages/EditProgram.tsx
+++ b/web/src/pages/EditProgram.tsx
@@ -108,7 +108,7 @@ export default function EditProgram() {
   return (
     <div className="space-y-6 animate-slide-up pb-10">
       <div className="flex items-center gap-3">
-        <button onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
+        <button aria-label="Go back" onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
           <ArrowLeft className="w-5 h-5 text-tx-muted" />
         </button>
         <div>

--- a/web/src/pages/EditWorkout.tsx
+++ b/web/src/pages/EditWorkout.tsx
@@ -131,7 +131,7 @@ export default function EditWorkout() {
   return (
     <div className="space-y-6 animate-slide-up pb-10">
       <div className="flex items-center gap-3">
-        <button onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
+        <button aria-label="Go back" onClick={() => navigate(-1)} className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
           <ArrowLeft className="w-5 h-5 text-tx-muted" />
         </button>
         <div>
@@ -214,7 +214,7 @@ export default function EditWorkout() {
                       </div>
                       <p className="text-xs text-tx-muted ml-8">{exercise?.muscle_group} • {exercise?.equipment}</p>
                     </div>
-                    <button type="button" onClick={() => removeExercise(exIdx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+                    <button type="button" aria-label="Remove exercise" onClick={() => removeExercise(exIdx)} className="p-1.5 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                       <Trash2 className="w-4 h-4 text-error-400" />
                     </button>
                   </div>
@@ -243,7 +243,7 @@ export default function EditWorkout() {
                           <label className="text-xs text-tx-muted font-medium uppercase tracking-wider block mb-1">Weight</label>
                           <WeightInput size="sm" value={set.weight ? String(set.weight) : ''} onChange={v => updateSet(exIdx, setIdx, 'weight', v)} unit={wUnit} placeholder="225" />
                         </div>
-                        <button type="button" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
+                        <button type="button" aria-label="Remove set" onClick={() => removeSet(exIdx, setIdx)} className="p-2 hover:bg-error-500/20 rounded transition-colors flex-shrink-0">
                           <Trash2 className="w-4 h-4 text-error-400" />
                         </button>
                       </div>

--- a/web/src/pages/EditWorkout.tsx
+++ b/web/src/pages/EditWorkout.tsx
@@ -136,7 +136,7 @@ export default function EditWorkout() {
         </button>
         <div>
           <h1 className="font-display font-bold text-2xl text-tx-primary">Edit Workout</h1>
-          <p className="text-xs text-tx-muted">{formData.exercises.length} exercises • {totalSets} sets</p>
+          <p className="text-xs text-tx-muted">{formData.exercises.length} exercise{formData.exercises.length === 1 ? '' : 's'} • {totalSets} set{totalSets === 1 ? '' : 's'}</p>
         </div>
       </div>
 
@@ -227,7 +227,7 @@ export default function EditWorkout() {
                   <div className="space-y-2 mb-3">
                     <div className="flex items-center justify-between">
                       <label className="text-xs text-tx-muted font-medium uppercase tracking-wider">Sets</label>
-                      <span className="text-xs text-tx-muted">{workoutEx.sets.length} sets</span>
+                      <span className="text-xs text-tx-muted">{workoutEx.sets.length} set{workoutEx.sets.length === 1 ? '' : 's'}</span>
                     </div>
                     {workoutEx.sets.map((set, setIdx) => (
                       <div key={setIdx} className="flex gap-2 items-end bg-surface-raised/40 p-3 rounded-lg border border-surface-border/50">

--- a/web/src/pages/ExerciseDetail.tsx
+++ b/web/src/pages/ExerciseDetail.tsx
@@ -99,6 +99,7 @@ export default function ExerciseDetail() {
       {/* Header */}
       <div className="flex items-start gap-3">
         <button
+          aria-label="Go back"
           onClick={() => navigate(-1)}
           className="p-2 hover:bg-surface-muted rounded-lg transition-colors mt-0.5 flex-shrink-0"
         >

--- a/web/src/pages/GymModeWorkout.tsx
+++ b/web/src/pages/GymModeWorkout.tsx
@@ -256,7 +256,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
                         <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${muscleColor(ex.exercise.muscle_group)}`}>
                           {ex.exercise.muscle_group}
                         </span>
-                        <span className="text-[10px] text-tx-muted">{ex.sets.length} sets</span>
+                        <span className="text-[10px] text-tx-muted">{ex.sets.length} set{ex.sets.length === 1 ? '' : 's'}</span>
                       </div>
                     </div>
                     {done && <CheckCircle2 className="w-4 h-4 text-brand-400 flex-shrink-0" />}

--- a/web/src/pages/GymModeWorkout.tsx
+++ b/web/src/pages/GymModeWorkout.tsx
@@ -190,7 +190,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
   // ── Overview ──────────────────────────────────────────────────────────
   if (phase === 'overview') {
     return (
-      <div className="fixed inset-0 z-[60] bg-surface-base overflow-y-auto flex flex-col">
+      <div role="dialog" aria-modal="true" aria-label="Workout" className="fixed inset-0 z-[60] bg-surface-base overflow-y-auto flex flex-col">
         <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-surface-border flex-shrink-0">
           <div>
             <p className="text-xs font-semibold text-tx-muted uppercase tracking-wider mb-0.5">Workout</p>
@@ -333,7 +333,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
     ]
 
     return (
-      <div className="fixed inset-0 z-[60] bg-surface-base overflow-y-auto flex flex-col">
+      <div role="dialog" aria-modal="true" aria-label="Workout" className="fixed inset-0 z-[60] bg-surface-base overflow-y-auto flex flex-col">
         <TopBar s={session} onBack={() => isFirst ? setPhase('overview') : setGymState('exercise', activeIdx - 1, 0)} />
 
         <div className="flex-1 overflow-y-auto">
@@ -530,7 +530,7 @@ export default function GymModeWorkout({ wUnit }: GymModeWorkoutProps) {
   const hideCompleteForRest = restingHere && clampedSetIdx === restNextSet
 
   return (
-    <div className="fixed inset-0 z-[60] bg-surface-base flex flex-col">
+    <div role="dialog" aria-modal="true" aria-label="Workout" className="fixed inset-0 z-[60] bg-surface-base flex flex-col">
       <TopBar s={session} onBack={() => setPhase('exercise-info')} />
 
       {/* Exercise name + muscle (compact) */}

--- a/web/src/pages/LogFood.tsx
+++ b/web/src/pages/LogFood.tsx
@@ -316,6 +316,7 @@ export default function LogFood() {
       {/* Header with breadcrumb */}
       <div className="flex items-center gap-3 mb-5">
         <button
+          aria-label="Go back"
           onClick={() => phase === 'detail' && !editId ? setPhase('search') : navigate(-1)}
           className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-surface-muted active:scale-95 transition-all flex-shrink-0"
         >

--- a/web/src/pages/ProgramDetail.tsx
+++ b/web/src/pages/ProgramDetail.tsx
@@ -162,12 +162,14 @@ export default function ProgramDetail() {
             <Play className="w-3.5 h-3.5" /> Start Workout
           </button>
           <button
+            aria-label="Edit program"
             onClick={() => navigate(`/programs/${program.id}/edit`)}
             className="p-2 hover:bg-surface-muted rounded-lg transition-colors"
           >
             <Edit2 className="w-4 h-4 text-brand-500" />
           </button>
           <button
+            aria-label="Delete program"
             onClick={() => setConfirming(true)}
             className="p-2 hover:bg-error-500/10 rounded-lg transition-colors"
           >

--- a/web/src/pages/Programs.tsx
+++ b/web/src/pages/Programs.tsx
@@ -224,7 +224,7 @@ function ProgramCard({
               className="p-2 hover:bg-brand-500/10 rounded-lg transition-colors" title={canQuickStart ? 'Start workout' : 'Rest day today — open program'}>
               <Play className="w-4 h-4 text-brand-500" />
             </button>
-            <button onClick={e => { e.stopPropagation(); onEdit(program.id) }}
+            <button aria-label={`Edit ${program.name}`} onClick={e => { e.stopPropagation(); onEdit(program.id) }}
               className="p-2 hover:bg-surface-muted rounded-lg transition-colors">
               <Edit2 className="w-4 h-4 text-brand-500" />
             </button>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -119,7 +119,7 @@ export default function Settings() {
     setSeedMsg(null)
     try {
       const res = await exerciseAPI.refreshCache()
-      setSeedMsg(`Refreshed ${res.refreshed.toLocaleString()} exercises`)
+      setSeedMsg(`Refreshed ${res.refreshed.toLocaleString()} exercise${res.refreshed === 1 ? '' : 's'}`)
       loadCacheStatus()
     } catch (err: any) {
       setSeedMsg(err.message || 'Refresh failed')

--- a/web/src/pages/StartWorkout.tsx
+++ b/web/src/pages/StartWorkout.tsx
@@ -26,6 +26,7 @@ export default function StartWorkout() {
     <div className="space-y-6 animate-slide-up">
       <div className="flex items-center gap-3">
         <button
+          aria-label="Go back"
           onClick={() => navigate(-1)}
           className="p-2 hover:bg-surface-muted rounded-lg transition-colors"
         >

--- a/web/src/pages/WorkoutDetail.tsx
+++ b/web/src/pages/WorkoutDetail.tsx
@@ -228,7 +228,7 @@ export default function WorkoutDetail() {
                         {ex.exercise.muscle_group}
                       </span>
                     )}
-                    <span className="text-xs text-tx-muted truncate">{sets.length} sets{exVol > 0 ? ` · ${exVol.toLocaleString()} ${wUnit}` : ''}</span>
+                    <span className="text-xs text-tx-muted truncate">{sets.length} set{sets.length === 1 ? '' : 's'}{exVol > 0 ? ` · ${exVol.toLocaleString()} ${wUnit}` : ''}</span>
                   </div>
                 </div>
                 {maxWeight > 0 && (

--- a/web/src/pages/WorkoutDetail.tsx
+++ b/web/src/pages/WorkoutDetail.tsx
@@ -95,12 +95,14 @@ export default function WorkoutDetail() {
         </Link>
         <div className="flex items-center gap-1">
           <button
+            aria-label="Edit workout"
             onClick={() => navigate(`/workouts/${workout.id}/edit`)}
             className="p-2 hover:bg-surface-muted rounded-lg transition-colors"
           >
             <Edit2 className="w-4 h-4 text-brand-500" />
           </button>
           <button
+            aria-label="Delete workout"
             onClick={() => setConfirming(true)}
             className="p-2 hover:bg-error-500/10 rounded-lg transition-colors"
           >

--- a/web/src/pages/WorkoutExercisePicker.tsx
+++ b/web/src/pages/WorkoutExercisePicker.tsx
@@ -76,6 +76,7 @@ export default function WorkoutExercisePicker() {
       {/* Header */}
       <div className="flex items-center gap-3 mb-4 flex-shrink-0">
         <button
+          aria-label="Back to workout"
           onClick={() => navigate('/workout/active')}
           className="p-2 hover:bg-surface-muted rounded-lg transition-colors"
         >

--- a/web/src/pages/Workouts.tsx
+++ b/web/src/pages/Workouts.tsx
@@ -102,7 +102,7 @@ function WorkoutCard({ workout, onEdit, onDelete }: { workout: types.Workout; on
                 </span>
               )}
               {durationMin > 0 && <span className="text-tx-muted/40 text-xs">·</span>}
-              <span className="text-xs text-tx-muted whitespace-nowrap">{workout.exercises?.length || 0} exercises</span>
+              <span className="text-xs text-tx-muted whitespace-nowrap">{workout.exercises?.length || 0} exercise{(workout.exercises?.length || 0) === 1 ? '' : 's'}</span>
               {totalVolume > 0 && (
                 <>
                   <span className="text-tx-muted/40 text-xs">·</span>

--- a/web/src/pages/Workouts.tsx
+++ b/web/src/pages/Workouts.tsx
@@ -176,6 +176,7 @@ function WorkoutCard({ workout, onEdit, onDelete }: { workout: types.Workout; on
           {/* Desktop hover icons */}
           <div className="hidden sm:flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
             <button
+              aria-label={`Edit ${workout.name}`}
               onClick={e => { e.stopPropagation(); onEdit(workout.id) }}
               className="p-2 hover:bg-surface-muted rounded-lg transition-colors"
             >


### PR DESCRIPTION
Fourth slice off #150. **Web only**, 22 files, +120/−35 — and half of that is the tests.

## What breaks without this

**Icon-only controls had no accessible name.** A screen reader announced "button", and
nothing else — including for the controls that remove a set, remove an exercise, delete a
workout, and delete a program.

**The gym overlay covered the app without saying so.** `aria-modal` tells assistive tech to
ignore what is behind it, but only `inert` stops Tab walking into it. Without inert, Finish
and Remove set sit behind the overlay: invisible, still focusable, and unrecoverable if
pressed mid-workout.

## What changed

- 12 icon-only controls get a name (`Go back`, `Remove set`, `Remove exercise`, `Remove day`,
  `Move day up`/`down`, `Edit`/`Delete workout`, `Edit`/`Delete program`, `Back to workout`).
- The three gym overlay roots get `role="dialog" aria-modal="true" aria-label="Workout"`.
- `<main>` becomes `inert` while the overlay is up, driven by one `gymOverlayUp` condition
  computed once instead of three copies of the same boolean.
- Pluralisation finished where it was half-applied (`1 set`, not `1 sets`).

## How to verify (≤5 min)

```bash
cd web && npx playwright test a11y.spec.ts --project=chromium
cd web && npx playwright test workouts.spec.ts --grep inert --project=chromium
```

To see the old behaviour, swap the labelled pages for main's copies and re-run — **all five
name tests fail**; swap `Layout.tsx`/`GymModeWorkout.tsx` and the dialog test fails on the
missing role. I ran exactly that.

## Tests

- `web/e2e/a11y.spec.ts` (new, 5 cases) — asserts **by role**, not by CSS or position. An
  `aria-label` rots silently; no existing spec touched these controls at all. Asserting the
  name is the only thing that keeps it correct.
- `workouts.spec.ts` — the overlay is a named dialog, `<main>` is inert, and **Tab pressed 25
  times never lands behind it**. That is a claim a snapshot cannot make.

## Note on the conflict I resolved

`f3eab26` cherry-picked with one conflict in `Settings.tsx`. Its version changed `setSeedMsg`
to a `{ text, failed }` object — that shape belongs to the **failed-load slice**, not this
one. I kept main's string shape and took only the pluralisation, so nothing from a later PR
leaks in here. Confirmed: the diff references no `ErrorState`, `useAsyncAction`,
`ConfirmSheet` or `ErrorBoundary`.

## Gate

web unit 84 · build clean · 0 lint errors · tsc clean · e2e 38 passed across the four
affected specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWC4KiFeoRZ3gtApGFHv1u