### PR TITLE
Tell the reviewer what matters in this repo

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -93,7 +93,9 @@ jobs:
           # so instructions written there would be mistaken for a path.
           claude_args: >-
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
-            --append-system-prompt "Before reviewing, read REVIEW.md at the repository root
-            and treat it as this repository's review policy: it sets what counts as
-            Important here, the conventions to always check, the nit cap, and what not to
-            report. It takes precedence over your default calibration where they differ." 
+            --append-system-prompt "Read REVIEW.md at the repository root and follow it as
+            this repository's review policy. It sets severity calibration, the nit cap, the
+            evidence bar and what not to report, and takes precedence over your default
+            calibration. It deliberately does not restate the project's standards: those
+            are in CLAUDE.md, which you already read, and REVIEW.md tells you how to weigh
+            a violation of them." 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -84,4 +84,16 @@ jobs:
           #   --allowedTools : the action starts the inline-comment MCP server only when
           #                    --allowedTools names it, even though the skill's own
           #                    frontmatter already declares the same tool
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # REVIEW.md is the single source of the review policy — pointed at rather than
+          # inlined here, so the rules live in a reviewable file next to the code they
+          # describe instead of inside a YAML string. The checkout above puts it on disk.
+          #
+          # It is passed as an appended system prompt rather than appended to `prompt`,
+          # because /code-review reads everything after its flags as the review TARGET,
+          # so instructions written there would be mistaken for a path.
+          claude_args: >-
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --append-system-prompt "Before reviewing, read REVIEW.md at the repository root
+            and treat it as this repository's review policy: it sets what counts as
+            Important here, the conventions to always check, the nit cap, and what not to
+            report. It takes precedence over your default calibration where they differ." 

--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,11 @@ docs/*.md
 !docs/API_CHANGES.md
 docs/*.txt
 
-# Local Claude context
-CLAUDE.md
+# Personal Claude context. CLAUDE.md itself is COMMITTED — it is the project's shared
+# standards, and the PR review reads it from the checkout, so ignoring it meant the
+# reviewer was told to follow rules it could not see. Machine-specific notes belong in
+# ~/.claude/CLAUDE.md or a CLAUDE.local.md, not here.
+CLAUDE.local.md
 .claude/
 
 # Playwright artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,492 @@
+# Lyftr — project context
+
+Self-hosted workout tracker. Go backend, React/TypeScript frontend, SQLite, Docker.
+GitHub: https://github.com/Cawlumm/lyftr
+
+Written for everyone who works on this repo, human or agent. It is checked in, so it is
+also what the automated PR review reads; `REVIEW.md` says how findings against these rules
+should be weighed, and deliberately does not restate them.
+
+Machine-specific setup — your own paths, ports, editor, hardware limits — does not belong
+here. Put that in your personal `~/.claude/CLAUDE.md`, which is not shared.
+
+Every rule below was paid for by a bug. Where one names a file, that file is the single
+place the rule is enforced; adding a second is how the rule stops holding.
+
+---
+
+## Stack
+
+| Layer | Tech |
+|-------|------|
+| Backend | Go 1.26, Gin, SQLite (`_foreign_keys=on`) |
+| Frontend | React 18, TypeScript, Tailwind CSS, Vite, Recharts |
+| Auth | JWT + refresh tokens (middleware/auth.go) |
+| Deployment | Docker Compose, nginx reverse proxy |
+
+---
+
+## Project Structure
+
+```
+backend/
+  main.go               — entry point, wires DB + routes + seed
+  config/config.go      — env vars (JWT_SECRET, CORS_ORIGIN, PORT)
+  controllers/          — one file per resource
+  db/sqlite.go          — opens SQLite, enables WAL + foreign keys
+  db/migrations.go      — schema migrations (run on startup)
+  middleware/auth.go    — JWT validation middleware
+  models/models.go      — all structs + request types
+  routes/routes.go      — all routes, protected vs public
+  seed/exercises.go     — async exercise seeding from free-exercise-db
+  seed/users.go         — demo user seeding
+  utils/response.go     — utils.OK / utils.BadRequest helpers
+
+web/src/
+  pages/                — one file per page/route
+  services/api.ts       — all API calls (axios), typed
+  types/index.ts        — shared TypeScript types
+  App.tsx               — React Router routes
+```
+
+---
+
+## Key Conventions
+
+**Backend**
+- All handlers use `utils.OK(c, data)` and `utils.BadRequest(c, msg)`
+- Routes: public under `/api/v1/auth/`, protected under `/api/v1/` (JWT required)
+- Admin routes: `protected.GET/POST("admin/...")` — requires auth, no separate role check yet
+- Weight stored in **lbs** internally (backend stores raw numbers; the unit is a frontend convention). Frontend converts via `lbsToDisplay`/`displayToLbs` in `web/src/stores/settings.ts` based on `user_settings.weight_unit` — never store display values directly
+- `exercise_id` FK references `exercises(id)` — **no ON DELETE CASCADE** — never wipe exercises table while workout/program data exists
+- New migrations go in `db/migrations.go` — append only, never modify existing
+
+**Frontend**
+- API calls go through `web/src/services/api.ts` — add new endpoints there, not inline
+- Always null-guard arrays before `.reduce`/`.forEach`: `(w.exercises ?? []).forEach(...)`
+- Duration stored as **seconds** in DB — display as `Math.round(duration / 60)` min
+- Light/dark theme via `localStorage.setItem('theme', 'light|dark')` + `document.documentElement.classList`
+- Mobile-first: 90% of users on mobile, desktop is secondary
+- New pages: create in `web/src/pages/`, add route in `App.tsx`, add API methods in `api.ts`
+
+---
+
+## Time & Calendar Days — read before touching any date
+
+**The rule: a row records its own day. Nothing re-derives one from whoever is reading.**
+
+An instant does not contain a day — a day is an instant *plus a place*. So every
+day-scoped row stores both. This is the model Fitbit, Garmin, Strava and Android
+Health Connect all use, and the reason travelling no longer rewrites history.
+
+| Entity | Instant | Day attribution | Peer precedent |
+|---|---|---|---|
+| `food_logs`, `weight_logs` | `logged_at` (UTC) | `logged_on` — stored `YYYY-MM-DD` | Fitbit `logDate` |
+| `workouts` | `started_at` (UTC) | `tz_offset_minutes` — offset at start | Strava `utc_offset`, Garmin `startTimeOffsetInSeconds` |
+
+Diary entries store the day because the user *picks* it. Workouts store an offset
+because the day *follows* from where the moment happened. Fitbit splits them the
+same way.
+
+**`user_settings.timezone` is not dead and is not the source of day attribution.**
+It answers only questions about *now*, which no stored row can answer:
+- "What is today?" for a read with no `date` param
+- "30 days back from *your* today" — `/food/history`, `/weight/stats` send no dates
+- The day/offset for a write from a client too old to send one (back-compat fallback)
+
+### Single points of truth — do not add a fifth way to get a day
+
+- **Backend**: `backend/controllers/timezone.go`. `resolveDay` (writes),
+  `resolveQueryDay` (reads), `daysAgoDay` (windows), `tzOffsetMinutes` (workouts).
+  Every handler goes through one of these. No inline `time.Now().In(loc)` elsewhere.
+- **Client**: `packages/shared/src/utils/dateUtils.ts` — **one copy, imported by both
+  apps** from `@lyftr/shared`. `entryDay(e)` for diary rows, `workoutDay(w)` for
+  workouts — never `new Date(x).getDate()` or `.toISOString().slice(0,10)` in a page.
+  Writes go through `withLoggedOn` / `utcOffsetMinutes` in the API layer, so no screen
+  can forget to send the day.
+- There is no longer a web-side fork to keep in step (and no `dateUtils.fork.test.ts`).
+  What protects the shared copy now is CI: the `web` paths filter in `ci.yml` includes
+  `packages/shared/**`, so editing a shared util runs web's unit suite, build and e2e
+  as well as mobile's.
+
+### Gotchas
+
+- SQLite `date(started_at, ...)` returns NULL: the modernc driver writes Go's
+  `String()` form (`2026-04-25 03:30:00 +0000 UTC`). Use `substr(x, 1, 19)` first.
+- `time/tzdata` must stay imported — Alpine ships no `/usr/share/zoneinfo`, so
+  `LoadLocation` would silently fall back to UTC in production only.
+- Day arithmetic uses `AddDate(0, 0, n)`, never `Add(24 * time.Hour)` (DST).
+
+---
+
+## Numbers & Locale — read before rendering or reading a number
+
+**The rule: the app stores canonical, the screen shows the user's notation, and one
+module owns the conversion both ways.**
+
+Half of Europe writes twelve and a half as `12,5`. Android's `decimal-pad` shows the
+*locale's* separator, and on those keypads there is often no full stop at all — so a field
+that strips "anything that isn't a digit or a dot" makes decimals unenterable for those
+users. That was #141. React Native makes the sanitizing mandatory rather than defensive:
+`ReactEditText` replaces Android's `KeyListener` specifically to *"permit all keyboard
+input through"*, so `keyboardType` constrains what is **drawn**, never what arrives.
+
+| Layer | Notation | Why |
+|---|---|---|
+| DB, API, stores, arithmetic | canonical `.` | one machine-readable form; `Number()` works everywhere |
+| A numeric field's buffer | canonical `.` | so no caller has to learn a second notation |
+| Anything a person reads | the locale's | what they typed is what they see |
+
+### Single points of truth — do not add a fourth way to write a number
+
+All in `packages/shared/src/utils/number.ts`, imported by both apps:
+
+- **`configureNumberLocale({ decimal, group })`** — called **once**, from
+  `mobile/src/lib/lyftr.ts`, with `expo-localization`'s native values. Injected rather
+  than detected for the same reason `detectTimezone` is: Hermes leaves
+  `Intl.NumberFormat#formatToParts` unimplemented on iOS (`PlatformIntlApple.mm` is a
+  literal `llvm_unreachable`), so detecting the separators would crash on half the fleet.
+  Web never calls it and keeps the en-US default — `<input type="number">` is localised by
+  the browser.
+- **`sanitizeNumericInput(raw, mode)`** — typed text → canonical. Every numeric
+  `TextInput` on mobile goes through it; there is no second copy.
+- **`toLocaleText(canonical)`** — a field's canonical buffer → what that field draws.
+- **`formatNumber(n, { decimals, grouped })`** — a stored number → text a person reads.
+  Cards, chips, captions, chart ticks. Grouping is opt-in.
+
+Never `String(n)`, `n.toFixed(1)` or `` `${n}` `` for text a user reads — that is the
+fourth way, and it is how one row came to show `83,4` in the field and `83.4` in the
+caption beside it.
+
+### Gotchas
+
+- **Numbers that are not for reading stay canonical.** SVG path data, keys, ids, query
+  params. `DashboardCharts.tsx` builds paths with `toFixed(1)`; localise that and the
+  path parser reads the comma as a coordinate separator and the chart collapses.
+- **Whitespace is never a separator.** `fr`, `ru`, `sv`, `pl`, `cs`, `fi`, `nb`, `uk` use
+  a space as the *group* character and `expo-localization` passes it through verbatim.
+  Treating it as a separator candidate made a trailing space read as a decimal point.
+- **Grouping is never detected.** A `TextInput` re-sends the whole field each keystroke, so
+  `"1,"` arrives with nothing after it and is read as a decimal. `1,200` on en-US is `1.2`
+  **whether typed or pasted** — they agree on purpose. An earlier grouping-aware rule made
+  them disagree (`1.2` typed, `1200` pasted), so the same characters meant different numbers
+  depending on how they arrived. Pinned by `number.test.ts` and `number.fuzz.test.ts`.
+- **Non-ASCII digits are folded arithmetically** (U+0660–0669, U+06F0–06F9), not via
+  `normalize('NFKC')` — NFKC folds fullwidth digits but leaves Arabic-Indic alone, so a
+  test written with `１２` passes while the real case still logs a weight of 0.
+- **A locale-dependent test must say so.** `packages/shared` is plain `ts-jest` and the
+  en-US default comes from the module literal, so a test that does not call
+  `configureNumberLocale` is an en-US test — which is the one locale the bug never
+  appears in. See `NumberField.locale.test.tsx` for the rendered-component shape.
+
+---
+
+## Failing Requests — read before touching the API client
+
+**The rule: every request settles, and only the server may end a session.**
+
+A promise that never settles is not a slow app, it is a dead one. Anything gated on it —
+`saving`, `isLoading`, a disabled button — stays that way until the process is killed,
+while the render loop carries on at 60fps around it. That is #145: the reporter filmed a
+workout timer ticking beside five taps on a dead button, and it took a full restart to
+clear. The hang was a token refresh issued on the bare `axios` export, which inherits
+axios's own `timeout: 0` instead of the client's bound.
+
+| the failure | what it means | what we do |
+|---|---|---|
+| timeout, dropped connection, 5xx, proxy 502/504 | we never got an answer | keep the session, surface the error, let them retry |
+| refresh answers 400/401/403 | the server revoked it | clear the tokens, `onAuthFailure` |
+
+Silence is not a verdict. Signing out on it ends a live workout every time someone walks
+past a dead spot in their gym's wifi — which is who self-hosts this. wger's Flutter client
+lands in the same place ("pure network errors keep the session intact so offline use
+continues to work"), though it clears on 5xx where we keep; a self-hosted backend restart
+answering 502 must not evict anyone.
+
+### Single points of truth
+
+- **`packages/shared/src/client.ts`** — one axios instance, `REQUEST_TIMEOUT` on every
+  call *including the refresh*, `sessionWasRevoked` for the table above, and `refreshOnce`
+  so a burst of 401s shares one round-trip rather than racing to rotate the same token.
+  Both apps import it, so a fix here is a fix on web and mobile at once.
+- **`apiErrorMessage(err, fallback)`** — the only way to turn an error into words. Never
+  read `err.response.data.error` at a call site: the failures that matter most have no
+  response at all, and the raw read falls through to a generic string. It routes those to
+  `networkFailureMessage`, which names cleartext blocks, bad certificates and timeouts
+  from the native detail RN hides on the XHR.
+- **Say it where the tap was.** `ConfirmSheet` takes an `error` and stays open, so a failed
+  confirm shows why with the retry under the same finger. Dismissing to a banner at the top
+  of a scrolled list is the same as saying nothing.
+
+### Gotchas
+
+- **A bare `axios.*` call is not the client.** It skips the instance's timeout, the auth
+  header and the interceptor. `client.ts` has exactly two on purpose — the `/info` probe
+  (8s, fails fast by design) and the refresh (cannot use `api` without recursing into the
+  interceptor that calls it). Both pass an explicit `timeout`. Adding a third without one
+  re-opens #145.
+- **RN does not report timeouts the way the web does.** No `ECONNABORTED`, no
+  `request._timedOut` — just the literal string `timeout` on the XHR's `_response`.
+  Measured on Android against a black-holed refresh; `classifyNetworkError` matches it.
+- **Reproduce network failure with a black hole, not a stopped server.** A stopped server
+  gives an instant ECONNREFUSED and hides every bug of this class. Gym wifi accepts the
+  connection and says nothing; a proxy that accepts and never replies is the faithful
+  model, and it is what turned #145 from intermittent into a one-tap repro.
+
+## Data Models (summary)
+
+- `User` → `UserSettings` (calorie/macro targets, weight unit)
+- `Workout` → `WorkoutExercise[]` → `Set[]`
+- `Program` → `ProgramExercise[]` → `ProgramSet[]` (target reps/weight)
+- `Exercise` (seeded, 800+, shared across users)
+- `FoodLog` (meal, macros, per day)
+- `WeightLog` (bodyweight over time)
+
+---
+
+## Known Constraints
+
+- SQLite FK: `workout_exercises` and `program_exercises` reference `exercises(id)` with no cascade. Never DELETE from exercises while user data exists.
+- Go 1.26 required — Dockerfile must use `golang:1.26-alpine`
+- Build command: `go build -ldflags="-s -w" -o lyftr-api .` (not `./...`)
+- Exercise seeding uses `sync/atomic.Bool` to prevent concurrent seeds
+
+---
+
+## Demo Credentials
+
+- Email: `demo@lyftr.local` / Password: `password123`
+- Pre-seeded: PPL program + 8 weeks of workouts
+- **Only seeded when `DEMO_MODE` is on, and it is off by default everywhere — development
+  included.** It used to default to `ENV == "development"`, and `ENV` itself defaults to
+  `"development"`, so a bare `go run .` seeded this account with a password published in
+  the docs. Now it is explicit opt-in: `DEMO_MODE=true go run .`. Compose passes
+  `${DEMO_MODE:-false}` and `fly.toml` sets it true, so no real deployment changed.
+- The same flag drives the one-tap demo button on the login screen, exposed as `demo_mode`
+  on `/api/v1/info` and read via `demoMode()` from `@lyftr/shared`. The button follows the
+  account because both read one flag — never gate it on `import.meta.env.DEV`, which is
+  decided at build time and so was absent from the public demo (a production build) and
+  present against servers with no demo account.
+- CI's e2e job runs against the production default with **no** demo account; the suite
+  registers its own throwaway user in `globalSetup`, so it depends on nothing being seeded.
+
+## Registration modes
+
+`REGISTRATION` = `open` (default) | `first-user` | `closed`, enforced in
+`controllers/auth.go` before any hashing and advertised as `registration_open` on
+`/api/v1/info`. `first-user` re-counts inside the insert transaction
+(`stores.UserStore.CreateFirst`) — the handler's pre-check alone loses the race it exists
+to prevent. An invalid value is a startup failure, never a fallback to open.
+
+---
+
+## Dev Setup
+
+```bash
+cd backend && go run .                # :3000 — `.`, not main.go: package main spans several files
+cd web && npm install && npm run dev  # :5173, proxies /api → :3000
+docker compose up -d                  # prod, needs .env with JWT_SECRET
+```
+
+### Mobile builds — MANDATORY
+
+**Never build the app locally.** No `expo run:android`/`run:ios`, no `expo prebuild` +
+Gradle, no `eas build --local`. Build through the **EAS CLI** (cloud) or a CI runner:
+
+```bash
+cd mobile && eas build --platform android --profile development
+```
+
+A first local build is 10–25 min of toolchain download before it compiles anything, and
+`prebuild` writes an untracked `mobile/android/` and rewrites the `android`/`ios` scripts in
+`mobile/package.json`. The `development` profile (`mobile/eas.json`) is `developmentClient:
+true`, so it is a **one-time** cost — after installing it, JS changes load over `npx expo
+start` with no rebuild.
+
+Emulator notes: the backend is `http://10.0.2.2:3000` (the emulator's own loopback is
+itself). Maestro flows live in `mobile/.maestro/`.
+
+---
+
+## Roadmap & Feature Specs
+
+### 1. Nutrition Page Polish (IN PROGRESS)
+`web/src/pages/Food.tsx` exists but needs:
+- Daily summary bar at top: calories ring + macro breakdown (protein/carbs/fat)
+- Meals accordion: Breakfast / Lunch / Dinner / Snacks — each collapsible, shows entries
+- Add food form: name, meal selector, calories, protein, carbs, fat, servings, serving size
+- Barcode field optional (future camera scan)
+- Targets pulled from `userAPI.getSettings()` → `calorie_target`, `protein_target`, etc.
+- API: `foodAPI.list(date)`, `foodAPI.log(payload)`, `foodAPI.delete(id)`, `foodAPI.stats(date)`
+
+### 2. Weight Tracking Page Polish (IN PROGRESS)
+`web/src/pages/Weight.tsx` exists but needs:
+- Recharts LineChart: bodyweight over last 30/90 days (toggle)
+- Stats strip: current weight, 7-day avg, total change since first log
+- Log weight form: weight input + optional notes + date picker
+- Unit-aware: display kg if `weight_unit === 'kg'`, convert from lbs storage
+- API: `weightAPI.list({ limit })`, `weightAPI.log(payload)`, `weightAPI.delete(id)`
+
+### 3. Dashboard Redesign (DONE)
+Shipped on both web (`web/src/pages/Dashboard.tsx`) and mobile (`mobile/app/(tabs)/index.tsx` +
+`mobile/src/components/dashboard/`). Key points (for reference):
+- KPI strip: this week workouts | today calories | today protein
+- Volume trend BarChart (last 7 workouts, recharts)
+- Mon–Sun dot strip for current week
+- Last workout card with exercise rows + best set chips
+- Nutrition card compact view
+- Weight sparkline (only if ≥2 entries)
+- Empty states for each section — no crash on fresh account
+
+### 4. PWA / Installable (BUILT, UNMERGED)
+Implemented on `feature/pwa-installable` (33f5369, pushed, no PR) — `vite-plugin-pwa`,
+service worker, icons, splash screens, offline page. **Five weeks stale and it does not
+merge cleanly:** six conflicts, two of them structural — `web/package-lock.json` was
+deleted on main when the monorepo moved to one root lockfile, and `web/src/stores/auth.ts`
+moved into `@lyftr/shared`. It also still ships `apple-mobile-web-app-title` as "Lyfter",
+which would put the typo on people's home screens. Reviving it is its own PR.
+
+### 5. Personal Records (PR) Tracking (DONE)
+Shipped. `GET /api/v1/exercises/:id/prs` and `/history` exist in `routes/routes.go`, the
+"Your Best" card renders on `ExerciseDetail.tsx`, and it is covered by
+`controllers/exercises_test.go` (`TestGetExercisePRs_*`) plus e2e in `exercises.spec.ts`.
+
+### 5b. Auto-progression suggestions (DONE)
+Also shipped (#40) — `POST /api/v1/programs/:id/suggestions/resolve` accepts or dismisses
+staged next-session targets computed from history. Worth knowing: PRs and progression are
+the two features Hevy and Strong charge for, so anything describing Lyftr should say it has
+them. This section was marked PLANNED long after both landed, and that stale line has
+already caused one round of published copy to understate the project.
+
+### 6. Workout Templates from History (PLANNED)
+- "Repeat this workout" button on WorkoutDetail page
+- Pre-fills AddWorkout form with same exercises + last used weights
+- User can adjust before saving
+
+### 8. Social / Share (FUTURE)
+- Share workout summary as image (html-to-image or canvas)
+- Public profile URL: `/u/:username` — shows recent workouts, PRs (opt-in)
+
+### 9. iOS Native App (FUTURE)
+- Swift + SwiftUI
+- Same API, JWT auth
+- Offline mode with local SQLite sync
+- Not starting until web is fully polished
+
+### 10. Hosted Option (FUTURE)
+- Single-tenant: one DB per user on managed infra
+- Stripe for billing
+- Same codebase, env flag `HOSTED=true` disables self-host features
+
+---
+
+## Code Style
+
+- Go: `gofmt`, no unnecessary abstractions, errors wrapped with context
+- TypeScript: existing patterns, no new deps without discussion
+- No comments unless WHY is non-obvious
+- No half-finished features on main branch
+- Each PR: one feature or fix, focused diff
+
+---
+
+## Git — MANDATORY
+
+**Never force-push. Never rewrite published history.** No `git push --force`, no
+`--force-with-lease`, no `git rebase` of a branch that has already been pushed, no
+`git commit --amend` on a pushed commit. Once a commit is on the remote it is
+permanent — fix things by adding a commit on top.
+
+**Bring a branch up to date by merging, not rebasing:**
+
+```bash
+git checkout feature/my-branch
+git merge origin/main          # not: git rebase origin/main
+```
+
+**Squash-merge PRs** — `gh pr merge --squash`. Not `--merge`, not `--rebase`. One
+commit per PR keeps `main` readable; the individual commits stay on the PR if anyone
+needs them.
+
+Squashing on merge is not a contradiction of the no-force-push rule above: GitHub
+writes a new commit onto `main` rather than rewriting anything already published.
+
+---
+
+## Test Requirements — read before commit or push
+
+**CI is the e2e gate. Local runs are the fast checks CI does not cover.**
+
+`ci.yml` triggers on `push: branches: ['**']`, so every push to any branch runs
+Playwright, not just PRs. Running the suite locally *as well* buys a few minutes of
+earlier warning at real cost on a memory-constrained machine: a Chromium fleet and a Metro
+bundler together will exhaust a laptop with a modest amount of RAM, and the resulting
+`worker process exited unexpectedly` — out of memory — reads exactly like a broken test.
+Chasing that has cost more than it has ever caught. If your machine has room, run it; the
+point is that a failure there is not automatically a failure in the code.
+
+Before a commit or push, run what is fast and what CI will not run for you:
+
+```bash
+cd backend && go test ./... -timeout 180s   # ./... — see the gap below
+cd backend && go vet ./...                  # CI does not run this
+# formatting: use the normalised loop below, NOT bare `gofmt -l .`
+cd web && npm run test:unit && npm run lint
+npm run shared:test && npm run type-check -w @lyftr/mobile
+npm run test -w @lyftr/mobile -- --ci --maxWorkers=4
+```
+
+Then push, and **watch the run** — `gh pr checks <n>` or a Monitor. Pushing is not
+finishing; a red check you walked away from is the same as a failing local test you
+ignored.
+
+### Where CI's coverage stops — do not over-trust it
+
+- **Go: all packages, since CI moved to `go test ./...`.** It ran three of seven for a
+  long time, which left `utils/`, `stores/`, `config/` and `oedb/` invisible — and
+  `utils/validation.go`, which owns every error sentence the API emits, was among them.
+  Keep new packages inside `./...` rather than adding a hand-maintained list.
+- **No `gofmt`, no `go vet`, no `govulncheck`.** Space-indented Go has been pushed and
+  merged unnoticed. Until CI gains the check, formatting is yours to verify — but
+  **not with bare `gofmt -l .`** on a Windows checkout: git hands you CRLF, gofmt only
+  emits LF, so it reports *every* Go file and the real nits drown in the noise. On a
+  checkout with LF endings plain `gofmt -l` is correct. To be safe either way, normalise
+  first:
+
+  ```bash
+  for f in $(git ls-files '*.go'); do
+    diff -q <(tr -d '' < "$f") <(tr -d '' < "$f" | gofmt) >/dev/null || echo "$f"
+  done
+  ```
+
+  A CI check runs on Linux, where the checkout is LF, so plain `gofmt -l` is correct
+  there. This dodge is local-only.
+- **e2e is path-filtered** to `backend/**` or `web/**` (and `packages/shared/**`, which
+  the web filter includes). A mobile-only change correctly runs no Playwright — mobile is
+  not in that suite, so its guards and jest suite are the only thing standing there.
+- **Markdown-only *pushes* run nothing** (`paths-ignore` on the `push` trigger).
+  Pull requests always run, deliberately: `main` requires these checks, and a workflow
+  skipped at the trigger leaves them Pending forever rather than skipped, so a docs-only PR
+  could never merge. The per-job `changes` filter keeps such a run near-free.
+
+**Rules:**
+- Never push a change you have seen fail. Red CI is fixed forward, never abandoned.
+- Fix the root cause; never skip or comment out a failing test.
+- Run e2e locally when you want the signal before pushing, or when CI is red and you are
+  reproducing — free the RAM first (`dev-doctor.ps1`, then close Metro/Expo).
+
+---
+
+## Working without a specific brief
+
+For anyone — contributor or agent — picking up work with no ticket in hand:
+1. Check the roadmap above — work top-to-bottom on PLANNED items. Treat its statuses as
+   indicative: they have gone stale before, so confirm against the code before relying on
+   one.
+2. Follow conventions exactly — no new patterns without reason
+3. Mobile layout always primary, desktop secondary
+4. Run through empty state + null guard checklist before marking done
+5. After any backend change: verify migration runs clean, test endpoint with curl
+6. After any frontend change: verify mobile 390px width, no overflow
+7. Run the local checks above, push, and watch CI — a task is done when its run is green,
+   not when the push succeeds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ answering 502 must not evict anyone.
 
 ---
 
-## Demo Credentials
+## Demo mode
 
 - Email: `demo@lyftr.local` / Password: `password123`
 - Pre-seeded: PPL program + 8 weeks of workouts
@@ -305,78 +305,6 @@ start` with no rebuild.
 
 Emulator notes: the backend is `http://10.0.2.2:3000` (the emulator's own loopback is
 itself). Maestro flows live in `mobile/.maestro/`.
-
----
-
-## Roadmap & Feature Specs
-
-### 1. Nutrition Page Polish (IN PROGRESS)
-`web/src/pages/Food.tsx` exists but needs:
-- Daily summary bar at top: calories ring + macro breakdown (protein/carbs/fat)
-- Meals accordion: Breakfast / Lunch / Dinner / Snacks — each collapsible, shows entries
-- Add food form: name, meal selector, calories, protein, carbs, fat, servings, serving size
-- Barcode field optional (future camera scan)
-- Targets pulled from `userAPI.getSettings()` → `calorie_target`, `protein_target`, etc.
-- API: `foodAPI.list(date)`, `foodAPI.log(payload)`, `foodAPI.delete(id)`, `foodAPI.stats(date)`
-
-### 2. Weight Tracking Page Polish (IN PROGRESS)
-`web/src/pages/Weight.tsx` exists but needs:
-- Recharts LineChart: bodyweight over last 30/90 days (toggle)
-- Stats strip: current weight, 7-day avg, total change since first log
-- Log weight form: weight input + optional notes + date picker
-- Unit-aware: display kg if `weight_unit === 'kg'`, convert from lbs storage
-- API: `weightAPI.list({ limit })`, `weightAPI.log(payload)`, `weightAPI.delete(id)`
-
-### 3. Dashboard Redesign (DONE)
-Shipped on both web (`web/src/pages/Dashboard.tsx`) and mobile (`mobile/app/(tabs)/index.tsx` +
-`mobile/src/components/dashboard/`). Key points (for reference):
-- KPI strip: this week workouts | today calories | today protein
-- Volume trend BarChart (last 7 workouts, recharts)
-- Mon–Sun dot strip for current week
-- Last workout card with exercise rows + best set chips
-- Nutrition card compact view
-- Weight sparkline (only if ≥2 entries)
-- Empty states for each section — no crash on fresh account
-
-### 4. PWA / Installable (BUILT, UNMERGED)
-Implemented on `feature/pwa-installable` (33f5369, pushed, no PR) — `vite-plugin-pwa`,
-service worker, icons, splash screens, offline page. **Five weeks stale and it does not
-merge cleanly:** six conflicts, two of them structural — `web/package-lock.json` was
-deleted on main when the monorepo moved to one root lockfile, and `web/src/stores/auth.ts`
-moved into `@lyftr/shared`. It also still ships `apple-mobile-web-app-title` as "Lyfter",
-which would put the typo on people's home screens. Reviving it is its own PR.
-
-### 5. Personal Records (PR) Tracking (DONE)
-Shipped. `GET /api/v1/exercises/:id/prs` and `/history` exist in `routes/routes.go`, the
-"Your Best" card renders on `ExerciseDetail.tsx`, and it is covered by
-`controllers/exercises_test.go` (`TestGetExercisePRs_*`) plus e2e in `exercises.spec.ts`.
-
-### 5b. Auto-progression suggestions (DONE)
-Also shipped (#40) — `POST /api/v1/programs/:id/suggestions/resolve` accepts or dismisses
-staged next-session targets computed from history. Worth knowing: PRs and progression are
-the two features Hevy and Strong charge for, so anything describing Lyftr should say it has
-them. This section was marked PLANNED long after both landed, and that stale line has
-already caused one round of published copy to understate the project.
-
-### 6. Workout Templates from History (PLANNED)
-- "Repeat this workout" button on WorkoutDetail page
-- Pre-fills AddWorkout form with same exercises + last used weights
-- User can adjust before saving
-
-### 8. Social / Share (FUTURE)
-- Share workout summary as image (html-to-image or canvas)
-- Public profile URL: `/u/:username` — shows recent workouts, PRs (opt-in)
-
-### 9. iOS Native App (FUTURE)
-- Swift + SwiftUI
-- Same API, JWT auth
-- Offline mode with local SQLite sync
-- Not starting until web is fully polished
-
-### 10. Hosted Option (FUTURE)
-- Single-tenant: one DB per user on managed infra
-- Stripe for billing
-- Same codebase, env flag `HOSTED=true` disables self-host features
 
 ---
 
@@ -480,9 +408,8 @@ ignored.
 ## Working without a specific brief
 
 For anyone — contributor or agent — picking up work with no ticket in hand:
-1. Check the roadmap above — work top-to-bottom on PLANNED items. Treat its statuses as
-   indicative: they have gone stale before, so confirm against the code before relying on
-   one.
+1. Work from the issue tracker, not from this file. Priorities and status live where they
+   can be closed; a list here goes stale silently and has done before.
 2. Follow conventions exactly — no new patterns without reason
 3. Mobile layout always primary, desktop secondary
 4. Run through empty state + null guard checklist before marking done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,24 +139,15 @@ input through"*, so `keyboardType` constrains what is **drawn**, never what arri
 
 ### Single points of truth — do not add a fourth way to write a number
 
-All in `packages/shared/src/utils/number.ts`, imported by both apps:
+In `packages/shared/src/utils/number.ts`, imported by both apps:
 
-- **`configureNumberLocale({ decimal, group })`** — called **once**, from
-  `mobile/src/lib/lyftr.ts`, with `expo-localization`'s native values. Injected rather
-  than detected for the same reason `detectTimezone` is: Hermes leaves
-  `Intl.NumberFormat#formatToParts` unimplemented on iOS (`PlatformIntlApple.mm` is a
-  literal `llvm_unreachable`), so detecting the separators would crash on half the fleet.
-  Web never calls it and keeps the en-US default — `<input type="number">` is localised by
-  the browser.
 - **`sanitizeNumericInput(raw, mode)`** — typed text → canonical. Every numeric
   `TextInput` on mobile goes through it; there is no second copy.
-- **`toLocaleText(canonical)`** — a field's canonical buffer → what that field draws.
-- **`formatNumber(n, { decimals, grouped })`** — a stored number → text a person reads.
-  Cards, chips, captions, chart ticks. Grouping is opt-in.
 
-Never `String(n)`, `n.toFixed(1)` or `` `${n}` `` for text a user reads — that is the
-fourth way, and it is how one row came to show `83,4` in the field and `83.4` in the
-caption beside it.
+**The display half of this — turning a stored number back into the reader's notation — is
+not merged yet.** Until it is, there is no shared formatter, so a screen that needs one is
+writing the first: put it in this module rather than in the screen, so the rule above stays
+true of one file. Do not document it here before it lands.
 
 ### Gotchas
 
@@ -170,14 +161,13 @@ caption beside it.
   `"1,"` arrives with nothing after it and is read as a decimal. `1,200` on en-US is `1.2`
   **whether typed or pasted** — they agree on purpose. An earlier grouping-aware rule made
   them disagree (`1.2` typed, `1200` pasted), so the same characters meant different numbers
-  depending on how they arrived. Pinned by `number.test.ts` and `number.fuzz.test.ts`.
+  depending on how they arrived. Pinned by `number.test.ts`.
 - **Non-ASCII digits are folded arithmetically** (U+0660–0669, U+06F0–06F9), not via
   `normalize('NFKC')` — NFKC folds fullwidth digits but leaves Arabic-Indic alone, so a
   test written with `１２` passes while the real case still logs a weight of 0.
-- **A locale-dependent test must say so.** `packages/shared` is plain `ts-jest` and the
-  en-US default comes from the module literal, so a test that does not call
-  `configureNumberLocale` is an en-US test — which is the one locale the bug never
-  appears in. See `NumberField.locale.test.tsx` for the rendered-component shape.
+- **A locale-dependent test must say so.** `packages/shared` is plain `ts-jest` with no
+  locale set up, so a test that does not establish one is an en-US test — and en-US is the
+  one locale where separator bugs never appear. Say which locale a test is asserting.
 
 ---
 
@@ -294,17 +284,23 @@ docker compose up -d                  # prod, needs .env with JWT_SECRET
 Gradle, no `eas build --local`. Build through the **EAS CLI** (cloud) or a CI runner:
 
 ```bash
-cd mobile && eas build --platform android --profile development
+cd mobile && eas build --platform android --profile preview
 ```
 
 A first local build is 10–25 min of toolchain download before it compiles anything, and
 `prebuild` writes an untracked `mobile/android/` and rewrites the `android`/`ios` scripts in
-`mobile/package.json`. The `development` profile (`mobile/eas.json`) is `developmentClient:
-true`, so it is a **one-time** cost — after installing it, JS changes load over `npx expo
-start` with no rebuild.
+`mobile/package.json`.
 
-Emulator notes: the backend is `http://10.0.2.2:3000` (the emulator's own loopback is
-itself). Maestro flows live in `mobile/.maestro/`.
+`mobile/eas.json` currently defines **`preview` and `production` only**. There is no
+`development` profile, so nothing here produces a `developmentClient` build; adding one is
+what you want if you need native modules on device, and it is a one-time cost.
+
+For JS-only work you usually need neither: **Expo Go plus `npx expo start` loads the
+working tree directly**, which is enough to drive the real screens against a real backend.
+
+Emulator notes: the backend is reachable at `http://10.0.2.2:3000` (the emulator's own
+loopback is itself), or over an `adb reverse` tunnel if one is set up — check
+`adb reverse --list` before assuming which. Maestro flows live in `mobile/.maestro/`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,14 +38,14 @@ backend/
   middleware/auth.go    — JWT validation middleware
   models/models.go      — all structs + request types
   routes/routes.go      — all routes, protected vs public
-  seed/exercises.go     — async exercise seeding from free-exercise-db
-  seed/users.go         — demo user seeding
+  stores/exercise.go    — exercise store, incl. free-exercise-db seeding
+  seed/users.go         — demo user seeding (see also seed/demo_data.go)
   utils/response.go     — utils.OK / utils.BadRequest helpers
 
 web/src/
   pages/                — one file per page/route
   services/api.ts       — all API calls (axios), typed
-  types/index.ts        — shared TypeScript types
+  (types come from @lyftr/shared, re-exported via services/api.ts)
   App.tsx               — React Router routes
 ```
 
@@ -238,8 +238,11 @@ answering 502 must not evict anyone.
 
 - SQLite FK: `workout_exercises` and `program_exercises` reference `exercises(id)` with no cascade. Never DELETE from exercises while user data exists.
 - Go 1.26 required — Dockerfile must use `golang:1.26-alpine`
-- Build command: `go build -ldflags="-s -w" -o lyftr-api .` (not `./...`)
-- Exercise seeding uses `sync/atomic.Bool` to prevent concurrent seeds
+- Build via `backend/build.sh`, which both Dockerfiles invoke — never `go build` by hand.
+  It is the single source of the version ldflag
+  (`-X …/config.buildVersion=${VERSION:-dev}`), and CI's `version-smoke` job asserts on
+  the value, so a binary built without it is one CI rejects. Note `.`, not `./...`:
+  package main spans several files.
 
 ---
 
@@ -300,7 +303,10 @@ working tree directly**, which is enough to drive the real screens against a rea
 
 Emulator notes: the backend is reachable at `http://10.0.2.2:3000` (the emulator's own
 loopback is itself), or over an `adb reverse` tunnel if one is set up — check
-`adb reverse --list` before assuming which. Maestro flows live in `mobile/.maestro/`.
+`adb reverse --list` before assuming which.
+
+Maestro flows are **not** in the repo: `mobile/.maestro/` is gitignored, so a fresh
+checkout has none and yours are yours alone.
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,86 +1,70 @@
 # Review instructions
 
-Policy for the automated review that runs on every PR
-(`.github/workflows/claude-code-review.yml`). Findings are advisory — nothing here
-blocks a merge directly — but `main` requires review threads to be resolved, so an
-unresolved finding does stop a merge until someone answers it.
+How the automated review on each PR should judge and report. Findings are advisory —
+nothing here blocks a merge directly — but `main` requires review threads to be resolved,
+so an unresolved finding does hold a merge until someone answers it.
 
-Keep this file short. Every rule here competes for attention with the others; general
-project context belongs in `CLAUDE.md`, which this review also reads.
+**This file does not restate the project's standards.** Those live in `CLAUDE.md`, at the
+repository root and in subdirectories, and the review already reads them. Duplicating a
+rule here would create two copies to keep in step, and the copies would drift. This file
+is only about severity, volume, evidence, and what to leave alone.
 
 ## What Important means here
 
-Reserve 🔴 Important for a change that would **break behaviour, lose data, or end a
-session**. This is a self-hosted workout tracker: the expensive failures are a lost
-training log and a user signed out mid-workout, not a badly named variable.
+Reserve 🔴 Important for a change that would **break behaviour, lose or corrupt user data,
+or lock someone out of their own account**. Everything else — naming, structure, style,
+tests for code already covered — is a nit at most.
 
-Everything else — naming, structure, style, missing tests on code that is already
-covered — is a nit at most.
+Two classes sit above their usual severity in a self-hosted app someone trusts with their
+own records:
 
-Escalate to Important, above their usual severity:
+- **A wrong value presented as a right one.** A substituted default, a stale cache or a
+  swallowed failure rendered as though it were the user's data. Worse when that value can
+  be written back, because then it is data loss rather than a display bug.
+- **Anything that can end a session or destroy work the user has not finished.**
 
-- A failed read that renders as data. A caught error that falls back to `[]`, `0`, or a
-  defaults object draws "no workouts yet" over "we could not reach the server", and the
-  user cannot tell. If that substituted value can then be **written back**, it is data
-  loss, not a display bug — that is exactly how a failed settings GET came to overwrite
-  real macro targets.
-- Anything that could sign a user out on a network failure. Only a 400/401/403 from the
-  refresh may end a session; a timeout, a dropped connection or a 5xx must not.
+## Standards come from CLAUDE.md
 
-## Always check
+Treat a newly introduced violation of `CLAUDE.md` as a finding, at the severity its
+consequence deserves rather than automatically as a nit — those files exist because each
+rule was paid for by a bug.
 
-Named conventions, because a rule that names the function is the one that gets applied:
-
-- **No bare `axios.*`.** It skips the client's timeout, auth header and interceptor.
-  `client.ts` has exactly two deliberate exceptions and both pass an explicit `timeout`.
-- **No `err.response.data.error` at a call site.** The failures that matter most have no
-  response at all. `apiErrorMessage(err, fallback)` is the only way to turn an error into
-  words.
-- **No `format(dayToLocalDate(x), …)`.** `dayToLocalDate` is not total: given a non-day it
-  returns an Invalid Date, and date-fns throws. Use `formatDay`, which reads `—`.
-- **Days are stored, not re-derived.** A day-scoped row carries its own day; nothing
-  recomputes one from the reader's clock. Server-side that means `resolveDay` /
-  `resolveQueryDay`; client-side `entryDay` / `workoutDay`.
-- **Numbers a person reads go through `formatNumber` / `toLocaleText`.** Never
-  `String(n)`, `n.toFixed(1)` or a template literal. Numbers that are *not* for reading —
-  SVG path data, keys, query params — stay canonical.
-- **A promise that can hang.** Every request must settle. Anything gated on one — a
-  `saving` flag, a disabled button — must have a path back.
-
-## Taking code from another branch
-
-A file taken from a long-lived branch must not revert what `main` gained in the meantime.
-Extracting `web/src/index.css` from a stale branch silently reverted three
-`@fontsource` imports and dropped every custom font in the app — and `tsc`, lint, three
-unit suites and the whole of CI passed. Flag any hunk that removes something `main` has
-without saying why.
+Also flag the reverse: a change that makes a statement in `CLAUDE.md` untrue. A stale rule
+is worse than a missing one, because it is trusted.
 
 ## Cap the nits
 
-At most five nits per review; summarise the rest as a count. Several PRs here are one
-mechanical pattern repeated twenty times, and forty style comments on such a diff buries
-the one finding that matters.
+At most five nits per review; summarise the rest as a count. Much of this repo's churn is
+one pattern applied across many files, and forty style comments on such a diff bury the
+finding that matters.
 
-After the first review of a PR, report Important findings only. A one-line fix should not
-reach round seven on style.
+After the first review of a PR, report Important findings only. A small follow-up push
+should not draw a fresh round of style notes.
 
-## Verification bar
+## Evidence, not inference
 
-A claim about behaviour needs a `file:line` citation in the source, not an inference from
-a name. If the only evidence is that something *sounds* wrong, say so and drop the
-severity.
+A claim about behaviour needs a `file:line` citation in the source. If the only evidence is
+that a name sounds wrong, say so plainly and lower the severity. A confident wrong finding
+costs more than a missed nit: it sends someone to change working code.
+
+## Regressions hide in moved code
+
+When a diff moves, copies or re-applies existing code — a refactor, a cherry-pick, a file
+taken from another branch — check that nothing already on the target branch was dropped in
+the process. Type checks, linters and test suites all pass a silent revert, so review is
+the only thing standing there.
 
 ## Feed the loop
 
-When you flag a mistake that `CLAUDE.md` should have prevented, and it is the second time,
-propose the `CLAUDE.md` correction as part of the review. Flag any change that has made
-`CLAUDE.md` outdated — it carries hard-won rules and a stale one has already caused
-published copy to understate the project.
+When you flag something `CLAUDE.md` should have prevented, and it is the second time,
+propose the `CLAUDE.md` correction as part of the review, so the standard improves instead
+of the same finding recurring.
 
 ## Do not report
 
-- Anything CI already enforces: `tsc`, ESLint, `go vet`, the unit and e2e suites.
-- Formatting. `gofmt` is checked locally; four files on `main` are known-unformatted and
-  are not this PR's problem unless it touches them.
-- `web/package-lock.json` and other lockfiles.
-- Test code that deliberately violates production rules in order to test them.
+- Anything CI already enforces: type checks, linters, `go vet`, the unit and e2e suites.
+- Formatting, unless the PR itself introduced the inconsistency.
+- Lockfiles and generated files.
+- Test code that deliberately violates a production rule in order to exercise it.
+- Pre-existing problems the PR merely sits near, unless it makes them materially worse —
+  note them once as 🟣, never as blocking.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,8 +4,8 @@ How the automated review on each PR should judge and report. Findings are adviso
 nothing here blocks a merge directly — but `main` requires review threads to be resolved,
 so an unresolved finding does hold a merge until someone answers it.
 
-**This file does not restate the project's standards.** Those live in `CLAUDE.md`, at the
-repository root and in subdirectories, and the review already reads them. Duplicating a
+**This file does not restate the project's standards.** Those live in `CLAUDE.md` at the
+repository root, and the review already reads it. Duplicating a
 rule here would create two copies to keep in step, and the copies would drift. This file
 is only about severity, volume, evidence, and what to leave alone.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,86 @@
+# Review instructions
+
+Policy for the automated review that runs on every PR
+(`.github/workflows/claude-code-review.yml`). Findings are advisory — nothing here
+blocks a merge directly — but `main` requires review threads to be resolved, so an
+unresolved finding does stop a merge until someone answers it.
+
+Keep this file short. Every rule here competes for attention with the others; general
+project context belongs in `CLAUDE.md`, which this review also reads.
+
+## What Important means here
+
+Reserve 🔴 Important for a change that would **break behaviour, lose data, or end a
+session**. This is a self-hosted workout tracker: the expensive failures are a lost
+training log and a user signed out mid-workout, not a badly named variable.
+
+Everything else — naming, structure, style, missing tests on code that is already
+covered — is a nit at most.
+
+Escalate to Important, above their usual severity:
+
+- A failed read that renders as data. A caught error that falls back to `[]`, `0`, or a
+  defaults object draws "no workouts yet" over "we could not reach the server", and the
+  user cannot tell. If that substituted value can then be **written back**, it is data
+  loss, not a display bug — that is exactly how a failed settings GET came to overwrite
+  real macro targets.
+- Anything that could sign a user out on a network failure. Only a 400/401/403 from the
+  refresh may end a session; a timeout, a dropped connection or a 5xx must not.
+
+## Always check
+
+Named conventions, because a rule that names the function is the one that gets applied:
+
+- **No bare `axios.*`.** It skips the client's timeout, auth header and interceptor.
+  `client.ts` has exactly two deliberate exceptions and both pass an explicit `timeout`.
+- **No `err.response.data.error` at a call site.** The failures that matter most have no
+  response at all. `apiErrorMessage(err, fallback)` is the only way to turn an error into
+  words.
+- **No `format(dayToLocalDate(x), …)`.** `dayToLocalDate` is not total: given a non-day it
+  returns an Invalid Date, and date-fns throws. Use `formatDay`, which reads `—`.
+- **Days are stored, not re-derived.** A day-scoped row carries its own day; nothing
+  recomputes one from the reader's clock. Server-side that means `resolveDay` /
+  `resolveQueryDay`; client-side `entryDay` / `workoutDay`.
+- **Numbers a person reads go through `formatNumber` / `toLocaleText`.** Never
+  `String(n)`, `n.toFixed(1)` or a template literal. Numbers that are *not* for reading —
+  SVG path data, keys, query params — stay canonical.
+- **A promise that can hang.** Every request must settle. Anything gated on one — a
+  `saving` flag, a disabled button — must have a path back.
+
+## Taking code from another branch
+
+A file taken from a long-lived branch must not revert what `main` gained in the meantime.
+Extracting `web/src/index.css` from a stale branch silently reverted three
+`@fontsource` imports and dropped every custom font in the app — and `tsc`, lint, three
+unit suites and the whole of CI passed. Flag any hunk that removes something `main` has
+without saying why.
+
+## Cap the nits
+
+At most five nits per review; summarise the rest as a count. Several PRs here are one
+mechanical pattern repeated twenty times, and forty style comments on such a diff buries
+the one finding that matters.
+
+After the first review of a PR, report Important findings only. A one-line fix should not
+reach round seven on style.
+
+## Verification bar
+
+A claim about behaviour needs a `file:line` citation in the source, not an inference from
+a name. If the only evidence is that something *sounds* wrong, say so and drop the
+severity.
+
+## Feed the loop
+
+When you flag a mistake that `CLAUDE.md` should have prevented, and it is the second time,
+propose the `CLAUDE.md` correction as part of the review. Flag any change that has made
+`CLAUDE.md` outdated — it carries hard-won rules and a stale one has already caused
+published copy to understate the project.
+
+## Do not report
+
+- Anything CI already enforces: `tsc`, ESLint, `go vet`, the unit and e2e suites.
+- Formatting. `gofmt` is checked locally; four files on `main` are known-unformatted and
+  are not this PR's problem unless it touches them.
+- `web/package-lock.json` and other lockfiles.
+- Test code that deliberately violates production rules in order to test them.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -62,7 +62,9 @@ of the same finding recurring.
 
 ## Do not report
 
-- Anything CI already enforces: type checks, linters, `go vet`, the unit and e2e suites.
+- Anything CI already enforces: type checks, linters, the unit and e2e suites. Check what
+  CI actually runs before assuming — `CLAUDE.md` documents where its coverage stops, and
+  the gaps move.
 - Formatting, unless the PR itself introduced the inconsistency.
 - Lockfiles and generated files.
 - Test code that deliberately violates a production rule in order to exercise it.


### PR DESCRIPTION
Gives the automated review a calibration policy. It runs with stock settings today, and its
first run (#158) found nothing — plausible, but not trustworthy until it's been told how to
judge.

## One source of truth for standards

`REVIEW.md` **deliberately does not restate any project standard.** Those live in
`CLAUDE.md`, which the review already reads automatically. A second copy of a rule is a
copy that drifts, and a stale rule is worse than a missing one because it's trusted.

Verified: no convention appears in both files.

So `REVIEW.md` holds only what `CLAUDE.md` can't — **how to weigh a finding**:

- **Severity calibration.** Important = breaks behaviour, loses data, or locks someone out.
  Two classes escalated for a self-hosted app: a wrong value presented as a right one, and
  anything that can end a session or destroy unfinished work.
- **Cap of five nits**, and Important-only after the first pass. Much of this repo's churn
  is one pattern across many files; forty style notes there bury the finding that matters.
- **Evidence bar.** Behaviour claims need a `file:line` citation. A confident wrong finding
  costs more than a missed nit — it sends someone to change working code.
- **Regressions hide in moved code.** Refactors, cherry-picks, files taken from another
  branch: check nothing on the target was dropped. Type checks, linters and test suites all
  pass a silent revert, so review is the only thing standing there.
- **Feed the loop.** Flag something `CLAUDE.md` should have prevented twice, and propose the
  `CLAUDE.md` fix as part of the review — so the standard improves rather than the finding
  recurring.
- **Do not report** what CI already enforces, lockfiles, generated files, or pre-existing
  problems the PR merely sits near.

## Generic on purpose

An earlier draft named this month's functions and this week's regression. Those are the
wrong level: the file has to still be right when none of those names are the ones that
matter. Every rule that survived generalises — "a wrong value presented as a right one"
covers the substituted-defaults bug without naming it, and covers whatever the next one is.

## Where the shape came from

- **`anthropics/claude-code/plugins/pr-review-toolkit`** — structure: principles, then
  explicit do-not-report. Its `silent-failure-hunter` states the same doctrine #150 was
  written to enforce.
- **`daviddlow/claude-sdlc-starter/REVIEW.md`** — the "feed the loop" rule.
- **`oven-sh/bun`** — prompts as checked-in, reviewable files rather than YAML strings.

## Mechanics

Pointed at rather than inlined, so the policy is a reviewable file. Passed via
`--append-system-prompt` because `/code-review` reads anything after its flags as the review
*target* — instructions in `prompt` would be mistaken for a path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWC4KiFeoRZ3gtApGFHv1u